### PR TITLE
feat: validate requirement schema

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -84,6 +84,32 @@ test('loadRequirements logs warning on invalid JSON', async () => {
   assert.match(warned, /Failed to load requirements mapping/);
 });
 
+test('loadRequirements warns and skips invalid entries', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'req-'));
+  const req = {
+    requirements: [
+      { id: 'REQ-1', tests: ['good'] },
+      { tests: ['missing id'] },
+      { id: 'REQ-3', tests: 'not-array' },
+    ],
+  };
+  const reqPath = path.join(dir, 'req.json');
+  await fs.writeFile(reqPath, JSON.stringify(req));
+  let warned = '';
+  const origWarn = console.warn;
+  console.warn = (msg) => {
+    warned += String(msg);
+  };
+  const { map, meta } = await loadRequirements(reqPath);
+  console.warn = origWarn;
+  await fs.rm(dir, { recursive: true, force: true });
+  assert.match(warned, /Invalid requirement entry/);
+  assert.strictEqual('good' in map, true);
+  assert.strictEqual('missing id' in map, false);
+  assert.strictEqual('not-array' in map, false);
+  assert.deepEqual(Object.keys(meta), ['REQ-1']);
+});
+
 test('collectTestCases uses machine-name property for owner', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-'));
   const xmlProp = `<testsuite><testcase name="foo" time="0"><properties><property name="machine-name" value="ci-bot"/></properties></testcase></testsuite>`;

--- a/scripts/summary/requirements.ts
+++ b/scripts/summary/requirements.ts
@@ -2,31 +2,90 @@ import fs from 'fs/promises';
 import { writeErrorSummary } from '../error-handler.ts';
 import { TestCase, RequirementGroup } from './index.ts';
 
+export interface RunnerDefaults {
+  owner?: string;
+  runner_label?: string;
+  runner_type?: string;
+  skip_dry_run?: boolean;
+}
+
+export interface RequirementEntry extends RunnerDefaults {
+  id: string;
+  description?: string;
+  runner?: string;
+  tests: string[];
+}
+
+interface RequirementsFile {
+  runners?: Record<string, RunnerDefaults>;
+  defaults?: Record<string, RunnerDefaults>;
+  requirements?: unknown;
+}
+
 export function redact(text: string): string {
   return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/g, '<redacted>');
+}
+
+function isRunnerDefaults(value: unknown): value is RunnerDefaults {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if ('owner' in v && typeof v.owner !== 'string') return false;
+  if ('runner_label' in v && typeof v.runner_label !== 'string') return false;
+  if ('runner_type' in v && typeof v.runner_type !== 'string') return false;
+  if ('skip_dry_run' in v && typeof v.skip_dry_run !== 'boolean') return false;
+  return true;
+}
+
+function isRequirementEntry(value: unknown): value is RequirementEntry {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string') return false;
+  if (!Array.isArray(v.tests) || !v.tests.every((t) => typeof t === 'string')) return false;
+  if ('description' in v && typeof v.description !== 'string') return false;
+  if ('runner' in v && typeof v.runner !== 'string') return false;
+  if ('owner' in v && typeof v.owner !== 'string') return false;
+  if ('runner_label' in v && typeof v.runner_label !== 'string') return false;
+  if ('runner_type' in v && typeof v.runner_type !== 'string') return false;
+  if ('skip_dry_run' in v && typeof v.skip_dry_run !== 'boolean') return false;
+  return true;
 }
 
 export async function loadRequirements(mappingFile: string) {
   try {
     const raw = await fs.readFile(mappingFile, 'utf8');
-    const parsed = JSON.parse(raw);
-    const defaults: Record<string, any> = parsed.runners || parsed.defaults || {};
+    const parsed: RequirementsFile = JSON.parse(raw);
+
+    const defaults: Record<string, RunnerDefaults> = {};
+    const rawDefs = (parsed.runners || parsed.defaults) ?? {};
+    if (rawDefs && typeof rawDefs === 'object') {
+      for (const [name, val] of Object.entries(rawDefs)) {
+        if (isRunnerDefaults(val)) {
+          defaults[name] = val;
+        } else {
+          console.warn(`Invalid runner defaults for ${name}`);
+        }
+      }
+    }
+
     const map: Record<string, { requirements: string[]; owner?: string }> = {};
     const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
+
     if (Array.isArray(parsed.requirements)) {
       for (const r of parsed.requirements) {
+        if (!isRequirementEntry(r)) {
+          console.warn(`Invalid requirement entry: ${JSON.stringify(r)}`);
+          continue;
+        }
         const def = (r.runner && defaults[r.runner]) || {};
         const owner = r.owner ?? def.owner;
         const runner_label = r.runner_label ?? def.runner_label;
         const runner_type = r.runner_type ?? def.runner_type;
         const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
         meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
-        if (Array.isArray(r.tests)) {
-          for (const t of r.tests) {
-            const key = t.toLowerCase();
-            if (!map[key]) map[key] = { requirements: [], owner };
-            map[key].requirements.push(r.id);
-          }
+        for (const t of r.tests) {
+          const key = t.toLowerCase();
+          if (!map[key]) map[key] = { requirements: [], owner };
+          map[key].requirements.push(r.id);
         }
       }
     }


### PR DESCRIPTION
## Summary
- define interfaces for requirement entries and runner defaults
- validate requirements mapping schema and warn on invalid entries
- cover validation with tests for skipping malformed entries

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a41519fc548329b43d407b44cfae1a