### PR TITLE
chore: regenerate dispatcher registry

### DIFF
--- a/dispatchers.json
+++ b/dispatchers.json
@@ -5,17 +5,17 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "RelativePath": {
         "type": "string",
@@ -25,7 +25,7 @@
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -35,17 +35,17 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "RelativePath": {
         "type": "string",
@@ -55,17 +55,17 @@
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       },
       "VIP_LVVersion": {
         "type": "string",
         "required": true,
-        "description": "LabVIEW version used to build the VI Package Configuration."
+        "description": "LabVIEW version used to build the VIPC"
       },
       "VIPCPath": {
         "type": "string",
         "required": false,
-        "description": "Path to the VI Package Configuration file."
+        "description": "Optional path to the VIPC file"
       }
     }
   },
@@ -75,52 +75,52 @@
       "AuthorName": {
         "type": "string",
         "required": true,
-        "description": "Author name recorded in build metadata."
+        "description": "Author name recorded in build metadata"
       },
       "Build": {
         "type": "number",
         "required": true,
-        "description": "Build number component."
+        "description": "Build number component"
       },
       "Commit": {
         "type": "string",
         "required": true,
-        "description": "Commit identifier used for the build metadata."
+        "description": "Commit identifier used for the build metadata"
       },
       "CompanyName": {
         "type": "string",
         "required": true,
-        "description": "Company name recorded in build metadata."
+        "description": "Company name recorded in build metadata"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEWMinorRevision": {
         "type": "string",
         "required": true,
-        "description": "Minor revision of LabVIEW used for the build."
+        "description": "Minor revision of LabVIEW used for the build"
       },
       "Major": {
         "type": "number",
         "required": true,
-        "description": "Major version component."
+        "description": "Major version component"
       },
       "Minor": {
         "type": "number",
         "required": true,
-        "description": "Minor version component."
+        "description": "Minor version component"
       },
       "Patch": {
         "type": "number",
         "required": true,
-        "description": "Patch version component."
+        "description": "Patch version component"
       },
       "RelativePath": {
         "type": "string",
@@ -135,52 +135,52 @@
       "Build": {
         "type": "number",
         "required": true,
-        "description": "Build number component."
+        "description": "Build number component"
       },
       "Build_Spec": {
         "type": "string",
         "required": true,
-        "description": "Name of the build specification to run."
+        "description": "Name of the build specification within the project"
       },
       "Commit": {
         "type": "string",
         "required": true,
-        "description": "Commit identifier used for the build metadata."
+        "description": "Commit identifier used for the build metadata"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEW_Project": {
         "type": "string",
         "required": true,
-        "description": "Path to the LabVIEW project file."
+        "description": "Path to the LabVIEW project file"
       },
       "Major": {
         "type": "number",
         "required": true,
-        "description": "Major version component."
+        "description": "Major version component"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the library supports."
+        "description": "Minimum LabVIEW version that the library supports"
       },
       "Minor": {
         "type": "number",
         "required": true,
-        "description": "Minor version component."
+        "description": "Minor version component"
       },
       "Patch": {
         "type": "number",
         "required": true,
-        "description": "Patch version component."
+        "description": "Patch version component"
       },
       "RelativePath": {
         "type": "string",
@@ -190,7 +190,7 @@
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -200,52 +200,52 @@
       "Build": {
         "type": "number",
         "required": true,
-        "description": "Build number component."
+        "description": "Build number component"
       },
       "Commit": {
         "type": "string",
         "required": true,
-        "description": "Commit identifier used for the build metadata."
+        "description": "Commit identifier used for the build metadata"
       },
       "DisplayInformationJSON": {
         "type": "string",
         "required": true,
-        "description": "Path to JSON file containing display information."
+        "description": "JSON string containing display information for the package"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEWMinorRevision": {
         "type": "string",
         "required": true,
-        "description": "Minor revision of LabVIEW used to build the package."
+        "description": "Minor revision of LabVIEW used to build the package"
       },
       "Major": {
         "type": "number",
         "required": true,
-        "description": "Major version component."
+        "description": "Major version component"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the package supports."
+        "description": "Minimum LabVIEW version that the package supports"
       },
       "Minor": {
         "type": "number",
         "required": true,
-        "description": "Minor version component."
+        "description": "Minor version component"
       },
       "Patch": {
         "type": "number",
         "required": true,
-        "description": "Patch version component."
+        "description": "Patch version component"
       },
       "RelativePath": {
         "type": "string",
@@ -255,17 +255,17 @@
       "ReleaseNotesFile": {
         "type": "string",
         "required": false,
-        "description": "Path to the release notes file."
+        "description": "Optional path to a release notes file"
       },
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       },
       "VIPBPath": {
         "type": "string",
         "required": true,
-        "description": "Path to the VI Package Build (.vipb) file."
+        "description": "Path to the VIPB build specification file"
       }
     }
   },
