### PR TITLE
feat: add strict unknown parameter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Alternatively, load arguments from a JSON file:
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json
 ```
 
+By default the dispatcher ignores unknown parameters and emits a warning. Add `-FailOnUnknown` to treat unexpected parameters as errors:
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json -FailOnUnknown
+```
+
 ### Discovering actions
 
 List all available actions:

--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -8,6 +8,7 @@ param(
   [Parameter()] [ValidateSet('ERROR','WARN','INFO','DEBUG')] [string] $LogLevel = 'INFO',
   [switch] $DryRun,
   [switch] $ListActions,
+  [switch] $FailOnUnknown,
   [string] $Describe
 )
 
@@ -228,7 +229,13 @@ try {
   # Only pass parameters that the adapter actually accepts
   $filterResult = Filter-Args -InputArgs $argsHash -FuncName $funcName -ActionNameForWarn $key -ReturnUnknownParams
   $argsHash = $filterResult.Args
-  if ($filterResult.UnknownParams) { Write-Warning $filterResult.UnknownParams }
+  if ($filterResult.UnknownParams) {
+    if ($FailOnUnknown) {
+      throw $filterResult.UnknownParams
+    } else {
+      Write-Warning $filterResult.UnknownParams
+    }
+  }
 
   if ($argsHash.ContainsKey('RelativePath')) {
     $argsHash['RelativePath'] = Normalize-RelativePath -RelativePath $argsHash['RelativePath'] -BaseDirectory $WorkingDirectory

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -24,6 +24,16 @@ Example:
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -DryRun
 ```
 
+### `-FailOnUnknown`
+
+Treats unsupported parameters as errors. By default, the dispatcher ignores unknown parameters and emits a warning. Specify `-FailOnUnknown` to throw instead.
+
+Example:
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -FailOnUnknown
+```
+
 ### `-WorkingDirectory`
 
 Runs the adapter after changing to the specified directory using `-WorkingDirectory`.

--- a/tests/pester/Dispatcher.FailOnUnknown.Tests.ps1
+++ b/tests/pester/Dispatcher.FailOnUnknown.Tests.ps1
@@ -1,0 +1,32 @@
+#requires -Version 7.0
+# Pester tests verifying dispatcher FailOnUnknown switch.
+# Requirement: REQ-000 - Dispatcher merges argument sources and warns on unknown parameters.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'Dispatcher FailOnUnknown' {
+    $meta = @{
+        requirement = 'REQ-000'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/Dispatcher.FailOnUnknown.Tests.ps1'
+    }
+
+    It 'warns on unknown parameters by default' -Tag 'REQ-000' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $json = @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '64'; Extra = 'value' } | ConvertTo-Json -Compress
+        $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $params.WorkingDirectory -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
+    }
+
+    It 'throws on unknown parameters when FailOnUnknown is set' -Tag 'REQ-000' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $json = @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '64'; Extra = 'value' } | ConvertTo-Json -Compress
+        { & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $params.WorkingDirectory -DryRun -FailOnUnknown } | Should -Throw "Ignored unknown parameters for 'close-labview': Extra"
+    }
+}


### PR DESCRIPTION
## Summary
- add `-FailOnUnknown` switch to dispatcher for strict parameter validation
- document new switch and default warning behavior
- test warning vs error handling of unknown parameters

## Testing
- `node --version`
- `pwsh --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Import-Module Pester; $cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a3cdc87030832994565d7c66419ff0