### PR TITLE
feat: add requirement coverage tagging

### DIFF
--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -43,6 +43,10 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
     working_directory: '.'
 ```
 
+## Outputs
+
+Running the action writes a `requirement-coverage.json` file to the working directory. The file lists each requirement ID discovered from test tags and whether its associated tests passed (`PASS`), failed (`FAIL`), or were not executed (`NOT_RUN`).
+
 ## Return Codes
 
 - `0` – all tests passed

--- a/docs/workflows/run-pester-tests.md
+++ b/docs/workflows/run-pester-tests.md
@@ -46,4 +46,6 @@ jobs:
       - name: Run run-pester-tests
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory "${{ github.workspace }}/target"
+
+After the workflow completes, the target repository will contain a `requirement-coverage.json` file summarizing requirement pass/fail status from the test run.
 ```

--- a/scripts/run-pester-tests/README.md
+++ b/scripts/run-pester-tests/README.md
@@ -17,6 +17,10 @@ For full documentation, see [run-pester-tests action](../../docs/actions/run-pes
     working_directory: '.'
 ```
 
+## Outputs
+
+Upon completion a `requirement-coverage.json` file is written to the specified `working_directory`. It reports the pass/fail status of each requirement ID inferred from test tags.
+
 See also: [docs/actions/run-pester-tests.md](../../docs/actions/run-pester-tests.md)
 
 ## License

--- a/scripts/run-pester-tests/RunPesterTests.ps1
+++ b/scripts/run-pester-tests/RunPesterTests.ps1
@@ -20,18 +20,37 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-
-$testPath = Join-Path $WorkingDirectory 'tests/pester'
+$testPath = Join-Path (Resolve-Path $WorkingDirectory) 'tests/pester'
+Push-Location $WorkingDirectory
 $cfg = New-PesterConfiguration
-$cfg.Output.NoColor = $true
+if ($cfg.Output.PSObject.Properties.Name -contains 'NoColor') {
+    $cfg.Output.NoColor = $true
+}
 $cfg.Run.Path = $testPath
 $cfg.TestResult.Enabled = $false
-$ansiPattern = '\x1B\[[0-9;]*[A-Za-z]'
 
-$output = & {
-    Invoke-Pester -Configuration $cfg 2>&1
-}
+$run = Invoke-Pester -Configuration $cfg
 $exitCode = $LASTEXITCODE
-$output | ForEach-Object { $_ -replace $ansiPattern, '' }
+
+$coverage = @{}
+foreach ($test in $run.TestResult) {
+    foreach ($tag in $test.Tags) {
+        if (-not $coverage.ContainsKey($tag)) { $coverage[$tag] = 'PASS' }
+        if ($test.Result -ne 'Passed') { $coverage[$tag] = 'FAIL' }
+    }
+}
+
+$requirementsPath = Join-Path $WorkingDirectory 'requirements.json'
+if (Test-Path $requirementsPath) {
+    $requirements = (Get-Content $requirementsPath | ConvertFrom-Json).requirements
+    $report = foreach ($req in $requirements) {
+        $status = if ($coverage.ContainsKey($req.id)) { $coverage[$req.id] } else { 'NOT_RUN' }
+        [pscustomobject]@{ id = $req.id; status = $status }
+    }
+    $reportPath = Join-Path $WorkingDirectory 'requirement-coverage.json'
+    $report | ConvertTo-Json -Depth 5 | Set-Content -Path $reportPath
+}
+
+Pop-Location
 exit $exitCode
 

--- a/tests/pester/PathRestoration.Actions.Tests.ps1
+++ b/tests/pester/PathRestoration.Actions.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Adapters restore PATH' {
         @{ Func='Invoke-SetDevelopmentMode'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','set-development-mode','Set_Development_Mode.ps1'); Arguments=@{ RelativePath='.' } }
     )
 
-    It "restores PATH after <Func>" -TestCases $cases {
+    It "restores PATH after <Func>" -Tag 'REQ-000' -TestCases $cases {
         param($Func, $Script, $Arguments)
         $originalPath = $env:PATH
         $params = $Arguments


### PR DESCRIPTION
## Summary
- tag path restoration test with its requirement
- generate requirement coverage report during Pester runs
- document requirement coverage output for run-pester-tests action

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Invoke-Pester -Path ./tests/pester'`

------
https://chatgpt.com/codex/tasks/task_e_68a4a473dd0c8329b53e8410bbc28e94