### PR TITLE
Standardize PowerShell error handling

### DIFF
--- a/scripts/build/Build.ps1
+++ b/scripts/build/Build.ps1
@@ -82,15 +82,14 @@ function Execute-Script {
         Invoke-Expression $command
         Write-Verbose "Command completed. Checking exit code..."
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`". Exit code: $LASTEXITCODE" -ForegroundColor Red
-            exit $LASTEXITCODE
+            Write-Error "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`". Exit code: $LASTEXITCODE"
+            throw "Script failed with exit code $LASTEXITCODE"
         }
         Write-Verbose "Exit code is 0; no errors detected."
     }
     catch {
-        Write-Host "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`". Exiting." -ForegroundColor Red
-        Write-Verbose "Exception details: $($_.Exception.Message)"
-        exit 1
+        Write-Error "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`""
+        throw
     }
 }
 
@@ -266,7 +265,7 @@ try {
     Write-Verbose "Script: Build.ps1 completed without errors."
 }
 catch {
-    Write-Host "An unexpected error occurred during script execution: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Error "An unexpected error occurred during script execution: $($_.Exception.Message)"
     Write-Verbose "Stack Trace: $($_.Exception.StackTrace)"
     exit 1
 }

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -33,6 +33,10 @@ Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
 
 See also: [docs/actions/build.md](../../docs/actions/build.md)
 
+## Error handling
+
+On failure the script outputs `An unexpected error occurred during script execution: <details>` and returns a non-zero exit code.
+
 ## License
 
 This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/scripts/revert-development-mode/README.md
+++ b/scripts/revert-development-mode/README.md
@@ -18,6 +18,10 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 
 See also: [docs/actions/revert-development-mode.md](../../docs/actions/revert-development-mode.md)
 
+## Error handling
+
+Failures emit `An unexpected error occurred during script execution: <details>` and the script exits with a non-zero status.
+
 ## License
 
 This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/scripts/revert-development-mode/RevertDevelopmentMode.ps1
+++ b/scripts/revert-development-mode/RevertDevelopmentMode.ps1
@@ -41,7 +41,7 @@ function Execute-Script {
             throw "Script failed with exit code $LASTEXITCODE"
         }
     } catch {
-        Write-Error "Error occurred while executing: $ScriptCommand. $_"
+        Write-Error "Error occurred while executing: $ScriptCommand"
         if (-not $LASTEXITCODE) {
             $global:LASTEXITCODE = 1
         }

--- a/scripts/set-development-mode/README.md
+++ b/scripts/set-development-mode/README.md
@@ -18,6 +18,10 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 
 See also: [docs/actions/set-development-mode.md](../../docs/actions/set-development-mode.md)
 
+## Error handling
+
+Failures produce the message `An unexpected error occurred during script execution: <details>` and the script exits with a non-zero status.
+
 ## License
 
 This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/scripts/set-development-mode/Set_Development_Mode.ps1
+++ b/scripts/set-development-mode/Set_Development_Mode.ps1
@@ -27,7 +27,8 @@ function Execute-Script {
     try {
         Invoke-Expression $ScriptCommand -ErrorAction Stop
     } catch {
-        throw "Error occurred while executing: $ScriptCommand"
+        Write-Error "Error occurred while executing: $ScriptCommand"
+        throw
     }
 }
 # Sequential script execution with error handling

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -11,6 +11,7 @@ Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
 $params = Get-LabVIEWIconEditorArgsJson
 $projectRoot = $params.WorkingDirectory
+$errorText = 'An unexpected error occurred during script execution'
 
 Describe 'Invalid RelativePath handling' {
     $meta = @{
@@ -23,7 +24,7 @@ Describe 'Invalid RelativePath handling' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json -WorkingDirectory $projectRoot *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
-        $out | Should -Match 'An unexpected error occurred during script execution'
+        $out | Should -Match $errorText
     }
 
     It 'fails when RelativePath is missing' -Tag 'REQ-005' {


### PR DESCRIPTION
## Summary
- unify PowerShell catch blocks to emit a consistent error message
- document the standard error format in script READMEs
- clarify dispatcher test expectations for the unified error text

## Testing
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "\$cfg = New-PesterConfiguration; \$cfg.Run.Path = './tests/pester'; \$cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration \$cfg"` *(fails: Tests Passed: 88, Failed: 17, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b172cf8883299eb4fdb007f538b4