### PR TITLE
Use Material theme for MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,13 @@
 site_name: Open Source LabVIEW Actions
 site_url: https://open-source-actions.github.io/open-source-actions/
 docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - content.code.copy
+    - toc.integrate
 nav:
   - Home:
     - Overview: index.md

--- a/setup-mkdocs/action.yml
+++ b/setup-mkdocs/action.yml
@@ -15,4 +15,4 @@ runs:
           ${{ runner.os }}-pip-mkdocs-
     - name: Install MkDocs
       shell: bash
-      run: pip install mkdocs==1.5.3
+      run: pip install mkdocs==1.5.3 mkdocs-material


### PR DESCRIPTION
## Summary
- configure MkDocs to use Material theme with navigation tabs, code copy button, and integrated TOC
- install mkdocs-material within setup-mkdocs action

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "\$cfg = New-PesterConfiguration; \$cfg.Run.Path = './tests/pester'; \$cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration \$cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a3db1a98ec8329b93d8db34d64dcb3