### PR TITLE
feat: surface missing requirement mappings

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,6 +2,8 @@
 
 This project tracks high‑level requirements and maps each one to the Pester test files that verify it. The authoritative mapping is stored in [`requirements.json`](../requirements.json); the table below provides a human‑readable summary for quick reference.
 
+If every test maps to `Unmapped`, the `scripts/generate-ci-summary.ts` script logs a warning. Set `REQUIRE_REQUIREMENTS_MAPPING` in the environment to treat this situation as an error.
+
 Runner Type indicates whether a requirement runs on a standard GitHub-hosted image or an integration runner with preinstalled tooling. See [runner-types](runner-types.md) for guidance on choosing between them.
 
 | ID | Description | Tests | Runner | Runner Type | Skip Dry Run |

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -313,6 +313,57 @@ test('skips invalid JUnit files and still generates summary', async () => {
   await fs.rm('artifacts', { recursive: true, force: true });
 });
 
+test('warns when all tests are unmapped', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'unmapped-'));
+  const junitPath = path.join(dir, 'junit.xml');
+  await fs.writeFile(junitPath, '<testsuite><testcase name="foo" time="0"/></testsuite>');
+  const reqPath = path.join(dir, 'req.json');
+  await fs.writeFile(reqPath, JSON.stringify({ requirements: [] }));
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOBS: junitPath,
+    EVIDENCE_DIR: dir,
+    REQ_MAPPING_FILE: reqPath,
+    RUNNER_OS: 'Linux',
+  };
+
+  const { stderr } = await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+  assert.match(stderr, /All tests are unmapped/);
+
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
+});
+
+test('errors when strict unmapped mode enabled', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'unmapped-'));
+  const junitPath = path.join(dir, 'junit.xml');
+  await fs.writeFile(junitPath, '<testsuite><testcase name="foo" time="0"/></testsuite>');
+  const reqPath = path.join(dir, 'req.json');
+  await fs.writeFile(reqPath, JSON.stringify({ requirements: [] }));
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOBS: junitPath,
+    EVIDENCE_DIR: dir,
+    REQ_MAPPING_FILE: reqPath,
+    RUNNER_OS: 'Linux',
+    REQUIRE_REQUIREMENTS_MAPPING: '1',
+  };
+
+  await assert.rejects(
+    execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env }),
+    /All tests are unmapped/,
+  );
+
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
+});
+
 test('ignores stale JUnit files outside artifacts path', async () => {
   await fs.rm('artifacts', { recursive: true, force: true });
   const freshDir = path.join('artifacts', 'current');

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -82,6 +82,14 @@ async function main() {
   }
   const { map, meta } = await loadRequirements(mappingFile);
   const groups = mapToRequirements(tests, map, meta);
+  const allUnmapped = groups.every(g => g.id === 'Unmapped');
+  if (allUnmapped) {
+    const msg = 'All tests are unmapped; verify requirements mapping.';
+    if (process.env.REQUIRE_REQUIREMENTS_MAPPING) {
+      throw new Error(msg);
+    }
+    console.warn(msg);
+  }
   const totals = buildSummary(groups);
 
   const outDir = path.join('artifacts', osType);


### PR DESCRIPTION
## Summary
- detect when all tests map to `Unmapped`
- optionally fail run with `REQUIRE_REQUIREMENTS_MAPPING`
- document unmapped requirement warning and add tests

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a43a7d7a18832999b0e8424a388f0e