### PR TITLE
Use distinct self-hosted Windows runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - icon-editor-windows
+    - self-hosted-windows-lv

--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -83,12 +83,17 @@
             {
               "os": "ubuntu-24.04",
               "runs-on": "ubuntu-24.04",
-              "runner_type": "default"
+              "runner_type": "linux"
             },
             {
-              "os": "windows-latest",
-              "runs-on": "windows-latest",
+              "os": "self-hosted-windows-lv",
+              "runs-on": "self-hosted-windows-lv",
               "runner_type": "integration"
+            },
+            {
+              "os": "self-hosted-windows-lv",
+              "runs-on": "self-hosted-windows-lv",
+              "runner_type": "default"
             }
           ]
         }
@@ -103,21 +108,21 @@
         },
         {
           "name": "Ensure PowerShell 7.5.1",
-          "if": "matrix.os == 'windows-latest'",
+          "if": "matrix.runner_type != 'linux'",
           "shell": "pwsh",
           "run": "$required = [Version]'7.5.1'\nif ($PSVersionTable.PSVersion -lt $required) {\n  $msiUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.1/PowerShell-7.5.1-win-x64.msi'\n  $msiPath = Join-Path $env:RUNNER_TEMP 'PowerShell-7.5.1-win-x64.msi'\n  Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath\n  $expectedHash = 'b110eccaf55bb53ae5e6b6de478587ed8203570b0bda9bd374a0998e24d4033a'\n  $actualHash = (Get-FileHash $msiPath -Algorithm SHA256).Hash\n  if ($actualHash -ne $expectedHash) {\n    throw \"SHA256 mismatch: $actualHash\"\n  }\n  Start-Process msiexec -Wait -ArgumentList '/i', $msiPath, '/qn', 'ADD_PATH=1'\n}\n$version = (pwsh --version).Trim() -replace '^PowerShell '\nif ([Version]$version -lt $required) {\n  throw \"PowerShell version $version is less than $required\"\n}\n"
         },
         {
           "name": "Capture setup info",
           "shell": "pwsh",
-          "run": "$data = [ordered]@{\n  'Current runner version' = $env:RUNNER_VERSION\n  'Runner Image'          = $env:ImageOS\n  'ImageVersion'          = $env:ImageVersion\n  'RUNNER_NAME'           = $env:RUNNER_NAME\n  'RUNNER_OS'             = $env:RUNNER_OS\n  'RUNNER_ARCH'           = $env:RUNNER_ARCH\n}\n$file = \"setup-info-${{ matrix.os }}.md\"\n\"was captured from the set up job.\" | Out-File -FilePath $file -Encoding utf8\nforeach ($k in $data.Keys) {\n  if ($data[$k]) {\n    \"${k}: $($data[$k])\" | Out-File -FilePath $file -Encoding utf8 -Append\n  }\n}\n"
+          "run": "$data = [ordered]@{\n  'Current runner version' = $env:RUNNER_VERSION\n  'Runner Image'          = $env:ImageOS\n  'ImageVersion'          = $env:ImageVersion\n  'RUNNER_NAME'           = $env:RUNNER_NAME\n  'RUNNER_OS'             = $env:RUNNER_OS\n  'RUNNER_ARCH'           = $env:RUNNER_ARCH\n}\n$file = \"setup-info-${{ matrix.runner_type }}.md\"\n\"was captured from the set up job.\" | Out-File -FilePath $file -Encoding utf8\nforeach ($k in $data.Keys) {\n  if ($data[$k]) {\n    \"${k}: $($data[$k])\" | Out-File -FilePath $file -Encoding utf8 -Append\n  }\n}\n"
         },
         {
           "uses": "actions/upload-artifact@v4",
           "if": "always()",
           "with": {
-            "name": "setup-info-${{ matrix.os }}",
-            "path": "setup-info-${{ matrix.os }}.md"
+            "name": "setup-info-${{ matrix.runner_type }}",
+            "path": "setup-info-${{ matrix.runner_type }}.md"
           }
         },
         {
@@ -139,7 +144,7 @@
           "uses": "actions/upload-artifact@v4",
           "if": "always()",
           "with": {
-            "name": "pester-junit-${{ matrix.os }}",
+            "name": "pester-junit-${{ matrix.runner_type }}",
             "path": "pester-results/pester-junit.xml",
             "if-no-files-found": "error"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,20 @@ jobs:
         include:
           - os: ubuntu-24.04
             runs-on: ubuntu-24.04
-            runner_type: default
-          - os: windows-latest
-            runs-on: windows-latest
+            runner_type: linux
+          - os: self-hosted-windows-lv
+            runs-on: self-hosted-windows-lv
             runner_type: integration
+          - os: self-hosted-windows-lv
+            runs-on: self-hosted-windows-lv
+            runner_type: default
     runs-on: ${{ matrix.runs-on }}
     env:
       RUNNER_TYPE: ${{ matrix.runner_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Ensure PowerShell 7.5.1
-        if: matrix.os == 'windows-latest'
+        if: matrix.runner_type != 'linux'
         shell: pwsh
         run: |
           $required = [Version]'7.5.1'
@@ -89,7 +92,7 @@ jobs:
             'RUNNER_OS'             = $env:RUNNER_OS
             'RUNNER_ARCH'           = $env:RUNNER_ARCH
           }
-          $file = "setup-info-${{ matrix.os }}.md"
+          $file = "setup-info-${{ matrix.runner_type }}.md"
           "was captured from the set up job." | Out-File -FilePath $file -Encoding utf8
           foreach ($k in $data.Keys) {
             if ($data[$k]) {
@@ -99,8 +102,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: setup-info-${{ matrix.os }}
-          path: setup-info-${{ matrix.os }}.md
+          name: setup-info-${{ matrix.runner_type }}
+          path: setup-info-${{ matrix.runner_type }}.md
       - name: Install Pester
         shell: pwsh
         run: |
@@ -124,7 +127,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: pester-junit-${{ matrix.os }}
+          name: pester-junit-${{ matrix.runner_type }}
           path: pester-results/pester-junit.xml
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
- run Windows CI on `self-hosted-windows-lv` runners for both integration and default scenarios
- tag Windows artifacts and PowerShell setup steps by runner type
- allow new runner label in actionlint configuration

## Testing
- `npm run check:node`
- `npm install`
- `npm test` *(fails: associates classname with requirement)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: 17 failed, 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a397ad537883299d0975d1c6e05877