### PR TITLE
chore: use plural test result env var

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -46,7 +46,7 @@
         {
           "run": "npm run generate:summary",
           "env": {
-            "TEST_RESULTS_GLOB": "test-results/*junit*.xml"
+            "TEST_RESULTS_GLOBS": "test-results/*junit*.xml"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run derive:registry
       - run: npm run generate:summary
         env:
-          TEST_RESULTS_GLOB: test-results/*junit*.xml
+          TEST_RESULTS_GLOBS: test-results/*junit*.xml
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -155,7 +155,7 @@ test('writes outputs to OS-specific directory', async () => {
 
   const env = {
     ...process.env,
-    TEST_RESULTS_GLOB: junitPath,
+    TEST_RESULTS_GLOBS: junitPath,
     EVIDENCE_DIR: tmp,
     RUNNER_OS: 'Windows',
   };
@@ -196,7 +196,7 @@ test('partitions requirement groups by runner_type', async () => {
 
   const env = {
     ...process.env,
-    TEST_RESULTS_GLOB: junitPath,
+    TEST_RESULTS_GLOBS: junitPath,
     EVIDENCE_DIR: dir,
     REQ_MAPPING_FILE: reqPath,
     RUNNER_OS: 'Linux',


### PR DESCRIPTION
## Summary
- use `TEST_RESULTS_GLOBS` in CI workflows
- adjust tests to expect plural env var

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: 17 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a37dde221883299166edba3ff02afa