### PR TITLE
Add tests for dispatcher argument precedence

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -34,6 +34,17 @@ Arguments can also be read from a JSON file:
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json -LogLevel INFO
 ```
 
+### Argument precedence
+
+When multiple argument sources are supplied, values are merged in the following order:
+
+1. `ArgsFile`
+2. `ArgsJson`
+3. `ArgsHashtable`
+4. dispatcher switches (for example, `-DryRun`)
+
+Later entries override earlier ones. Unknown parameters from any source are ignored and emitted as warnings.
+
 ## Wrapper action usage
 
 ```yaml

--- a/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
+++ b/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
@@ -1,3 +1,14 @@
+#requires -Version 7.0
+# Pester tests verifying dispatcher argument inputs and precedence.
+# Requirement: REQ-000 - Dispatcher merges argument sources and warns on unknown parameters.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
 Describe 'Dispatcher Args Inputs' {
     $meta = @{
         requirement = 'REQ-000'
@@ -5,7 +16,55 @@ Describe 'Dispatcher Args Inputs' {
         Evidence    = 'tests/pester/Dispatcher.ArgsInputs.Tests.ps1'
     }
 
-    It 'dummy test' -Tag 'REQ-000' {
-        $true | Should -BeTrue
+    It 'accepts ArgsJson and warns on unknown parameters' -Tag 'REQ-000' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+
+        $json = @{
+            MinimumSupportedLVVersion = '2021'
+            SupportedBitness          = '64'
+            Extra                     = 'value'
+        } | ConvertTo-Json -Compress
+
+        $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match '"SupportedBitness":"64"'
+        $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
+    }
+
+    It 'accepts ArgsFile and warns on unknown parameters' -Tag 'REQ-000' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+
+        $jsonFile = Join-Path $TestDrive 'args.json'
+        @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '64'; Extra = 'value' } |
+            ConvertTo-Json -Compress | Set-Content -Path $jsonFile
+
+        $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match '"SupportedBitness":"64"'
+        $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
+    }
+
+    It 'uses inline args to override file and warns on all unknown parameters' -Tag 'REQ-000' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+
+        $file = Join-Path $TestDrive 'args.json'
+        @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32'; FileExtra = 1 } |
+            ConvertTo-Json -Compress | Set-Content -Path $file
+
+        $json = @{ SupportedBitness = '64'; JsonExtra = 2 } | ConvertTo-Json -Compress
+        $table = @{ MinimumSupportedLVVersion = '2019'; TableExtra = 3 }
+
+        $out = & $global:dispatcher -ActionName close-labview -ArgsFile $file -ArgsJson $json -ArgsHashtable $table -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match '"MinimumSupportedLVVersion":"2019"'
+        $out | Should -Match '"SupportedBitness":"64"'
+        $out | Should -Match 'Ignored unknown parameters'
+        $out | Should -Match 'FileExtra'
+        $out | Should -Match 'JsonExtra'
+        $out | Should -Match 'TableExtra'
     }
 }
+


### PR DESCRIPTION
## Summary
- test dispatcher with ArgsJson, ArgsFile, and inline overrides
- document argument source precedence in UnifiedDispatcher guide

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(failed: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b4f78158832989ec89a20a161011