### PR TITLE
Limit CI summary to current artifacts

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -44,6 +44,9 @@
           "run": "npm run derive:registry"
         },
         {
+          "run": "rm -rf artifacts"
+        },
+        {
           "run": "npm run generate:summary",
           "env": {
             "TEST_RESULTS_GLOBS": "test-results/*junit*.xml"
@@ -173,6 +176,9 @@
         },
         {
           "run": "npm install"
+        },
+        {
+          "run": "rm -rf artifacts"
         },
         {
           "uses": "actions/download-artifact@v4",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - run: npm run link:check
       - run: npm run test:ci
       - run: npm run derive:registry
+      - run: rm -rf artifacts
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: test-results/*junit*.xml
@@ -142,6 +143,7 @@ jobs:
           node-version: 24
       - run: npm run check:node
       - run: npm install
+      - run: rm -rf artifacts
       - uses: actions/download-artifact@v4
         with:
           path: ./artifacts

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable.
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable. The summary script searches `artifacts/` by default; set `TEST_RESULTS_GLOBS` if your reports are elsewhere.
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -55,7 +55,11 @@ MkDocs serves the site at <http://127.0.0.1:8000/> by default. The server automa
 
 ## JUnit integration
 
-The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates.
+The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates. By default, the summary script only searches `artifacts/` for JUnit XML files; if your results are elsewhere, pass a glob via `TEST_RESULTS_GLOBS`, for example:
+
+```bash
+TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary
+```
 
 ### Pester properties
 

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -22,7 +22,7 @@ test('generate-ci-summary features', async () => {
   assert.match(content, /TEST_RESULTS_GLOBS/);
   assert.match(reqContent, /<redacted>/);
   assert.match(summaryContent, /<details><summary>/);
-  assert.match(content, /\*\*\/\*junit\*\.xml/);
+  assert.match(content, /artifacts\/\*\*\/\*junit\*\.xml/);
 });
 
 test('writeErrorSummary skips summary file for non-Error throws', async () => {
@@ -310,6 +310,26 @@ test('skips invalid JUnit files and still generates summary', async () => {
 
   await fs.rm(dir, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });
+});
+
+test('ignores stale JUnit files outside artifacts path', async () => {
+  await fs.rm('artifacts', { recursive: true, force: true });
+  const freshDir = path.join('artifacts', 'current');
+  await fs.mkdir(freshDir, { recursive: true });
+  const freshXml = '<testsuite><testcase name="fresh" time="0"/></testsuite>';
+  await fs.writeFile(path.join(freshDir, 'junit.xml'), freshXml);
+  const stalePath = path.join('stale-junit.xml');
+  await fs.writeFile(stalePath, '<testsuite><testcase name="stale" time="0"/></testsuite>');
+
+  const env = { ...process.env, RUNNER_OS: 'Linux' };
+  await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const trace = await fs.readFile(path.join('artifacts', 'linux', 'traceability.md'), 'utf8');
+  assert.match(trace, /fresh/);
+  assert.strictEqual(trace.includes('stale'), false);
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+  await fs.rm(stalePath, { force: true });
 });
 
 test('partitions requirement groups by runner_type', async () => {

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -35,7 +35,7 @@ async function main() {
     }
     junitFiles = Array.from(found);
   } else {
-    const single = process.env.TEST_RESULTS_GLOB || '**/*junit*.xml';
+    const single = process.env.TEST_RESULTS_GLOB || 'artifacts/**/*junit*.xml';
     junitFiles = await glob(single, { nodir: true });
   }
   let tests: TestCase[] = [];


### PR DESCRIPTION
## Summary
- narrow default JUnit search to `artifacts/` to avoid stale results
- clean artifact directories before generating summaries in CI
- document new behavior and test that stale JUnit files are ignored

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a41dbb971483299a1dd1e93de94863