### PR TITLE
feat: split self-hosted Windows runners

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -1,5 +1,12 @@
 {
-    "self-hosted-windows-lv": {
+  "runners": {
+    "self-hosted-windows-lv-integration": {
+      "owner": "NI",
+      "runner_label": "self-hosted-windows-lv",
+      "runner_type": "integration",
+      "skip_dry_run": false
+    },
+    "self-hosted-windows-lv-default": {
       "owner": "NI",
       "runner_label": "self-hosted-windows-lv",
       "runner_type": "default",
@@ -257,7 +264,7 @@
       "id": "REQIE-001",
       "description": "After checking out the LabVIEW icon editor repository, PreSequence: The sequencer shall enumerate and record the build matrix used by the workflow (LabVIEW versions and bitness). Acceptance: a 'matrix.json' file exists listing each tuple {\"lv-version\": \"2021\"|\"2023\", \"bitness\": \"32\"|\"64\"} with at least [ [\"2021\",\"32\"], [\"2021\",\"64\"], [\"2023\",\"64\"] ]. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.PreSequence.matrix-enumeration"
       ]
@@ -266,7 +273,7 @@
       "id": "REQIE-002",
       "description": "After checking out the LabVIEW icon editor repository, Setup: For each matrix entry, the sequencer shall apply VIPC dependencies using the canonical action inputs (minimum_supported_lv_version, vip_lv_version, supported_bitness, relative_path). Evidence: a 'vipc-apply.json' summary per matrix entry capturing inputs, start/end timestamps, exit code, and status. Acceptance: all entries report exit_code == 0 and status == 'success'. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Setup.apply-vipc-succeeds"
       ]
@@ -275,7 +282,7 @@
       "id": "REQIE-003",
       "description": "After checking out the LabVIEW icon editor repository, Setup: The sequencer shall compute and persist semantic version information. Evidence: a 'version.json' containing VERSION, MAJOR, MINOR, PATCH, BUILD, IS_PRERELEASE and the commit SHA used. Acceptance: VERSION conforms to SemVer and all numeric components are present. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Setup.version-outputs-captured"
       ]
@@ -284,7 +291,7 @@
       "id": "REQIE-004",
       "description": "After checking out the LabVIEW icon editor repository, Setup: The 'missing-in-project' check shall be executed for the specified LabVIEW version(s) and both 32-bit and 64-bit bitness as applicable. Evidence: 'missing-in-project.json' including project-file, lv-version, bitness, and result. Acceptance: result == 'present' for expected module paths. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Setup.missing-in-project-matrix"
       ]
@@ -293,7 +300,7 @@
       "id": "REQIE-005",
       "description": "After checking out the LabVIEW icon editor repository, Main: Unit tests shall be executed (Pester) across the configured matrix. Evidence: a 'pester-summary.json' file containing total, passed, failed, skipped, duration_ms, and per-test results; XML output is not required. Acceptance: failed == 0 and total >= 1. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Main.unit-tests-pass"
       ]
@@ -302,7 +309,7 @@
       "id": "REQIE-006",
       "description": "After checking out the LabVIEW icon editor repository, Main: Build Packed Libraries (PPL) shall succeed for both 32-bit and 64-bit targets. Evidence: existence of 'resource/plugins/lv_icon_x86.lvlibp' and 'resource/plugins/lv_icon_x64.lvlibp' and a 'ppl.hash' file containing SHA256 for each artifact. Acceptance: non-zero artifact sizes and matching SHA256 re-computation. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Main.ppl-built-and-hashed",
         "BuildProfile1.IconEditor.Main.artifact-size-nonzero"
@@ -312,7 +319,7 @@
       "id": "REQIE-007",
       "description": "After checking out the LabVIEW icon editor repository, Main: Renaming and artifact upload steps shall complete. Evidence: an 'artifact-manifest.json' listing uploaded artifact names ('lv_icon_x86.lvlibp', 'lv_icon_x64.lvlibp'), paths, and sizes. Acceptance: manifest entries match on-disk files and GitHub Artifacts report success. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Main.artifacts-renamed-and-uploaded"
       ]
@@ -321,7 +328,7 @@
       "id": "REQIE-008",
       "description": "After checking out the LabVIEW icon editor repository, Main: The workflow shall generate a VI Package (.vip) using the prescribed actions and inputs. Evidence: 'vi-package.hash' (SHA256 of produced .vip), and a 'vi-package.json' summarizing package metadata (name, version, company, build). Acceptance: at least one .vip exists, size > 0, and hash is recorded. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Main.vi-package-built-and-hashed"
       ]
@@ -330,7 +337,7 @@
       "id": "REQIE-009",
       "description": "After checking out the LabVIEW icon editor repository, Main: The workflow shall produce a display information JSON for the VI Package and inject it prior to packaging. Evidence: 'display-info.json' containing the exact keys used by the action (Package Version.major/minor/patch/build, Product/Company/Author fields, etc.). Acceptance: all required keys exist and reflect the computed version (REQ-011). g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Main.display-info-generated"
       ]
@@ -339,7 +346,7 @@
       "id": "REQIE-010",
       "description": "After checking out the LabVIEW icon editor repository, Cleanup: The workflow shall terminate any LabVIEW processes via the 'close-labview' step for each applicable bitness. Evidence: 'close-labview.log' including bitness, attempts, and final process list. Acceptance: no LabVIEW process remains after the step. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.Cleanup.labview-closed"
       ]
@@ -348,7 +355,7 @@
       "id": "REQIE-011",
       "description": "After checking out the LabVIEW icon editor repository, PostSequence: The sequencer shall assemble a canonical single-line CI evidence string summarizing statuses and key facts for REQ-001..REQ-018. The string SHALL be a minified JSON assigned to a step output named 'CI_EVIDENCE' and saved as 'ci_evidence.txt'. Acceptance: the string parses as JSON and includes {\"pipeline\":\"IconEditor\", \"git_sha\":..., \"matrix\":[...], \"version\":{...}, \"artifacts\":{...}, \"req_status\":{\"REQ-001\":\"PASS\"|\"FAIL\", ...}}. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-assembled",
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-output"
@@ -358,7 +365,7 @@
       "id": "REQIE-012",
       "description": "After checking out the LabVIEW icon editor repository, PostSequence: The CI evidence string shall be logged succinctly to the job summary and made available to downstream jobs via $GITHUB_OUTPUT. Evidence: the step output 'CI_EVIDENCE' is present and a 'summary.md' contains a redacted preview. Acceptance: dependent jobs can read 'needs.<job>.outputs.CI_EVIDENCE' and parse it successfully. g-cli is expected at 'C:\\Program Files\\G-CLI\\bin\\g-cli.exe'.",
       "skip_dry_run": true,
-      "runner": "self-hosted-windows-lv",
+      "runner": "self-hosted-windows-lv-integration",
       "tests": [
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-published"
       ]


### PR DESCRIPTION
## Summary
- group runner definitions under `runners`
- add `self-hosted-windows-lv-integration` and `self-hosted-windows-lv-default`
- point Windows LV requirements to the new integration runner

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: Expected 0 but got 1 for multiple Unified Dispatcher tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a39e6dce1c832996598536510e07cd