### PR TITLE
refactor: modularize CI summary helpers

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -6,18 +6,21 @@ import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { collectTestCases, loadRequirements, mapToRequirements } from '../generate-ci-summary.ts';
+import { collectTestCases } from '../summary/tests.ts';
+import { loadRequirements, mapToRequirements } from '../summary/requirements.ts';
 import { groupToMarkdown, summaryToMarkdown, requirementsSummaryToMarkdown, buildSummary, computeStatusCounts } from '../summary/index.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
 const summaryUrl = new URL('../summary/index.ts', import.meta.url);
+const requirementsUrl = new URL('../summary/requirements.ts', import.meta.url);
 
 test('generate-ci-summary features', async () => {
   const content = await fs.readFile(fileUrl, 'utf8');
   const summaryContent = await fs.readFile(summaryUrl, 'utf8');
+  const reqContent = await fs.readFile(requirementsUrl, 'utf8');
   assert.match(content, /TEST_RESULTS_GLOBS/);
-  assert.match(content, /<redacted>/);
+  assert.match(reqContent, /<redacted>/);
   assert.match(summaryContent, /<details><summary>/);
   assert.match(content, /\*\*\/\*junit\*\.xml/);
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -5,145 +5,18 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { glob } from 'glob';
 import { writeErrorSummary } from './error-handler.ts';
-import { buildSummary, summaryToMarkdown, requirementsSummaryToMarkdown, requirementTestsToMarkdown, groupToMarkdown, TestCase, RequirementGroup } from './summary/index.ts';
+import {
+  buildSummary,
+  summaryToMarkdown,
+  requirementsSummaryToMarkdown,
+  requirementTestsToMarkdown,
+  groupToMarkdown,
+  TestCase,
+  RequirementGroup,
+} from './summary/index.ts';
 import { generateActionDocs } from './summary/generate-action-docs.ts';
-import { parseJUnit } from './junit-parser.ts';
-
-
-function normalizeTestId(id: string): string {
-  return id.toLowerCase().replace(/::/g, '-').replace(/\s+/g, '-');
-}
-
-function redact(text: string): string {
-  return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/g, '<redacted>');
-}
-
-export async function loadRequirements(mappingFile: string) {
-  try {
-    const raw = await fs.readFile(mappingFile, 'utf8');
-    const parsed = JSON.parse(raw);
-    const defaults: Record<string, any> = parsed.runners || parsed.defaults || {};
-    const map: Record<string, { requirements: string[]; owner?: string }> = {};
-    const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
-    if (Array.isArray(parsed.requirements)) {
-      for (const r of parsed.requirements) {
-        const def = (r.runner && defaults[r.runner]) || {};
-        const owner = r.owner ?? def.owner;
-        const runner_label = r.runner_label ?? def.runner_label;
-        const runner_type = r.runner_type ?? def.runner_type;
-        const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
-        meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
-        if (Array.isArray(r.tests)) {
-          for (const t of r.tests) {
-            const key = t.toLowerCase();
-            if (!map[key]) map[key] = { requirements: [], owner };
-            map[key].requirements.push(r.id);
-          }
-        }
-      }
-    }
-    return { map, meta };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`Failed to load requirements mapping from ${mappingFile}: ${msg}`);
-    await writeErrorSummary(err);
-    return { map: {}, meta: {} };
-  }
-}
-
-export async function collectTestCases(files: string[], evidenceDir: string, os?: string): Promise<TestCase[]> {
-  const evidenceFiles = await fs.readdir(evidenceDir).catch(() => []);
-  const tests: TestCase[] = [];
-  const osType = (os ?? process.env.RUNNER_OS ?? 'unknown').toLowerCase();
-  for (const file of files) {
-    const xml = await fs.readFile(file, 'utf8');
-    let report;
-    try {
-      report = await parseJUnit(xml);
-    } catch {
-      continue;
-    }
-    for (const suite of report.suites) {
-      for (const tc of suite.testcases) {
-        const id = normalizeTestId(tc.name);
-        const test: TestCase = {
-          id,
-          name: tc.name,
-          className: tc.classname,
-          status: tc.status,
-          duration: tc.time,
-          requirements: [...tc.requirements],
-          os: osType,
-        };
-        const props = tc.properties;
-        const ownerVal = props['owner'] ?? props['machine-name'];
-        if (ownerVal) test.owner = ownerVal;
-        const evidenceVal = props['evidence'] ?? props['attachment'] ?? props['ci_link'];
-        if (evidenceVal) test.evidence = evidenceVal;
-        if (!test.evidence) {
-          const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
-          if (evidence) test.evidence = path.join('evidence', evidence);
-        }
-        if (!test.owner) {
-          const ownerMatch = tc.name.match(/\[Owner:([^\]]+)\]/i);
-          if (ownerMatch) test.owner = ownerMatch[1];
-        }
-        tests.push(test);
-      }
-    }
-  }
-  return tests;
-}
-
-export function mapToRequirements(
-  tests: TestCase[],
-  mapping: Record<string, { requirements: string[]; owner?: string }>,
-  meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }>
-): RequirementGroup[] {
-  const groups: Map<string, RequirementGroup> = new Map();
-  for (const test of tests) {
-    const stripAnnotations = (s: string) => s.replace(/\[[^\]]+\]/g, '').trim();
-    const nameKey = stripAnnotations(test.name).toLowerCase();
-    const classKey = test.className ? stripAnnotations(test.className).toLowerCase() : undefined;
-    const mapped = mapping[nameKey] || (classKey ? mapping[classKey] : undefined);
-    const reqs = mapped ? mapped.requirements : test.requirements;
-    if (mapped && mapped.owner) test.owner = mapped.owner;
-    if (!test.owner) {
-      for (const r of reqs) {
-        if (meta[r]?.owner) {
-          test.owner = meta[r].owner;
-          break;
-        }
-      }
-    }
-    const targetReqs = reqs.length ? reqs : ['Unmapped'];
-    for (const reqId of targetReqs) {
-      if (!groups.has(reqId)) {
-        groups.set(reqId, {
-          id: reqId,
-          description: meta[reqId]?.description,
-          owner: meta[reqId]?.owner,
-          runner_label: meta[reqId]?.runner_label,
-          runner_type: meta[reqId]?.runner_type,
-          skip_dry_run: meta[reqId]?.skip_dry_run,
-          tests: [],
-        });
-      }
-      groups.get(reqId)!.tests.push(test);
-    }
-  }
-  const statusRank: Record<string, number> = { Failed: 0, Passed: 1, Skipped: 2 };
-  const sorted = Array.from(groups.values()).sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
-  for (const g of sorted) {
-    g.tests.sort((a, b) => {
-      const diff = statusRank[a.status] - statusRank[b.status];
-      if (diff !== 0) return diff;
-      return a.name.localeCompare(b.name);
-    });
-  }
-  return sorted;
-}
-
+import { collectTestCases } from './summary/tests.ts';
+import { loadRequirements, mapToRequirements, redact } from './summary/requirements.ts';
 
 async function main() {
   const mappingFile = process.env.REQ_MAPPING_FILE || 'requirements.json';
@@ -233,4 +106,3 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
     process.exit(1);
   });
 }
