### PR TITLE
chore: require requirement references in commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+- 
+
+## Requirement(s)
+- REQ-
+
+## Testing
+- [ ] `npm test`

--- a/.github/workflows/requirement-id-check.yml
+++ b/.github/workflows/requirement-id-check.yml
@@ -1,0 +1,15 @@
+name: requirement-id-check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  requirement-id:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ensure commits reference requirement IDs
+        run: scripts/check-commit-requirements.sh "${{ github.event.pull_request.base.sha }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,7 @@ For documentation updates, follow the [documentation contribution guidelines](do
 npm run lint:md
 npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')
 ```
+
+## Commit Messages
+
+Each commit should reference at least one requirement ID defined in `requirements.json` (for example, `REQ-001`). Pull requests are automatically checked for this convention.

--- a/scripts/check-commit-requirements.sh
+++ b/scripts/check-commit-requirements.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_sha="${1:-origin/main}"
+
+if [ ! -f requirements.json ]; then
+  echo "requirements.json not found" >&2
+  exit 1
+fi
+
+pattern=$(jq -r '.requirements[].id' requirements.json | paste -sd'|' -)
+
+missing=0
+while read -r subject; do
+  if ! grep -Eq "($pattern)" <<<"$subject"; then
+    echo "Commit message missing requirement ID: $subject"
+    missing=1
+  fi
+done < <(git log --format=%s "$base_sha"..HEAD)
+
+if [ "$missing" -ne 0 ]; then
+  echo "One or more commits are missing requirement IDs." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add commit-message checker to ensure requirement IDs are referenced
- document commit message requirement and add PR template

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4a19f3ffc832987e8806a230bbe22