### PR TITLE
Use test IDs in requirement traceability

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -160,8 +160,8 @@ test('groupToMarkdown omits numeric identifiers', () => {
   const groups = [{
     id: 'REQ-XYZ',
     tests: [
-      { id: 'a', name: 'alpha', status: 'Passed', duration: 0, requirements: [] },
-      { id: 'b', name: 'beta', status: 'Failed', duration: 0, requirements: [] },
+      { id: 'alpha', name: 'Alpha', status: 'Passed', duration: 0, requirements: [] },
+      { id: 'beta', name: 'Beta', status: 'Failed', duration: 0, requirements: [] },
     ],
   }];
   const md = groupToMarkdown(groups);
@@ -175,9 +175,9 @@ test('groupToMarkdown supports optional limit for truncation', () => {
   const groups = [{
     id: 'REQ-XYZ',
     tests: [
-      { id: 'a', name: 'alpha', status: 'Passed', duration: 0, requirements: [] },
-      { id: 'b', name: 'beta', status: 'Failed', duration: 0, requirements: [] },
-      { id: 'c', name: 'gamma', status: 'Skipped', duration: 0, requirements: [] },
+      { id: 'alpha', name: 'Alpha', status: 'Passed', duration: 0, requirements: [] },
+      { id: 'beta', name: 'Beta', status: 'Failed', duration: 0, requirements: [] },
+      { id: 'gamma', name: 'Gamma', status: 'Skipped', duration: 0, requirements: [] },
     ],
   }];
   const truncated = groupToMarkdown(groups, 2);

--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -23,26 +23,26 @@ test('groups owners and includes requirements and evidence', async () => {
   // owners grouped correctly
   const aliceSection = stdout.match(/<details><summary>alice<\/summary>[\s\S]*?<\/details>/)[0];
   const bobSection = stdout.match(/<details><summary>bob<\/summary>[\s\S]*?<\/details>/)[0];
-  assert(aliceSection.includes('Alpha') && aliceSection.includes('Gamma'));
-  assert(!aliceSection.includes('Beta'));
-  assert(bobSection.includes('Beta'));
-  assert(!bobSection.includes('Alpha') && !bobSection.includes('Gamma'));
+  assert(aliceSection.includes('alpha') && aliceSection.includes('gamma'));
+  assert(!aliceSection.includes('beta'));
+  assert(bobSection.includes('beta'));
+  assert(!bobSection.includes('alpha') && !bobSection.includes('gamma'));
 
   // header and rows
   assert(aliceSection.includes('| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |'));
   assert(
     aliceSection.includes(
-      '| REQ-123 | \\[Owner:alice\\] Alpha | Passed | 0.000 | alice | \\[link\\](http://example.com/alpha.log) |'
+      '| REQ-123 | alpha | Passed | 0.000 | alice | \\[link\\](http://example.com/alpha.log) |'
     )
   );
   assert(
     aliceSection.includes(
-      '| REQ-789 | \\[Owner:alice\\] Gamma | Passed | 0.000 | alice | \\[link\\](http://example.com/gamma.log) |'
+      '| REQ-789 | gamma | Passed | 0.000 | alice | \\[link\\](http://example.com/gamma.log) |'
     )
   );
   assert(
     bobSection.includes(
-      '| REQ-456 | \\[Owner:bob\\] Beta | Passed | 0.000 | bob | \\[link\\](http://example.com/beta.log) |'
+      '| REQ-456 | beta | Passed | 0.000 | bob | \\[link\\](http://example.com/beta.log) |'
     )
   );
 });

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -45,7 +45,7 @@ async function main() {
       const evidence = t.evidence ? `[link](${t.evidence})` : '';
       rows.push([
         t.requirements.join(', '),
-        t.name,
+        t.id,
         t.status,
         t.duration.toFixed(3),
         t.owner ?? owner,

--- a/scripts/summary/index.ts
+++ b/scripts/summary/index.ts
@@ -101,7 +101,7 @@ export function requirementTestsToMarkdown(groups: RequirementGroup[]) {
   const rows: string[][] = [];
   for (const g of groups) {
     for (const t of g.tests) {
-      rows.push([g.id, t.name, t.status]);
+      rows.push([g.id, t.id, t.status]);
     }
   }
   return ['### Requirement Testcases', buildTable(header, rows)].join('\n');
@@ -121,7 +121,7 @@ export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
       const evidence = t.evidence ? `[link](${t.evidence})` : '';
       rows.push([
         g.id,
-        t.name,
+        t.id,
         t.status,
         t.duration.toFixed(3),
         t.owner ?? g.owner ?? '',

--- a/scripts/summary/tests.ts
+++ b/scripts/summary/tests.ts
@@ -4,7 +4,11 @@ import { TestCase } from './index.ts';
 import { parseJUnit } from '../junit-parser.ts';
 
 export function normalizeTestId(id: string): string {
-  return id.toLowerCase().replace(/::/g, '-').replace(/\s+/g, '-');
+  return id
+    .replace(/\[[^\]]*\]\s*/g, '')
+    .toLowerCase()
+    .replace(/::/g, '-')
+    .replace(/\s+/g, '-');
 }
 
 export async function collectTestCases(files: string[], evidenceDir: string, os?: string): Promise<TestCase[]> {


### PR DESCRIPTION
## Summary
- normalize test IDs by stripping annotations
- display test IDs instead of names in requirement and traceability tables
- adjust Pester traceability and tests for new ID handling

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a4464717448329af0859fb32176070