### PR TITLE
feat: add palette to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,15 @@ docs_dir: docs
 
 theme:
   name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.tabs
     - content.code.copy


### PR DESCRIPTION
## Summary
- add light and dark theme palettes with toggle icons to mkdocs configuration

## Testing
- `node --version`
- `pwsh --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint` *(fails: command not found)*
- `pwsh -NoLogo -Command "\$cfg = New-PesterConfiguration; \$cfg.Run.Path = './tests/pester'; \$cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration \$cfg"`
- `mkdocs serve --no-strict`

------
https://chatgpt.com/codex/tasks/task_e_68a3ed10e5908329989b8dc2baf8969a