### PR TITLE
feat: allow suppressing unknown parameter warnings

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -97,8 +97,15 @@ function Show-Description([string]$Name) {
 # InputArgs: Hashtable of supplied arguments.
 # FuncName: Target dispatcher function name.
 # ActionNameForWarn: Action name used when emitting warnings.
-# ReturnUnknownParams: If set, returns unknown parameters as well.
-function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {
+# ReturnUnknownParams: If set, returns unknown parameters and suppresses warnings.
+# NoWarn: Suppresses warnings for unknown parameters without returning them.
+function Filter-Args(
+  [hashtable]$InputArgs,
+  [string]$FuncName,
+  [string]$ActionNameForWarn,
+  [switch]$ReturnUnknownParams,
+  [switch]$NoWarn
+) {
   $cmd = Get-Command $FuncName -ErrorAction Stop
 
   # Map each alias to its canonical parameter name for the target function
@@ -124,7 +131,9 @@ function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNa
   $msg = $null
   if ($unknown.Count) {
     $msg = "Ignored unknown parameters for '$ActionNameForWarn': $($unknown -join ', ')"
-    Write-Warning $msg
+    if (-not $NoWarn -and -not $ReturnUnknownParams) {
+      Write-Warning $msg
+    }
   }
   if ($ReturnUnknownParams) {
     return [pscustomobject]@{ Args = $filtered; UnknownParams = $msg }
@@ -217,7 +226,9 @@ try {
   Set-LogLevel -Level $LogLevel
 
   # Only pass parameters that the adapter actually accepts
-  $argsHash = Filter-Args -InputArgs $argsHash -FuncName $funcName -ActionNameForWarn $key
+  $filterResult = Filter-Args -InputArgs $argsHash -FuncName $funcName -ActionNameForWarn $key -ReturnUnknownParams
+  $argsHash = $filterResult.Args
+  if ($filterResult.UnknownParams) { Write-Warning $filterResult.UnknownParams }
 
   if ($argsHash.ContainsKey('RelativePath')) {
     $argsHash['RelativePath'] = Normalize-RelativePath -RelativePath $argsHash['RelativePath'] -BaseDirectory $WorkingDirectory

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -43,7 +43,7 @@ When multiple argument sources are supplied, values are merged in the following 
 3. `ArgsHashtable`
 4. dispatcher switches (for example, `-DryRun`)
 
-Later entries override earlier ones. Unknown parameters from any source are ignored and emitted as warnings.
+Later entries override earlier ones. Unknown parameters from any source are ignored; by default they emit warnings, which can be suppressed by requesting the message with `-ReturnUnknownParams` or by using `-NoWarn`.
 
 ## Wrapper action usage
 

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -103,8 +103,11 @@ Describe 'Filter-Args helper' {
 
     function Dummy { param([string]$Known) }
     $args = @{ Known = 'value'; Extra = 'x' }
-    $result = Filter-Args -InputArgs $args -FuncName 'Dummy' -ActionNameForWarn 'dummy' -ReturnUnknownParams
+    $warnings = @()
+    $result = Filter-Args -InputArgs $args -FuncName 'Dummy' -ActionNameForWarn 'dummy' -ReturnUnknownParams -WarningVariable warnings
+    $warnings | Should -BeNullOrEmpty
     $result.PSObject.Properties.Name | Should -Contain 'UnknownParams'
+    $result.UnknownParams | Should -Match 'Extra'
   }
 }
 


### PR DESCRIPTION
## Summary
- add `-NoWarn` switch to `Filter-Args` and suppress warnings when returning unknown params
- handle unknown parameter messages in dispatcher before logging
- document warning suppression behavior and extend test coverage

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Import-Module Pester; $cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a3c80084188329aef5b0063c38238b