### PR TITLE
feat(ci): require test results in strict mode

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -332,6 +332,15 @@ test('ignores stale JUnit files outside artifacts path', async () => {
   await fs.rm(stalePath, { force: true });
 });
 
+test('throws when no JUnit files found and strict mode enabled', async () => {
+  await fs.rm('artifacts', { recursive: true, force: true });
+  const env = { ...process.env, REQUIRE_TEST_RESULTS: '1', RUNNER_OS: 'Linux' };
+  await assert.rejects(
+    execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env }),
+    /No JUnit files found/,
+  );
+});
+
 test('partitions requirement groups by runner_type', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'partition-'));
   const junitPath = path.join(dir, 'junit.xml');

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -38,9 +38,14 @@ async function main() {
     const single = process.env.TEST_RESULTS_GLOB || 'artifacts/**/*junit*.xml';
     junitFiles = await glob(single, { nodir: true });
   }
+  const requireResults = !!process.env.REQUIRE_TEST_RESULTS;
   let tests: TestCase[] = [];
   if (junitFiles.length === 0) {
-    console.warn('No JUnit files found; writing empty summary.');
+    const msg = 'No JUnit files found';
+    if (requireResults) {
+      throw new Error(msg);
+    }
+    console.warn(`${msg}; writing empty summary.`);
   } else {
     tests = await collectTestCases(junitFiles, evidenceDir, osType);
   }


### PR DESCRIPTION
## Summary
- enforce strict mode via REQUIRE_TEST_RESULTS env var in generate-ci-summary
- add unit test for missing JUnit files when strict mode enabled

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: New-PesterConfiguration not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e3c4f54832984a2424965c2322c