### PR TITLE
test: silence filter-args warnings

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -104,7 +104,8 @@ Describe 'Filter-Args helper' {
     function Dummy { param([string]$Known) }
     $args = @{ Known = 'value'; Extra = 'x' }
     $warnings = @()
-    $result = Filter-Args -InputArgs $args -FuncName 'Dummy' -ActionNameForWarn 'dummy' -ReturnUnknownParams -WarningVariable warnings
+    # Capture and suppress warnings to keep test output clean while verifying no warnings are emitted
+    $result = Filter-Args -InputArgs $args -FuncName 'Dummy' -ActionNameForWarn 'dummy' -ReturnUnknownParams -WarningVariable warnings -WarningAction SilentlyContinue
     $warnings | Should -BeNullOrEmpty
     $result.PSObject.Properties.Name | Should -Contain 'UnknownParams'
     $result.UnknownParams | Should -Match 'Extra'


### PR DESCRIPTION
## Summary
- capture and suppress warnings in Filter-Args helper test to keep output clean

## Testing
- `node --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a3c9f605388329b5ca07fa49b65b2f