### PR TITLE
docs: watch scripts and enforce strict mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ edit_uri: edit/actions/docs/
 site_description: Actions for automating LabVIEW workflows
 site_author: Open Source Actions Team
 
+strict: true
+watch:
+  - docs
+  - scripts
 docs_dir: docs
 
 theme:


### PR DESCRIPTION
## Summary
- watch the `scripts` directory for changes
- enable MkDocs strict mode to catch broken links

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Import-Module Pester; $cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`
- `mkdocs serve` *(fails with broken links)*
- `mkdocs serve --no-strict -a localhost:8001` *(rebuilds on script change)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e50146608329b9f6bf3f19798e16