### PR TITLE
docs: enable markdown extensions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,13 @@ theme:
     - navigation.tabs
     - content.code.copy
     - toc.integrate
+
+markdown_extensions:
+  - admonition
+  - def_list
+  - toc
+  - pymdownx.superfences
+  - pymdownx.highlight
 nav:
   - Home:
     - Overview: index.md

--- a/setup-mkdocs/action.yml
+++ b/setup-mkdocs/action.yml
@@ -15,4 +15,4 @@ runs:
           ${{ runner.os }}-pip-mkdocs-
     - name: Install MkDocs
       shell: bash
-      run: pip install mkdocs==1.5.3 mkdocs-material
+      run: pip install mkdocs==1.5.3 mkdocs-material pymdown-extensions


### PR DESCRIPTION
## Summary
- enable admonition, def list, toc, and pymdownx extensions in MkDocs
- install `pymdown-extensions` alongside MkDocs in the setup action

## Testing
- `node --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a3dd7042a88329a8cd6e26372854da