### PR TITLE
Include runner type in CI artifacts

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -115,14 +115,14 @@
         {
           "name": "Capture setup info",
           "shell": "pwsh",
-          "run": "$data = [ordered]@{\n  'Current runner version' = $env:RUNNER_VERSION\n  'Runner Image'          = $env:ImageOS\n  'ImageVersion'          = $env:ImageVersion\n  'RUNNER_NAME'           = $env:RUNNER_NAME\n  'RUNNER_OS'             = $env:RUNNER_OS\n  'RUNNER_ARCH'           = $env:RUNNER_ARCH\n}\n$file = \"setup-info-${{ matrix.runner_type }}.md\"\n\"was captured from the set up job.\" | Out-File -FilePath $file -Encoding utf8\nforeach ($k in $data.Keys) {\n  if ($data[$k]) {\n    \"${k}: $($data[$k])\" | Out-File -FilePath $file -Encoding utf8 -Append\n  }\n}\n"
+          "run": "$data = [ordered]@{\n  'Current runner version' = $env:RUNNER_VERSION\n  'Runner Image'          = $env:ImageOS\n  'ImageVersion'          = $env:ImageVersion\n  'RUNNER_NAME'           = $env:RUNNER_NAME\n  'RUNNER_OS'             = $env:RUNNER_OS\n  'RUNNER_ARCH'           = $env:RUNNER_ARCH\n}\n$file = \"setup-info-${{ matrix.os }}-${{ matrix.runner_type }}.md\"\n\"was captured from the set up job.\" | Out-File -FilePath $file -Encoding utf8\nforeach ($k in $data.Keys) {\n  if ($data[$k]) {\n    \"${k}: $($data[$k])\" | Out-File -FilePath $file -Encoding utf8 -Append\n  }\n}\n"
         },
         {
           "uses": "actions/upload-artifact@v4",
           "if": "always()",
           "with": {
-            "name": "setup-info-${{ matrix.runner_type }}",
-            "path": "setup-info-${{ matrix.runner_type }}.md"
+            "name": "setup-info-${{ matrix.os }}-${{ matrix.runner_type }}",
+            "path": "setup-info-${{ matrix.os }}-${{ matrix.runner_type }}.md"
           }
         },
         {
@@ -144,7 +144,7 @@
           "uses": "actions/upload-artifact@v4",
           "if": "always()",
           "with": {
-            "name": "pester-junit-${{ matrix.runner_type }}",
+            "name": "pester-junit-${{ matrix.os }}-${{ matrix.runner_type }}",
             "path": "pester-results/pester-junit.xml",
             "if-no-files-found": "error"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             'RUNNER_OS'             = $env:RUNNER_OS
             'RUNNER_ARCH'           = $env:RUNNER_ARCH
           }
-          $file = "setup-info-${{ matrix.runner_type }}.md"
+          $file = "setup-info-${{ matrix.os }}-${{ matrix.runner_type }}.md"
           "was captured from the set up job." | Out-File -FilePath $file -Encoding utf8
           foreach ($k in $data.Keys) {
             if ($data[$k]) {
@@ -102,8 +102,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: setup-info-${{ matrix.runner_type }}
-          path: setup-info-${{ matrix.runner_type }}.md
+          name: setup-info-${{ matrix.os }}-${{ matrix.runner_type }}
+          path: setup-info-${{ matrix.os }}-${{ matrix.runner_type }}.md
       - name: Install Pester
         shell: pwsh
         run: |
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: pester-junit-${{ matrix.runner_type }}
+          name: pester-junit-${{ matrix.os }}-${{ matrix.runner_type }}
           path: pester-results/pester-junit.xml
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
- append OS and runner-type to setup info and pester artifact names
- confirm report job uses glob matching updated pester artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm test` *(fails: associates classname with requirement)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: 17 failed, 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a39b2ad98c8329896c81f6506fb6bf