### PR TITLE
feat: generate traceability matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,4 +133,11 @@ jobs:
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: artifacts/evidence
+      - run: npx tsx scripts/generate-traceability-matrix.ts
+      - run: cat artifacts/linux/traceability-matrix.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          name: traceability-matrix
+          path: artifacts/linux/traceability-matrix.md
       - run: npx tsx scripts/print-pester-traceability.ts >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:ci": "mkdir -p test-results && tsx --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml",
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",
     "generate:summary": "tsx scripts/generate-ci-summary.ts",
+    "generate:traceability-matrix": "tsx scripts/generate-traceability-matrix.ts",
     "postinstall": "patch-package",
     "lint:md": "markdownlint-cli2 README.md \"docs/**/*.md\" \"scripts/**/*.md\"",
     "link:check": "markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')"

--- a/scripts/generate-traceability-matrix.ts
+++ b/scripts/generate-traceability-matrix.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env tsx
+import fs from 'fs/promises';
+import path from 'path';
+import { execSync } from 'child_process';
+import { RequirementGroup } from './summary/index.ts';
+import { buildTable } from './utils/markdown.ts';
+
+async function main() {
+  const traceabilityPath = process.argv[2] || path.join('artifacts', 'linux', 'traceability.json');
+  const raw = await fs.readFile(traceabilityPath, 'utf8');
+  const data: { requirements: RequirementGroup[] } = JSON.parse(raw);
+  const groups = data.requirements;
+
+  const logOutput = execSync('git log --pretty=format:%H\\|%s', { encoding: 'utf8' });
+  const commitMap: Record<string, { sha: string; msg: string }[]> = {};
+  const regex = /(REQ[A-Z]*-\d+)/g;
+  for (const line of logOutput.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const [sha, message] = line.split('|');
+    const matches = message.match(regex);
+    if (!matches) continue;
+    for (const req of matches) {
+      if (!commitMap[req]) commitMap[req] = [];
+      commitMap[req].push({ sha, msg: message });
+    }
+  }
+
+  const baseUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+    ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
+    : undefined;
+
+  const header = ['Requirement', 'Description', 'Commits', 'Tests'];
+  const rows: string[][] = [];
+  for (const g of groups) {
+    const commits = (commitMap[g.id] || [])
+      .map(c => baseUrl ? `[${c.sha.slice(0,7)}](${baseUrl}/commit/${c.sha})` : c.sha.slice(0,7))
+      .join('<br>');
+    const tests = g.tests.map(t => `${t.id} (${t.status})`).join('<br>');
+    rows.push([g.id, g.description ?? '', commits, tests]);
+  }
+  const markdown = `### Requirement Traceability Matrix\n\n${buildTable(header, rows)}\n`;
+  const outDir = path.dirname(traceabilityPath);
+  await fs.writeFile(path.join(outDir, 'traceability-matrix.md'), markdown);
+  console.log(markdown);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to build requirement-to-commit traceability matrix
- wire traceability matrix generation into CI workflow and publish artifact

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0c263d48329a1c1efa05886663c