-

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 import path from 'path';
 import { glob } from 'glob';
-import { collectTestCases } from './generate-ci-summary.ts';
+import { collectTestCases } from './summary/tests.ts';
 
 async function main() {
   const junitFiles = await glob('downloaded/pester-junit-*/pester-junit.xml');

--- a/scripts/summary/requirements.ts
+++ b/scripts/summary/requirements.ts
@@ -1,0 +1,90 @@
+import fs from 'fs/promises';
+import { writeErrorSummary } from '../error-handler.ts';
+import { TestCase, RequirementGroup } from './index.ts';
+
+export function redact(text: string): string {
+  return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/g, '<redacted>');
+}
+
+export async function loadRequirements(mappingFile: string) {
+  try {
+    const raw = await fs.readFile(mappingFile, 'utf8');
+    const parsed = JSON.parse(raw);
+    const defaults: Record<string, any> = parsed.runners || parsed.defaults || {};
+    const map: Record<string, { requirements: string[]; owner?: string }> = {};
+    const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
+    if (Array.isArray(parsed.requirements)) {
+      for (const r of parsed.requirements) {
+        const def = (r.runner && defaults[r.runner]) || {};
+        const owner = r.owner ?? def.owner;
+        const runner_label = r.runner_label ?? def.runner_label;
+        const runner_type = r.runner_type ?? def.runner_type;
+        const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
+        meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
+        if (Array.isArray(r.tests)) {
+          for (const t of r.tests) {
+            const key = t.toLowerCase();
+            if (!map[key]) map[key] = { requirements: [], owner };
+            map[key].requirements.push(r.id);
+          }
+        }
+      }
+    }
+    return { map, meta };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`Failed to load requirements mapping from ${mappingFile}: ${msg}`);
+    await writeErrorSummary(err);
+    return { map: {}, meta: {} };
+  }
+}
+
+export function mapToRequirements(
+  tests: TestCase[],
+  mapping: Record<string, { requirements: string[]; owner?: string }>,
+  meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }>,
+): RequirementGroup[] {
+  const groups: Map<string, RequirementGroup> = new Map();
+  for (const test of tests) {
+    const stripAnnotations = (s: string) => s.replace(/\[[^\]]+\]/g, '').trim();
+    const nameKey = stripAnnotations(test.name).toLowerCase();
+    const classKey = test.className ? stripAnnotations(test.className).toLowerCase() : undefined;
+    const mapped = mapping[nameKey] || (classKey ? mapping[classKey] : undefined);
+    const reqs = mapped ? mapped.requirements : test.requirements;
+    if (mapped && mapped.owner) test.owner = mapped.owner;
+    if (!test.owner) {
+      for (const r of reqs) {
+        if (meta[r]?.owner) {
+          test.owner = meta[r].owner;
+          break;
+        }
+      }
+    }
+    const targetReqs = reqs.length ? reqs : ['Unmapped'];
+    for (const reqId of targetReqs) {
+      if (!groups.has(reqId)) {
+        groups.set(reqId, {
+          id: reqId,
+          description: meta[reqId]?.description,
+          owner: meta[reqId]?.owner,
+          runner_label: meta[reqId]?.runner_label,
+          runner_type: meta[reqId]?.runner_type,
+          skip_dry_run: meta[reqId]?.skip_dry_run,
+          tests: [],
+        });
+      }
+      groups.get(reqId)!.tests.push(test);
+    }
+  }
+  const statusRank: Record<string, number> = { Failed: 0, Passed: 1, Skipped: 2 };
+  const sorted = Array.from(groups.values()).sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+  for (const g of sorted) {
+    g.tests.sort((a, b) => {
+      const diff = statusRank[a.status] - statusRank[b.status];
+      if (diff !== 0) return diff;
+      return a.name.localeCompare(b.name);
+    });
+  }
+  return sorted;
+}
+

