### PR TITLE
test: cover groupToMarkdown truncation

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -144,6 +144,24 @@ test('groupToMarkdown omits numeric identifiers', () => {
   assert.match(md, /\| REQ-XYZ \| beta \| Failed \|/);
 });
 
+test('groupToMarkdown supports optional limit for truncation', () => {
+  const groups = [{
+    id: 'REQ-XYZ',
+    tests: [
+      { id: 'a', name: 'alpha', status: 'Passed', duration: 0, requirements: [] },
+      { id: 'b', name: 'beta', status: 'Failed', duration: 0, requirements: [] },
+      { id: 'c', name: 'gamma', status: 'Skipped', duration: 0, requirements: [] },
+    ],
+  }];
+  const truncated = groupToMarkdown(groups, 2);
+  assert.match(truncated, /Truncated/);
+  assert.strictEqual(truncated.includes('gamma'), false);
+
+  const full = groupToMarkdown(groups);
+  assert.doesNotMatch(full, /Truncated/);
+  assert.ok(full.includes('gamma'));
+});
+
 test('requirementsSummaryToMarkdown escapes pipes in description', () => {
   const groups = [
     { id: 'REQ-1', description: 'Alpha | Beta', tests: [] },


### PR DESCRIPTION
## Summary
- test: cover groupToMarkdown truncation

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: New-PesterConfiguration not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a41354f1e4832999e0e2d7439042a8