### PR TITLE
feat: align traceability table with summary format

### DIFF
--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -28,10 +28,31 @@ test('groups owners and includes requirements and evidence', async () => {
   assert(bobSection.includes('Beta'));
   assert(!bobSection.includes('Alpha') && !bobSection.includes('Gamma'));
 
-  // requirement IDs and evidence links
-  assert.match(aliceSection, /Alpha \| REQ-123 \| Passed \| \[link\]\(http:\/\/example.com\/alpha.log\)/);
-  assert.match(aliceSection, /Gamma \| REQ-789 \| Passed \| \[link\]\(http:\/\/example.com\/gamma.log\)/);
-  assert.match(bobSection, /Beta \| REQ-456 \| Passed \| \[link\]\(http:\/\/example.com\/beta.log\)/);
+  // table header
+  assert.match(
+    aliceSection,
+    /\| Requirement \| Test ID \| Status \| Duration \(s\) \| Owner \| Evidence \|/
+  );
+
+  // requirement IDs and evidence links with new layout
+  assert(
+    aliceSection.includes(
+      '| REQ-123 | Alpha | Passed | 0.000 | alice | \\[' +
+      'link\\](http://example.com/alpha.log) |'
+    )
+  );
+  assert(
+    aliceSection.includes(
+      '| REQ-789 | Gamma | Passed | 0.000 | alice | \\[' +
+      'link\\](http://example.com/gamma.log) |'
+    )
+  );
+  assert(
+    bobSection.includes(
+      '| REQ-456 | Beta | Passed | 0.000 | bob | \\[' +
+      'link\\](http://example.com/beta.log) |'
+    )
+  );
 });
 
 test('fails when no JUnit files are found', async () => {

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import { glob } from 'glob';
 import { collectTestCases } from './summary/tests.ts';
+import { buildTable } from './utils/markdown.ts';
 
 async function main() {
   const overrideDir = process.env.PESTER_JUNIT_PATH;
@@ -38,13 +39,17 @@ async function main() {
   const sortedOwners = Array.from(groups.keys()).sort();
   for (const owner of sortedOwners) {
     const tlist = groups.get(owner)!;
-    const table = ['| Test | Requirements | Status | Evidence |', '| --- | --- | --- | --- |'];
+    const header = ['Requirement', 'Test ID', 'Status', 'Duration (s)', 'Owner', 'Evidence'];
+    const rows: string[][] = [];
     for (const t of tlist) {
-      const reqs = t.requirements.join(', ');
       const evidence = t.evidence ? `[link](${t.evidence})` : '';
-      table.push(`| ${t.name} | ${reqs} | ${t.status} | ${evidence} |`);
+      const ownerVal = t.owner || owner;
+      const name = t.name.replace(/\[Owner:[^\]]+\]\s*/, '');
+      for (const req of t.requirements) {
+        rows.push([req, name, t.status, t.duration.toFixed(3), ownerVal, evidence]);
+      }
     }
-    const content = table.join('\n');
+    const content = buildTable(header, rows);
     lines.push(`<details><summary>${owner}</summary>\n\n${content}\n\n</details>`);
   }
   console.log(lines.join('\n\n'));


### PR DESCRIPTION
## Summary
- format Pester traceability output like summary tables
- adjust tests for new table layout and escaped links

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4413f46cc832994f9fc0b62e2599a