### PR TITLE
feat: enable mkdocs plugins

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,3 +52,9 @@ nav:
     - Revert Development Mode: actions/revert-development-mode.md
     - Run Unit Tests: actions/run-unit-tests.md
     - Set Development Mode: actions/set-development-mode.md
+plugins:
+  - search
+  - autorefs
+  - redirects:
+      redirect_maps:
+        old-page.md: new-page.md

--- a/setup-mkdocs/action.yml
+++ b/setup-mkdocs/action.yml
@@ -15,4 +15,4 @@ runs:
           ${{ runner.os }}-pip-mkdocs-
     - name: Install MkDocs
       shell: bash
-      run: pip install mkdocs==1.5.3 mkdocs-material pymdown-extensions
+      run: pip install mkdocs==1.5.3 mkdocs-material pymdown-extensions mkdocs-autorefs mkdocs-redirects


### PR DESCRIPTION
## Summary
- enable search, autorefs, and redirect handling in MkDocs config
- install mkdocs-autorefs and mkdocs-redirects in setup-mkdocs action

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Import-Module Pester; \$cfg = New-PesterConfiguration; \$cfg.Run.Path = './tests/pester'; \$cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration \$cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a3e37a569883298e9631ba886519b7