### PR TITLE
Handle latest Pester JUnit artifacts

### DIFF
--- a/scripts/__tests__/fixtures/multiple-artifacts/artifacts/pester-junit-1/pester-junit.xml
+++ b/scripts/__tests__/fixtures/multiple-artifacts/artifacts/pester-junit-1/pester-junit.xml
@@ -1,0 +1,8 @@
+<testsuite>
+  <testcase name="[Owner:carol] Old" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/old.log"/>
+      <property name="requirement" value="REQ-OLD"/>
+    </properties>
+  </testcase>
+</testsuite>

--- a/scripts/__tests__/fixtures/multiple-artifacts/artifacts/pester-junit-2/pester-junit.xml
+++ b/scripts/__tests__/fixtures/multiple-artifacts/artifacts/pester-junit-2/pester-junit.xml
@@ -1,0 +1,8 @@
+<testsuite>
+  <testcase name="[Owner:dave] New" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/new.log"/>
+      <property name="requirement" value="REQ-NEW"/>
+    </properties>
+  </testcase>
+</testsuite>

--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -9,12 +9,12 @@ const execFileP = promisify(execFile);
 
 const fixtureDir = fileURLToPath(new URL('./fixtures', import.meta.url));
 const rootDir = fileURLToPath(new URL('../..', import.meta.url));
+const scriptFile = path.join(rootDir, 'scripts/print-pester-traceability.ts');
 
 test('groups owners and includes requirements and evidence', async () => {
   const env = { ...process.env, RUNNER_OS: 'Linux' };
   const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
-  const scriptPath = '../../print-pester-traceability.ts';
-  const { stdout } = await execFileP(tsxPath, [scriptPath], { cwd: fixtureDir, env });
+  const { stdout } = await execFileP(tsxPath, [scriptFile], { cwd: fixtureDir, env });
 
   // ensure details sections for each owner
   assert.match(stdout, /<details><summary>alice<\/summary>/);
@@ -32,4 +32,27 @@ test('groups owners and includes requirements and evidence', async () => {
   assert.match(aliceSection, /Alpha \| REQ-123 \| Passed \| \[link\]\(http:\/\/example.com\/alpha.log\)/);
   assert.match(aliceSection, /Gamma \| REQ-789 \| Passed \| \[link\]\(http:\/\/example.com\/gamma.log\)/);
   assert.match(bobSection, /Beta \| REQ-456 \| Passed \| \[link\]\(http:\/\/example.com\/beta.log\)/);
+});
+
+test('fails when no JUnit files are found', async () => {
+  const env = { ...process.env, RUNNER_OS: 'Linux' };
+  const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
+  const cwd = path.join(fixtureDir, 'no-artifacts');
+  await assert.rejects(
+    execFileP(tsxPath, [scriptFile], { cwd, env }),
+    (err) => {
+      assert.equal(err.code, 1);
+      assert.match(err.stderr, /No JUnit files found/);
+      return true;
+    }
+  );
+});
+
+test('uses latest artifact directory when multiple are present', async () => {
+  const env = { ...process.env, RUNNER_OS: 'Linux' };
+  const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
+  const cwd = path.join(fixtureDir, 'multiple-artifacts');
+  const { stdout } = await execFileP(tsxPath, [scriptFile], { cwd, env });
+  assert.match(stdout, /<details><summary>dave<\/summary>/);
+  assert.doesNotMatch(stdout, /<details><summary>carol<\/summary>/);
 });

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -4,7 +4,24 @@ import { glob } from 'glob';
 import { collectTestCases } from './summary/tests.ts';
 
 async function main() {
-  const junitFiles = await glob('artifacts/pester-junit-*/pester-junit.xml');
+  const overrideDir = process.env.PESTER_JUNIT_PATH;
+  let junitFiles: string[] = [];
+  if (overrideDir) {
+    junitFiles = await glob(path.join(overrideDir, 'pester-junit.xml'));
+  } else {
+    const matches = await glob('artifacts/pester-junit-*/pester-junit.xml');
+    if (matches.length > 0) {
+      const latestDir = matches
+        .map((f) => path.dirname(f))
+        .sort()
+        .pop()!;
+      junitFiles = matches.filter((f) => path.dirname(f) === latestDir);
+    }
+  }
+  if (junitFiles.length === 0) {
+    console.warn('No JUnit files found');
+    process.exit(1);
+  }
   const tests = [];
   for (const file of junitFiles) {
     const dir = path.dirname(file);


### PR DESCRIPTION
## Summary
- Select latest `pester-junit-*` artifact or use `PESTER_JUNIT_PATH`
- Fail when no JUnit files found to avoid stale summaries
- Test scenarios for missing artifacts and multiple artifact dirs

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: New-PesterConfiguration not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a4222751248329b256166b90e6b7f9