@@ -275,22 +275,22 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -300,48 +300,48 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "OutputPath": {
         "type": "string",
         "required": false,
         "default": "Tooling/deployment/release_notes.md",
-        "description": "Path where generated release notes will be written."
+        "description": "Path where the release notes should be written"
       }
     }
   },
   "Invoke-MissingInProject": {
     "description": "Lists files referenced in a LabVIEW project that are missing on disk. LVVersion: LabVIEW version of the project. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). ProjectFile: Path to the .lvproj file to analyze. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
-      "SupportedBitness": {
-        "type": "string",
-        "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
-      },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LVVersion": {
         "type": "string",
         "required": true,
-        "description": "LabVIEW version of the project."
+        "description": "LabVIEW version of the project"
       },
       "ProjectFile": {
         "type": "string",
         "required": true,
-        "description": "Path to the LabVIEW project file."
+        "description": "Path to the"
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -351,52 +351,52 @@
       "Build": {
         "type": "number",
         "required": true,
-        "description": "Build number component."
+        "description": "Build number component"
       },
       "Commit": {
         "type": "string",
         "required": true,
-        "description": "Commit identifier used for the build metadata."
+        "description": "Commit identifier used for the build metadata"
       },
       "DisplayInformationJSON": {
         "type": "string",
         "required": true,
-        "description": "Path to JSON file containing display information."
+        "description": "JSON string containing display information for the package"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEWMinorRevision": {
         "type": "string",
         "required": true,
-        "description": "Minor revision of LabVIEW used for the build."
+        "description": "Minor revision of LabVIEW used for the build"
       },
       "Major": {
         "type": "number",
         "required": true,
-        "description": "Major version component."
+        "description": "Major version component"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the package supports."
+        "description": "Minimum LabVIEW version that the package supports"
       },
       "Minor": {
         "type": "number",
         "required": true,
-        "description": "Minor version component."
+        "description": "Minor version component"
       },
       "Patch": {
         "type": "number",
         "required": true,
-        "description": "Patch version component."
+        "description": "Patch version component"
       },
       "RelativePath": {
         "type": "string",
@@ -406,17 +406,17 @@
       "ReleaseNotesFile": {
         "type": "string",
         "required": false,
-        "description": "Path to the release notes file."
+        "description": "Optional path to a release notes file"
       },
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       },
       "VIPBPath": {
         "type": "string",
         "required": true,
-        "description": "Path to the VI Package Build (.vipb) file."
+        "description": "Path to the VIPB build specification file"
       }
     }
   },
@@ -426,27 +426,27 @@
       "Build_Spec": {
         "type": "string",
         "required": true,
-        "description": "Name of the build specification to run."
+        "description": "Name of the build specification within the project"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEW_Project": {
         "type": "string",
         "required": true,
-        "description": "Path to the LabVIEW project file."
+        "description": "Path to the LabVIEW project file"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "RelativePath": {
         "type": "string",
@@ -456,7 +456,7 @@
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -466,22 +466,22 @@
       "CurrentFilename": {
         "type": "string",
         "required": true,
-        "description": "Existing path to the file."
+        "description": "Existing path to the file"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "NewFilename": {
         "type": "string",
         "required": true,
-        "description": "New path for the file."
+        "description": "New path for the file"
       }
     }
   },
@@ -491,27 +491,27 @@
       "Build_Spec": {
         "type": "string",
         "required": true,
-        "description": "Name of the build specification to run."
+        "description": "Name of the build specification within the project"
       },
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "LabVIEW_Project": {
         "type": "string",
         "required": true,
-        "description": "Path to the LabVIEW project file."
+        "description": "Path to the LabVIEW project file"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "RelativePath": {
         "type": "string",
@@ -521,7 +521,7 @@
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -531,12 +531,12 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "RelativePath": {
         "type": "string",
@@ -551,17 +551,17 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "WorkingDirectory": {
         "type": "string",
         "required": true,
-        "description": "Path containing the Pester tests to execute."
+        "description": "Path containing the Pester tests to execute"
       }
     }
   },
@@ -571,22 +571,22 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "MinimumSupportedLVVersion": {
         "type": "string",
         "required": true,
-        "description": "Minimum LabVIEW version that the project supports."
+        "description": "Minimum LabVIEW version that the project supports"
       },
       "SupportedBitness": {
         "type": "string",
         "required": true,
-        "description": "Target LabVIEW bitness (32- or 64-bit)."
+        "description": "Target LabVIEW bitness (32- or 64-bit)"
       }
     }
   },
