### PR TITLE
feat: add traceability quality gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",
     "generate:summary": "tsx scripts/generate-ci-summary.ts",
     "generate:traceability-matrix": "tsx scripts/generate-traceability-matrix.ts",
+    "check:traceability": "tsx scripts/check-traceability.ts",
     "postinstall": "patch-package",
     "lint:md": "markdownlint-cli2 README.md \"docs/**/*.md\" \"scripts/**/*.md\"",
     "link:check": "markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')"

--- a/scripts/__tests__/check-traceability.test.js
+++ b/scripts/__tests__/check-traceability.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+const script = path.resolve('scripts/check-traceability.ts');
+const tsx = path.resolve('node_modules/.bin/tsx');
+
+async function initRepo(dir, msg) {
+  await execFileP('git', ['init', '-b', 'main'], { cwd: dir });
+  await fs.writeFile(path.join(dir, 'file.txt'), 'a');
+  await execFileP('git', ['add', '.'], { cwd: dir });
+  await execFileP('git', ['commit', '-m', msg], { cwd: dir });
+}
+
+test('fails when requirement lacks test coverage', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-'));
+  const req = { requirements: [{ id: 'REQ-1', tests: ['t1'] }] };
+  await fs.writeFile(path.join(dir, 'requirements.json'), JSON.stringify(req));
+  const trace = { requirements: [{ id: 'REQ-1', tests: [] }] };
+  await fs.writeFile(path.join(dir, 'trace.json'), JSON.stringify(trace));
+  await initRepo(dir, 'initial REQ-1');
+  await assert.rejects(
+    execFileP(tsx, [script], {
+      cwd: dir,
+      env: { ...process.env, REQ_MAPPING_FILE: 'requirements.json', TRACEABILITY_FILE: 'trace.json' },
+    }),
+    /No tests executed/
+  );
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('fails when commit lacks requirement reference', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-'));
+  const req = { requirements: [{ id: 'REQ-1', tests: ['t1'] }] };
+  await fs.writeFile(path.join(dir, 'requirements.json'), JSON.stringify(req));
+  const trace = { requirements: [{ id: 'REQ-1', tests: [{ id: 't1', status: 'Passed' }] }] };
+  await fs.writeFile(path.join(dir, 'trace.json'), JSON.stringify(trace));
+  await initRepo(dir, 'initial commit');
+  await assert.rejects(
+    execFileP(tsx, [script], {
+      cwd: dir,
+      env: { ...process.env, REQ_MAPPING_FILE: 'requirements.json', TRACEABILITY_FILE: 'trace.json', PR_BODY: '' },
+    }),
+    /No requirement references/
+  );
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('passes with coverage and requirement reference', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-'));
+  const req = { requirements: [{ id: 'REQ-1', tests: ['t1'] }] };
+  await fs.writeFile(path.join(dir, 'requirements.json'), JSON.stringify(req));
+  const trace = { requirements: [{ id: 'REQ-1', tests: [{ id: 't1', status: 'Passed' }] }] };
+  await fs.writeFile(path.join(dir, 'trace.json'), JSON.stringify(trace));
+  await initRepo(dir, 'initial REQ-1');
+  await execFileP(tsx, [script], {
+    cwd: dir,
+    env: { ...process.env, REQ_MAPPING_FILE: 'requirements.json', TRACEABILITY_FILE: 'trace.json' },
+  });
+  await fs.rm(dir, { recursive: true, force: true });
+});

--- a/scripts/check-traceability.ts
+++ b/scripts/check-traceability.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env tsx
+import fs from 'fs/promises';
+import path from 'path';
+import { execSync } from 'child_process';
+
+async function main() {
+  const reqFile = process.env.REQ_MAPPING_FILE || 'requirements.json';
+  const traceFile =
+    process.env.TRACEABILITY_FILE ||
+    path.join('artifacts', (process.env.RUNNER_OS || 'linux').toLowerCase(), 'traceability.json');
+
+  const reqRaw = JSON.parse(await fs.readFile(reqFile, 'utf8'));
+  const reqIds: string[] = (reqRaw.requirements || []).map((r: any) => r.id);
+
+  const traceRaw = JSON.parse(await fs.readFile(traceFile, 'utf8'));
+  const groups: any[] = traceRaw.requirements || [];
+
+  const missing: string[] = [];
+  for (const id of reqIds) {
+    const g = groups.find((gr) => gr.id === id);
+    if (!g || !Array.isArray(g.tests) || g.tests.length === 0) {
+      missing.push(id);
+    }
+  }
+  if (missing.length > 0) {
+    console.error(`No tests executed for requirements: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  const commitMsg = execSync('git log -1 --pretty=%B', { encoding: 'utf8' });
+  const prBody = process.env.PR_BODY || process.env.GITHUB_PR_BODY || '';
+  const combined = commitMsg + '\n' + prBody;
+  if (!/(REQ[A-Z]*-\d+)/.test(combined)) {
+    console.error('No requirement references found in commit message or PR body.');
+    process.exit(1);
+  }
+
+  console.log('Traceability checks passed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to verify requirements coverage and commit references
- test quality gate behaviour

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a4b8bee2208329b29d7857d7a21c56