### PR TITLE
docs: document runner types

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Get details about a specific action:
 pwsh actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 ```
 
+## Runner Types
+
+Workflows distinguish between standard GitHub-hosted images and integration runners with preinstalled tooling. See [docs/runner-types.md](docs/runner-types.md) for a detailed comparison.
+
 ## Testing
 
 Run the JavaScript tests with:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Ubuntu runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution. Install **Node.js 24+** and run `npm install` to pull in the TypeScript dependencies used by helper scripts.
+1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Ubuntu runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution. Install **Node.js 24+** and run `npm install` to pull in the TypeScript dependencies used by helper scripts. Decide whether to execute on a standard GitHub-hosted runner or an integration runner with preinstalled tooling; see [runner-types](runner-types.md) for details.
 2. **Invoke via Composite Action (GitHub):** Use the adapter-specific action in your workflow. For example, to **build a LabVIEW Packed Library**:
 
 ```yaml

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,6 +2,8 @@
 
 This project tracks high‑level requirements and maps each one to the Pester test files that verify it. The authoritative mapping is stored in [`requirements.json`](../requirements.json); the table below provides a human‑readable summary for quick reference.
 
+Runner Type indicates whether a requirement runs on a standard GitHub-hosted image or an integration runner with preinstalled tooling. See [runner-types](runner-types.md) for guidance on choosing between them.
+
 | ID | Description | Tests | Runner | Runner Type | Skip Dry Run |
 |----|-------------|-------|--------|-------------|--------------|
 | REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |  |  |  |

--- a/docs/runner-types.md
+++ b/docs/runner-types.md
@@ -1,0 +1,55 @@
+# Runner Types: Integration vs Default
+
+Modern CI pipelines in this repository classify runners into two categories to control cost and coverage. Understanding the difference allows you to target expensive resources only when necessary and keep feedback cycles fast.
+
+## Default ("standard") runners
+
+* **Environment** – GitHub-hosted virtual machines such as `ubuntu-latest` or `windows-latest`.
+* **Use cases** – Linting, unit tests and any step that can run on a clean ephemeral image.
+* **Configuration** – In `requirements.json` omit `runner_type` or set it to `standard`. Workflows simply use `runs-on: ubuntu-latest` or similar.
+* **Characteristics** – High concurrency, minimal boot time and no persistent state. Ideal for rapid validation.
+
+## Integration runners
+
+* **Environment** – Long-lived machines with preinstalled tooling such as LabVIEW, g-cli and hardware drivers. They may be self-hosted or specialized GitHub images.
+* **Use cases** – End‑to‑end scenarios that interact with external systems, require licensed software or need deterministic state.
+* **Configuration** – Tag the runner with `runner_type: "integration"` in `requirements.json` and reference the runner by label in workflows. Integration entries often set `skip_dry_run: true` to force real execution.
+* **Characteristics** – Limited availability and higher cost; jobs are serialized to protect shared resources. Treat these runners as scarce infrastructure.
+
+## Declaring runner types
+
+The `requirements.json` file defines which runner each test or requirement targets:
+
+```json
+{
+  "runners": {
+    "ubuntu-latest": {
+      "runner_label": "ubuntu-latest",
+      "runner_type": "integration"
+    },
+    "windows-latest": {
+      "runner_label": "windows-latest"
+      /* implicit runner_type: "standard" */
+    }
+  },
+  "requirements": [
+    {
+      "id": "REQ-009",
+      "runner": "ubuntu-latest",
+      "tests": ["Build.Workflow"]
+    }
+  ]
+}
+```
+
+The summarizer partitions results by `runner_type`, producing artifacts such as `summary-integration.md` alongside `summary-standard.md`. This separation keeps integration evidence distinct from fast feedback produced on default runners.
+
+## Recommendations for CI/CD engineers
+
+1. **Minimize integration usage.** Start with standard runners and move tests to integration environments only when they require external dependencies or state.
+2. **Isolate heavy workflows.** Place integration jobs in separate stages or repositories to avoid blocking quick validation paths.
+3. **Protect self-hosted runners.** Apply concurrency limits and explicit `needs` chains so multiple integration jobs do not compete for the same hardware.
+4. **Audit runner labels.** Keep `requirements.json` synchronized with the actual fleet of self-hosted machines. Stale labels lead to idle jobs.
+5. **Document expectations.** When adding new requirements or workflows, update `docs/requirements.md` so the `Runner` and `Runner Type` columns reflect the intended infrastructure.
+
+By explicitly classifying jobs, teams can scale the project efficiently—routine tasks remain fast on default runners while integration tests validate real‑world behavior without overloading scarce resources.


### PR DESCRIPTION
## Summary
- document standard vs integration runners
- link runner guidance from README, quickstart, and requirements docs

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: New-PesterConfiguration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3867f72f883299c55ae435e8d662d