@@ -596,12 +596,12 @@
       "DryRun": {
         "type": "boolean",
         "required": false,
-        "description": "If set, prints the command instead of executing it."
+        "description": "If set, prints the command instead of executing it"
       },
       "gcliPath": {
         "type": "string",
         "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
+        "description": "Optional path prepended to PATH for locating the g CLI"
       },
       "RelativePath": {
         "type": "string",
@@ -610,38 +610,13 @@
       }
     }
   },
-  "Run": {
-    "description": "Runs a helper script from the repository's scripts directory. ScriptSegments: Path segments under the scripts folder that locate the target script. Arguments: Hashtable of arguments forwarded to the script. DryRun: If set, writes the command without executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
-    "parameters": {
-      "Arguments": {
-        "type": "string",
-        "required": true,
-        "description": "Hashtable of arguments forwarded to the script."
-      },
-      "DryRun": {
-        "type": "boolean",
-        "required": false,
-        "description": "If set, prints the command instead of executing it."
-      },
-      "gcliPath": {
-        "type": "string",
-        "required": false,
-        "description": "Path prepended to PATH for locating the g CLI."
-      },
-      "ScriptSegments": {
-        "type": "string",
-        "required": true,
-        "description": "Path segments under the scripts folder that locate the target script."
-      }
-    }
-  },
-  "Set": {
+  "Set-LogLevel": {
     "description": "Sets the verbosity for informational and verbose messages. Level: Desired log level (ERROR, WARN, INFO, DEBUG).",
     "parameters": {
       "Level": {
         "type": "string",
         "required": false,
-        "description": "Desired log level (ERROR, WARN, INFO, DEBUG)."
+        "description": "Desired log level (ERROR, WARN, INFO, DEBUG)"
       }
     }
   }

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -59,7 +59,7 @@ function Invoke-MyNewAction {
 
 After adding your adapter function, regenerate the dispatcher registry:
 
-1. Run `npm run derive:registry` to update `dispatchers.json`.
+1. Run `npx tsx scripts/derive-dispatcher-registry.ts` to update `dispatchers.json`.
 2. Commit the regenerated file.
 
 ## Logging and Verbosity

--- a/scripts/derive-dispatcher-registry.ts
+++ b/scripts/derive-dispatcher-registry.ts
@@ -15,6 +15,17 @@ interface FuncInfo {
   parameters: Record<string, ParamInfo>;
 }
 
+function attachParamDescriptions(info: FuncInfo) {
+  if (!info.description) return;
+  for (const [name, param] of Object.entries(info.parameters)) {
+    const regex = new RegExp(`\\b${name}:\\s*([^\\.]+)`, 'i');
+    const match = info.description.match(regex);
+    if (match) {
+      param.description = match[1].trim();
+    }
+  }
+}
+
 function parseParams(block: string): Record<string, ParamInfo> {
   const params: Record<string, ParamInfo> = {};
   const lines = block.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
@@ -94,7 +105,7 @@ async function main() {
   const registry: Record<string, FuncInfo> = {};
   for (const file of files) {
     const content = await fs.readFile(file, 'utf8');
-    const fnRegex = /function\s+(\w+)\b/gi;
+    const fnRegex = /function\s+([\w-]+)\b/gi;
     let match: RegExpExecArray | null;
     while ((match = fnRegex.exec(content)) !== null) {
       const fn = match[1];
@@ -104,8 +115,10 @@ async function main() {
       if (!paramsBlock) continue;
       const description = extractDescription(content, match.index);
       registry[fn] = { description, parameters: parseParams(paramsBlock) };
+      attachParamDescriptions(registry[fn]);
     }
   }
+  delete registry['Invoke-OpenSourceActionScript'];
   for (const info of Object.values(registry)) {
     if (info.parameters.RelativePath) {
       info.parameters.RelativePath.description =


### PR DESCRIPTION
## Summary
- extract parameter descriptions when deriving dispatcher registry and skip internal helper function
- refresh dispatcher registry data
- document regeneration step for adapter authors

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Tests Passed: 88, Failed: 17, Skipped: 15, Inconclusive: 0, NotRun: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae8c6cb48329816e17ac6a9e3589