### PR TITLE
Align pester traceability tables with summary formatting

### DIFF
--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -28,10 +28,23 @@ test('groups owners and includes requirements and evidence', async () => {
   assert(bobSection.includes('Beta'));
   assert(!bobSection.includes('Alpha') && !bobSection.includes('Gamma'));
 
-  // requirement IDs and evidence links
-  assert.match(aliceSection, /Alpha \| REQ-123 \| Passed \| \[link\]\(http:\/\/example.com\/alpha.log\)/);
-  assert.match(aliceSection, /Gamma \| REQ-789 \| Passed \| \[link\]\(http:\/\/example.com\/gamma.log\)/);
-  assert.match(bobSection, /Beta \| REQ-456 \| Passed \| \[link\]\(http:\/\/example.com\/beta.log\)/);
+  // header and rows
+  assert(aliceSection.includes('| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |'));
+  assert(
+    aliceSection.includes(
+      '| REQ-123 | \\[Owner:alice\\] Alpha | Passed | 0.000 | alice | \\[link\\](http://example.com/alpha.log) |'
+    )
+  );
+  assert(
+    aliceSection.includes(
+      '| REQ-789 | \\[Owner:alice\\] Gamma | Passed | 0.000 | alice | \\[link\\](http://example.com/gamma.log) |'
+    )
+  );
+  assert(
+    bobSection.includes(
+      '| REQ-456 | \\[Owner:bob\\] Beta | Passed | 0.000 | bob | \\[link\\](http://example.com/beta.log) |'
+    )
+  );
 });
 
 test('fails when no JUnit files are found', async () => {

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import { glob } from 'glob';
 import { collectTestCases } from './summary/tests.ts';
+import { buildTable } from './utils/markdown.ts';
 
 async function main() {
   const overrideDir = process.env.PESTER_JUNIT_PATH;
@@ -38,13 +39,20 @@ async function main() {
   const sortedOwners = Array.from(groups.keys()).sort();
   for (const owner of sortedOwners) {
     const tlist = groups.get(owner)!;
-    const table = ['| Test | Requirements | Status | Evidence |', '| --- | --- | --- | --- |'];
+    const header = ['Requirement', 'Test ID', 'Status', 'Duration (s)', 'Owner', 'Evidence'];
+    const rows: string[][] = [];
     for (const t of tlist) {
-      const reqs = t.requirements.join(', ');
       const evidence = t.evidence ? `[link](${t.evidence})` : '';
-      table.push(`| ${t.name} | ${reqs} | ${t.status} | ${evidence} |`);
+      rows.push([
+        t.requirements.join(', '),
+        t.name,
+        t.status,
+        t.duration.toFixed(3),
+        t.owner ?? owner,
+        evidence,
+      ]);
     }
-    const content = table.join('\n');
+    const content = buildTable(header, rows);
     lines.push(`<details><summary>${owner}</summary>\n\n${content}\n\n</details>`);
   }
   console.log(lines.join('\n\n'));


### PR DESCRIPTION
## Summary
- Use summary table formatting in `print-pester-traceability.ts` for requirement, status, duration, owner and evidence columns
- Update tests for new traceability table layout

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a4413f46cc832994f9fc0b62e2599a