### PR TITLE
fix: use downloaded evidence dir for report job

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -184,7 +184,7 @@
             "TEST_RESULTS_GLOBS": "downloaded/test-results/**/*junit*.xml\ndownloaded/pester-junit-*/pester-junit.xml\n",
             "REQ_MAPPING_FILE": "requirements.json",
             "DISPATCHER_REGISTRY": "dispatchers.json",
-            "EVIDENCE_DIR": "test-screenshots"
+            "EVIDENCE_DIR": "downloaded/evidence"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,5 +147,5 @@ jobs:
             downloaded/pester-junit-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
-          EVIDENCE_DIR: test-screenshots
+          EVIDENCE_DIR: downloaded/evidence
       - run: npx tsx scripts/print-pester-traceability.ts >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- ensure report job scans downloaded evidence artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a382db8f848329b982d9888bb84636