### PR TITLE
feat: centralize test status counting

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -6,7 +6,7 @@ import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown, requirementsSummaryToMarkdown, buildSummary } from '../generate-ci-summary.ts';
+import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown, requirementsSummaryToMarkdown, buildSummary, computeStatusCounts } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
@@ -134,6 +134,17 @@ test('requirementsSummaryToMarkdown escapes pipes in description', () => {
   ];
   const md = requirementsSummaryToMarkdown(groups);
   assert.ok(md.includes('| REQ-1 | Alpha \\| Beta |'));
+});
+
+test('computeStatusCounts tallies test statuses', () => {
+  const tests = [
+    { id: '1', name: 'a', status: 'Passed', duration: 0, requirements: [] },
+    { id: '2', name: 'b', status: 'Failed', duration: 0, requirements: [] },
+    { id: '3', name: 'c', status: 'Skipped', duration: 0, requirements: [] },
+    { id: '4', name: 'd', status: 'Passed', duration: 0, requirements: [] },
+  ];
+  const counts = computeStatusCounts(tests);
+  assert.deepEqual(counts, { total: 4, passed: 2, failed: 1, skipped: 1 });
 });
 
 test('buildSummary splits totals by OS', () => {

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -237,14 +237,25 @@ export function summaryToMarkdown(totals: { overall: { passed: number; failed: n
   return ['### Test Summary', buildTable(header, rows)].join('\n');
 }
 
+export function computeStatusCounts(tests: TestCase[]) {
+  const counts = { total: tests.length, passed: 0, failed: 0, skipped: 0 };
+  for (const t of tests) {
+    if (t.status === 'Passed') {
+      counts.passed++;
+    } else if (t.status === 'Failed') {
+      counts.failed++;
+    } else {
+      counts.skipped++;
+    }
+  }
+  return counts;
+}
+
 export function requirementsSummaryToMarkdown(groups: RequirementGroup[]) {
   const header = ['Requirement ID', 'Description', 'Owner', 'Total Tests', 'Passed', 'Failed', 'Skipped', 'Pass Rate (%)'];
   const rows: string[][] = [];
   for (const g of groups) {
-    const total = g.tests.length;
-    const passed = g.tests.filter((t) => t.status === 'Passed').length;
-    const failed = g.tests.filter((t) => t.status === 'Failed').length;
-    const skipped = g.tests.filter((t) => t.status === 'Skipped').length;
+    const { total, passed, failed, skipped } = computeStatusCounts(g.tests);
     const rate = passed + failed === 0 ? 0 : (passed / (passed + failed)) * 100;
     rows.push([
       g.id,
@@ -275,9 +286,8 @@ export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
   const lines: string[] = [];
   let remaining = limit ?? Infinity;
   for (const g of groups) {
-    const total = g.tests.length;
-    const passedCount = g.tests.filter((t) => t.status === 'Passed').length;
-    const pct = total === 0 ? 0 : Math.round((passedCount / total) * 100);
+    const { total, passed } = computeStatusCounts(g.tests);
+    const pct = total === 0 ? 0 : Math.round((passed / total) * 100);
     const heading = `${g.id} (${pct}% passed)`;
     const tblHeader = ['Requirement', 'Test ID', 'Status', 'Duration (s)', 'Owner', 'Evidence'];
     const rows: string[][] = [];


### PR DESCRIPTION
## Summary
- add computeStatusCounts helper for total, passed, failed and skipped
- reuse helper in requirementsSummaryToMarkdown and groupToMarkdown
- test computeStatusCounts with mixed statuses

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a402368fec8329bba1adedf9c2509d