### PR TITLE
Warn and skip invalid JUnit files

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -236,6 +236,38 @@ test('writes outputs to OS-specific directory', async () => {
   await fs.rm('artifacts', { recursive: true, force: true });
 });
 
+test('skips invalid JUnit files and still generates summary', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'badjunit-'));
+  const goodXml = '<testsuite><testcase name="good" time="0"/></testsuite>';
+  const badXml = '<testsuite><testcase name="bad"></testsuite>';
+  const goodPath = path.join(dir, 'good.xml');
+  const badPath = path.join(dir, 'bad.xml');
+  await fs.writeFile(goodPath, goodXml);
+  await fs.writeFile(badPath, badXml);
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOBS: `${goodPath} ${badPath}`,
+    EVIDENCE_DIR: dir,
+    RUNNER_OS: 'Linux',
+  };
+
+  const { stderr } = await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const outDir = path.join('artifacts', 'linux');
+  const summary = await fs.readFile(path.join(outDir, 'summary.md'), 'utf8');
+  assert.match(summary, /\| linux \| 1 \| 0 \| 0 \|/);
+  const trace = await fs.readFile(path.join(outDir, 'traceability.md'), 'utf8');
+  assert.match(trace, /good/);
+  assert.strictEqual(trace.includes('bad'), false);
+  assert.match(stderr, /Failed to parse JUnit file/);
+
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
+});
+
 test('partitions requirement groups by runner_type', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'partition-'));
   const junitPath = path.join(dir, 'junit.xml');

--- a/scripts/summary/tests.ts
+++ b/scripts/summary/tests.ts
@@ -12,11 +12,12 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
   const tests: TestCase[] = [];
   const osType = (os ?? process.env.RUNNER_OS ?? 'unknown').toLowerCase();
   for (const file of files) {
-    const xml = await fs.readFile(file, 'utf8');
     let report;
     try {
+      const xml = await fs.readFile(file, 'utf8');
       report = await parseJUnit(xml);
-    } catch {
+    } catch (err) {
+      console.warn('Failed to parse JUnit file:', file, err);
       continue;
     }
     for (const suite of report.suites) {


### PR DESCRIPTION
## Summary
- avoid failing summary generation when a JUnit file can't be parsed
- test that one bad JUnit file is ignored and summaries still produce output

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a41137ba008329b691dbcf243ca375