### PR TITLE
ci: publish junit reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
+          name: test-results
+          path: test-results
+      - uses: actions/upload-artifact@v4
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
           name: traceability
           path: ${{ env.ARTIFACT_DIR }}/traceability.*
       - uses: actions/upload-artifact@v4
@@ -105,8 +110,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: pester-junit-${{ matrix.os }}-${{ matrix.runner_type }}
-          path: pester-results/pester-junit.xml
+          name: test-results-pester-${{ matrix.os }}-${{ matrix.runner_type }}
+          path: pester-results
           if-no-files-found: error
 
   report:
@@ -128,8 +133,7 @@ jobs:
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
-            artifacts/test-results/**/*junit*.xml
-            artifacts/pester-junit-*/pester-junit.xml
+            artifacts/test-results*/**/*junit*.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: artifacts/evidence


### PR DESCRIPTION
## Summary
- upload node and pester JUnit outputs as test-results artifacts
- collect all test result artifacts in summary job

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4bccfd85083298249a856dcdd7b7c