### PR TITLE
Escape additional Markdown characters

### DIFF
--- a/scripts/__tests__/markdown.test.js
+++ b/scripts/__tests__/markdown.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { escapeMarkdown } from '../utils/markdown.ts';
+
+test('escapeMarkdown escapes special characters', () => {
+  const input = '`*_[]|';
+  const expected = '\\`\\*\\_\\[\\]\\|';
+  assert.strictEqual(escapeMarkdown(input), expected);
+});
+
+test('escapeMarkdown leaves plain text untouched', () => {
+  const input = 'plain text';
+  assert.strictEqual(escapeMarkdown(input), input);
+});

--- a/scripts/utils/markdown.ts
+++ b/scripts/utils/markdown.ts
@@ -1,5 +1,5 @@
 export function escapeMarkdown(text: string): string {
-  return text.replace(/\|/g, '\\|');
+  return text.replace(/[|`*_\[\]]/g, '\\$&');
 }
 
 export function buildTable(header: string[], rows: string[][]): string {


### PR DESCRIPTION
## Summary
- Escape a wider set of Markdown control characters in `escapeMarkdown`
- Add tests covering Markdown escaping utility

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a40f00df288329a50c274b0774dd43