--- a/scripts/summary/tests.ts
+++ b/scripts/summary/tests.ts
@@ -1,0 +1,53 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { TestCase } from './index.ts';
+import { parseJUnit } from '../junit-parser.ts';
+
+export function normalizeTestId(id: string): string {
+  return id.toLowerCase().replace(/::/g, '-').replace(/\s+/g, '-');
+}
+
+export async function collectTestCases(files: string[], evidenceDir: string, os?: string): Promise<TestCase[]> {
+  const evidenceFiles = await fs.readdir(evidenceDir).catch(() => []);
+  const tests: TestCase[] = [];
+  const osType = (os ?? process.env.RUNNER_OS ?? 'unknown').toLowerCase();
+  for (const file of files) {
+    const xml = await fs.readFile(file, 'utf8');
+    let report;
+    try {
+      report = await parseJUnit(xml);
+    } catch {
+      continue;
+    }
+    for (const suite of report.suites) {
+      for (const tc of suite.testcases) {
+        const id = normalizeTestId(tc.name);
+        const test: TestCase = {
+          id,
+          name: tc.name,
+          className: tc.classname,
+          status: tc.status,
+          duration: tc.time,
+          requirements: [...tc.requirements],
+          os: osType,
+        };
+        const props = tc.properties;
+        const ownerVal = props['owner'] ?? props['machine-name'];
+        if (ownerVal) test.owner = ownerVal;
+        const evidenceVal = props['evidence'] ?? props['attachment'] ?? props['ci_link'];
+        if (evidenceVal) test.evidence = evidenceVal;
+        if (!test.evidence) {
+          const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
+          if (evidence) test.evidence = path.join('evidence', evidence);
+        }
+        if (!test.owner) {
+          const ownerMatch = tc.name.match(/\[Owner:([^\]]+)\]/i);
+          if (ownerMatch) test.owner = ownerMatch[1];
+        }
+        tests.push(test);
+      }
+    }
+  }
+  return tests;
+}
+


### PR DESCRIPTION
## Summary
- move test and requirement utilities into new modules under `scripts/summary`
- refactor CI summary generator to use new modules and focus on orchestration
- update scripts and tests to import from the new modules

## Testing
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a40d063324832989bb68b3db2f7362