### PR TITLE
docs: clarify traceability expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ npm run lint:md
 npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')
 ```
 
+## Requirement Traceability
+
+Each requirement is tracked as an issue or entry in `requirements.json`. Every
+code change must reference the requirement it addresses, and each requirement
+must be covered by at least one automated test. The CI pipeline checks these
+links and reports missing associations.
+
 ## Commit Messages
 
 Each commit should reference at least one requirement ID defined in `requirements.json` (for example, `REQ-001`). Pull requests are automatically checked for this convention.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ Invoke-Pester -Configuration $cfg
 
 XML test result output is intentionally disabled.
 
+## Requirement Traceability
+
+Each requirement is tracked as an issue or entry in
+[`requirements.json`](requirements.json). Every code change must reference the
+requirement it addresses, and each requirement must have at least one automated
+test. The CI pipeline checks these links and reports missing associations. For a
+full mapping of requirements to tests, see
+[docs/requirements.md](docs/requirements.md).
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules.


### PR DESCRIPTION
## Summary
- Document requirement traceability expectations in README
- Add traceability guidance for contributors

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5223a7c832987cc96453e07029e