### PR TITLE
feat: add artifact provenance manifest

### DIFF
--- a/.github/workflows/build-self-hosted.json
+++ b/.github/workflows/build-self-hosted.json
@@ -6,6 +6,11 @@
   "jobs": {
     "build": {
       "runs-on": "ubuntu-latest",
+      "env": {
+        "MAJOR": "1",
+        "MINOR": "0",
+        "PATCH": "0"
+      },
       "steps": [
         {
           "uses": "actions/checkout@v4"
@@ -15,22 +20,35 @@
           "uses": "./build/action.yml",
           "with": {
             "relative_path": "scripts/build",
-            "major": "1",
-            "minor": "0",
-            "patch": "0",
-            "build": "1",
-            "commit": "abcdef",
+            "major": "${{ env.MAJOR }}",
+            "minor": "${{ env.MINOR }}",
+            "patch": "${{ env.PATCH }}",
+            "build": "${{ github.run_number }}",
+            "commit": "${{ github.sha }}",
             "labview_minor_revision": "3",
             "company_name": "Acme Corp",
             "author_name": "Jane Doe"
           }
         },
         {
+          "name": "Record artifact metadata",
+          "id": "record",
+          "run": "VERSION=\"${MAJOR}.${MINOR}.${PATCH}.${GITHUB_RUN_NUMBER}\"\nSHORT_SHA=\"${GITHUB_SHA::7}\"\nARTIFACT=\"lv_icon_x64_v${VERSION}+${SHORT_SHA}.lvlibp\"\nmv scripts/build/lv_icon_x64.lvlibp \"scripts/build/${ARTIFACT}\"\nprintf '{\"commit\":\"%s\",\"build_number\":\"%s\",\"artifacts\":[\"%s\"]}' \"$GITHUB_SHA\" \"$GITHUB_RUN_NUMBER\" \"$ARTIFACT\" > scripts/build/artifact-manifest.json\necho \"artifact=${ARTIFACT}\" >> \"$GITHUB_OUTPUT\""
+        },
+        {
           "name": "Upload build artifact",
           "uses": "actions/upload-artifact@v4",
           "with": {
-            "name": "build-artifact",
-            "path": "scripts/build/lv_icon_x64.lvlibp"
+            "name": "${{ steps.record.outputs.artifact }}",
+            "path": "scripts/build/${{ steps.record.outputs.artifact }}"
+          }
+        },
+        {
+          "name": "Upload artifact manifest",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "artifact-manifest",
+            "path": "scripts/build/artifact-manifest.json"
           }
         }
       ]

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -6,22 +6,40 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      MAJOR: '1'
+      MINOR: '0'
+      PATCH: '0'
     steps:
       - uses: actions/checkout@v4
       - name: Run build action
         uses: ./build/action.yml
         with:
           relative_path: 'scripts/build'
-          major: '1'
-          minor: '0'
-          patch: '0'
-          build: '1'
-          commit: 'abcdef'
+          major: ${{ env.MAJOR }}
+          minor: ${{ env.MINOR }}
+          patch: ${{ env.PATCH }}
+          build: ${{ github.run_number }}
+          commit: ${{ github.sha }}
           labview_minor_revision: '3'
           company_name: 'Acme Corp'
           author_name: 'Jane Doe'
+      - name: Record artifact metadata
+        id: record
+        run: |
+          VERSION="${MAJOR}.${MINOR}.${PATCH}.${GITHUB_RUN_NUMBER}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          ARTIFACT="lv_icon_x64_v${VERSION}+${SHORT_SHA}.lvlibp"
+          mv scripts/build/lv_icon_x64.lvlibp "scripts/build/${ARTIFACT}"
+          printf '{"commit":"%s","build_number":"%s","artifacts":["%s"]}' "$GITHUB_SHA" "$GITHUB_RUN_NUMBER" "$ARTIFACT" > scripts/build/artifact-manifest.json
+          echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact
-          path: 'scripts/build/lv_icon_x64.lvlibp'
+          name: ${{ steps.record.outputs.artifact }}
+          path: scripts/build/${{ steps.record.outputs.artifact }}
+      - name: Upload artifact manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-manifest
+          path: scripts/build/artifact-manifest.json

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -1,6 +1,9 @@
 # Full Build 🛠️
 
 Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
+Each build records provenance by renaming output artifacts to include the
+build number and commit SHA and by writing an `artifact-manifest.json` file that
+maps the generated artifacts back to the source commit.
 
 ## Inputs
 
@@ -25,7 +28,7 @@ Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
     major: 1
     minor: 0
     patch: 0
-    build: 1
+    build: ${{ github.run_number }}
     commit: ${{ github.sha }}
     company_name: Example Co
     author_name: CI

--- a/tests/pester/Build.Workflow.Tests.ps1
+++ b/tests/pester/Build.Workflow.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Build.Workflow' {
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'build'
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build/action.yml' } | Select-Object -First 1
-        $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'lv_icon_x64\.lvlibp' } | Select-Object -First 1
+        $artifactStep = $job.steps | Where-Object { $_.name -eq 'Upload build artifact' } | Select-Object -First 1
         $checkoutSteps = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/checkout@v4' }
         $externalCheckout = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with'].ContainsKey('repository') }
 
@@ -24,17 +24,24 @@ Describe 'Build.Workflow' {
         $externalCheckout | Should -BeNullOrEmpty
 
         $buildStep.with.relative_path | Should -Be 'scripts/build'
-        $buildStep.with.major | Should -Be '1'
-        $buildStep.with.minor | Should -Be '0'
-        $buildStep.with.patch | Should -Be '0'
-        $buildStep.with.build | Should -Be '1'
-        $buildStep.with.commit | Should -Be 'abcdef'
+        $buildStep.with.major | Should -Be '${{ env.MAJOR }}'
+        $buildStep.with.minor | Should -Be '${{ env.MINOR }}'
+        $buildStep.with.patch | Should -Be '${{ env.PATCH }}'
+        $buildStep.with.build | Should -Be '${{ github.run_number }}'
+        $buildStep.with.commit | Should -Be '${{ github.sha }}'
         $buildStep.with.labview_minor_revision | Should -Be '3'
         $buildStep.with.company_name | Should -Be 'Acme Corp'
         $buildStep.with.author_name | Should -Be 'Jane Doe'
 
+        $artifactMeta = $job.steps | Where-Object { $_.name -eq 'Record artifact metadata' } | Select-Object -First 1
+        $manifestStep = $job.steps | Where-Object { $_.name -eq 'Upload artifact manifest' } | Select-Object -First 1
+
+        $artifactMeta | Should -Not -BeNullOrEmpty
         $artifactStep | Should -Not -BeNullOrEmpty
-        $artifactStep.with.path | Should -Be 'scripts/build/lv_icon_x64.lvlibp'
-        $artifactStep.with.name | Should -Be 'build-artifact'
+        $artifactStep.with.path | Should -Be 'scripts/build/${{ steps.record.outputs.artifact }}'
+        $artifactStep.with.name | Should -Be '${{ steps.record.outputs.artifact }}'
+        $manifestStep | Should -Not -BeNullOrEmpty
+        $manifestStep.with.path | Should -Be 'scripts/build/artifact-manifest.json'
+        $manifestStep.with.name | Should -Be 'artifact-manifest'
     }
 }


### PR DESCRIPTION
## Summary
- include commit and build number in build artifact filenames
- generate artifact-manifest.json tying artifacts to commit
- document provenance tracking and update tests

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a49bedb8c48329803fb38994d53e4d