### PR TITLE
Fix dispatcher test suite

### DIFF
--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -49,14 +49,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     }
   foreach ($kvp in $extra.GetEnumerator()) { $script:args | Add-Member -NotePropertyName $kvp.Key -NotePropertyValue $kvp.Value }
   $script:argsJson = $script:args | ConvertTo-Json -Compress
-  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions -WorkingDirectory $script:projectRoot |
+  $actions = & $global:dispatcher -ListActions -WorkingDirectory $script:projectRoot |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
 
   It "describes <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot *> $null
+    & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot *> $null
     $LASTEXITCODE | Should -Be 0
   }
 

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
-    $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
+    $out = & $global:dispatcher -ListActions -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
     $out | Should -Match 'apply-vipc'
     $out | Should -Match 'build-lvlibp'
     $out | Should -Match 'missing-in-project'
@@ -34,9 +34,9 @@ Describe 'Unified Dispatcher — discovery and validation' {
   It 'registry includes all Invoke* adapters in module' -Tag 'REQ-001' {
     $modulePath = Join-Path (Split-Path $global:dispatcher -Parent) 'OpenSourceActions.psm1'
     $module = Import-Module $modulePath -PassThru
-    $fnNames = (Get-Command -Module $module | Where-Object Name -like 'Invoke*').Name
+    $fnNames = (Get-Command -Module $module | Where-Object { $_.Name -like 'Invoke*' -and $_.Name -ne 'Invoke-OpenSourceActionScript' }).Name
     function Convert-Name([string]$fn) {
-      $name = $fn -replace '^Invoke'
+      $name = $fn -replace '^Invoke-?'
       $name = $name -creplace '([a-z0-9])([A-Z])', '$1-$2'
       $name = $name -creplace '([A-Z])([A-Z][a-z])', '$1-$2'
       $name = $name -ireplace 'Lab-VIEW', 'LabVIEW'
@@ -44,7 +44,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     }
     $expected = $fnNames | ForEach-Object { Convert-Name $_ }
     $wd = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
-    $listed = pwsh -NoProfile -File $global:dispatcher -ListActions -WorkingDirectory $wd | Out-String
+    $listed = & $global:dispatcher -ListActions -WorkingDirectory $wd | Out-String
     foreach ($action in $expected) {
       $listed | Should -Match " - $action"
     }
@@ -53,7 +53,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
-    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
+    $out = & $global:dispatcher -Describe build-lvlibp -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
     $out | Should -Match 'Major'
     $out | Should -Match 'Minor'
     $out | Should -Match 'Patch'

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -11,7 +11,7 @@ $scriptRoot = Join-Path $repoRoot 'scripts'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 $projectRoot = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
 $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
-$actionNames = pwsh -NoProfile -File $dispatcher -ListActions -WorkingDirectory $projectRoot |
+$actionNames = & $dispatcher -ListActions -WorkingDirectory $projectRoot |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { $_.Trim().Substring(2) }
 


### PR DESCRIPTION
## Summary
- fix dispatcher dry-run and registry tests to avoid quoting issues and helper function noise
- ensure script path tests call dispatcher directly

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a3c269ba3c8329b46f80faf17b2da4