### PR TITLE
Handle zipped JUnit results in CI summary generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0",
         "xml2js": "^0.6.2"
@@ -632,6 +633,15 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "link:check": "markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')"
   },
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0",
     "xml2js": "^0.6.2"

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -6,6 +6,7 @@ import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import AdmZip from 'adm-zip';
 import { collectTestCases } from '../summary/tests.ts';
 import { loadRequirements, mapToRequirements } from '../summary/requirements.ts';
 import { groupToMarkdown, summaryToMarkdown, requirementsSummaryToMarkdown, buildSummary, computeStatusCounts } from '../summary/index.ts';
@@ -380,4 +381,35 @@ test('partitions requirement groups by runner_type', async () => {
 
   await fs.rm(dir, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });
+});
+
+test('handles zipped JUnit artifacts', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'zip-'));
+  const zip = new AdmZip();
+  const xml = '<testsuite><testcase classname="Dispatcher.Tests" name="zip" time="0"/></testsuite>';
+  zip.addFile('junit.xml', Buffer.from(xml));
+  const zipPath = path.join(tmp, 'junit.zip');
+  zip.writeZip(zipPath);
+  await fs.mkdir(path.join(tmp, 'evidence'));
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const reqPath = fileURLToPath(new URL('../../requirements.json', import.meta.url));
+  const dispPath = fileURLToPath(new URL('../../dispatchers.json', import.meta.url));
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOBS: zipPath,
+    EVIDENCE_DIR: path.join(tmp, 'evidence'),
+    REQ_MAPPING_FILE: reqPath,
+    DISPATCHER_REGISTRY: dispPath,
+    RUNNER_OS: 'Linux',
+  };
+
+  await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const summary = await fs.readFile(path.join('artifacts', 'linux', 'requirements-summary.md'), 'utf8');
+  assert.match(summary, /REQ-001/);
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+  await fs.rm(tmp, { recursive: true, force: true });
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -2,8 +2,10 @@
 import fs from 'fs/promises';
 import { constants as fsConstants } from 'fs';
 import path from 'path';
+import os from 'os';
 import { pathToFileURL } from 'url';
 import { glob } from 'glob';
+import AdmZip from 'adm-zip';
 import { writeErrorSummary } from './error-handler.ts';
 import {
   buildSummary,
@@ -38,16 +40,45 @@ async function main() {
     const single = process.env.TEST_RESULTS_GLOB || 'artifacts/**/*junit*.xml';
     junitFiles = await glob(single, { nodir: true });
   }
+
+  let extractedDir: string | null = null;
+  const expanded: string[] = [];
+  for (const f of junitFiles) {
+    if (f.toLowerCase().endsWith('.zip')) {
+      if (!extractedDir) {
+        extractedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'junit-'));
+      }
+      try {
+        const zip = new AdmZip(f);
+        for (const entry of zip.getEntries()) {
+          if (!entry.isDirectory && entry.entryName.toLowerCase().endsWith('.xml')) {
+            const dest = path.join(extractedDir, path.basename(entry.entryName));
+            await fs.writeFile(dest, entry.getData());
+            expanded.push(dest);
+          }
+        }
+      } catch (err) {
+        console.warn(`Failed to extract JUnit archive ${f}:`, err);
+      }
+    } else {
+      expanded.push(f);
+    }
+  }
+  junitFiles = expanded;
   const requireResults = !!process.env.REQUIRE_TEST_RESULTS;
   let tests: TestCase[] = [];
-  if (junitFiles.length === 0) {
-    const msg = 'No JUnit files found';
-    if (requireResults) {
-      throw new Error(msg);
+  try {
+    if (junitFiles.length === 0) {
+      const msg = 'No JUnit files found';
+      if (requireResults) {
+        throw new Error(msg);
+      }
+      console.warn(`${msg}; writing empty summary.`);
+    } else {
+      tests = await collectTestCases(junitFiles, evidenceDir, osType);
     }
-    console.warn(`${msg}; writing empty summary.`);
-  } else {
-    tests = await collectTestCases(junitFiles, evidenceDir, osType);
+  } finally {
+    if (extractedDir) await fs.rm(extractedDir, { recursive: true, force: true });
   }
   const { map, meta } = await loadRequirements(mappingFile);
   const groups = mapToRequirements(tests, map, meta);


### PR DESCRIPTION
## Summary
- extract XML from zipped JUnit artifacts before generating summaries
- clean up temporary extraction directory and extend tests for zipped results
- depend on adm-zip for archive handling

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a437a5434c8329a7280ad270bd9d0f