### PR TITLE
Preserve and upload LabVIEW unit test reports

### DIFF
--- a/.github/workflows/run-unit-tests-self-hosted.json
+++ b/.github/workflows/run-unit-tests-self-hosted.json
@@ -22,11 +22,20 @@
           }
         },
         {
+          "name": "Upload test results to GitHub",
+          "uses": "actions/upload-test-results@v1",
+          "if": "${{ (success() || failure()) && !cancelled() }}",
+          "with": {
+            "files": "artifacts/unit-tests/UnitTestReport.xml",
+            "reporter": "junit"
+          }
+        },
+        {
           "name": "Upload unit test results",
           "uses": "actions/upload-artifact@v4",
           "with": {
             "name": "unit-test-results",
-            "path": "scripts/run-unit-tests/UnitTestReport.xml"
+            "path": "artifacts/unit-tests/UnitTestReport.xml"
           }
         }
       ]

--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -16,8 +16,14 @@ jobs:
           project_path: 'scripts/run-unit-tests/lv_icon.lvproj'
           test_config: 'scripts/run-unit-tests/unittest-config.cfg'
           working_directory: 'scripts/run-unit-tests'
+      - name: Upload test results to GitHub
+        uses: actions/upload-test-results@v1
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          files: 'artifacts/unit-tests/UnitTestReport.xml'
+          reporter: junit
       - name: Upload unit test results
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-results
-          path: 'scripts/run-unit-tests/UnitTestReport.xml'
+          path: 'artifacts/unit-tests/UnitTestReport.xml'

--- a/scripts/run-unit-tests/README.md
+++ b/scripts/run-unit-tests/README.md
@@ -1,7 +1,7 @@
 # Run Unit Tests ✅
 
 Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result table.
-Reports are deleted when all tests pass; set `keep_report` to retain them.
+The script copies `UnitTestReport.xml` to `artifacts/unit-tests/UnitTestReport.xml` for later use.
 
 ## Inputs
 
@@ -9,7 +9,6 @@ Reports are deleted when all tests pass; set `keep_report` to retain them.
 |------|----------|---------|-------------|
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
-| `keep_report` | No | `true` | Skip cleanup so `UnitTestReport.xml` remains on disk. |
 
 ## Quick-start
 
@@ -18,7 +17,6 @@ Reports are deleted when all tests pass; set `keep_report` to retain them.
   with:
     minimum_supported_lv_version: 2024
     supported_bitness: 64
-    # keep_report: true
 ```
 
 See also: [docs/actions/run-unit-tests.md](../../docs/actions/run-unit-tests.md)

--- a/scripts/run-unit-tests/RunUnitTests.ps1
+++ b/scripts/run-unit-tests/RunUnitTests.ps1
@@ -16,9 +16,6 @@
 .PARAMETER SupportedBitness
     Bitness for LabVIEW (e.g., "64").
 
-.PARAMETER KeepReport
-    Skip cleanup so the UnitTestReport.xml remains on disk.
-
 .NOTES
     PowerShell 7.5+ assumed for cross-platform support.
     This script *requires* that g-cli and LabVIEW be compatible with the OS.
@@ -32,10 +29,7 @@ param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("32","64")]
     [string]
-    $SupportedBitness,
-
-    [switch]
-    $KeepReport
+    $SupportedBitness
 )
 
 # --------------------------------------------------------------------
@@ -232,27 +226,22 @@ function MainSequence {
 # --------------------------  CLEANUP  --------------------------
 function Cleanup {
     Write-Host "`n=== Cleanup ==="
-    # If everything passed (and g-cli was OK), delete the report
-    if (($script:OriginalExitCode -eq 0) -and (-not $script:TestsHadFailures)) {
-        try {
-            Remove-Item $ReportPath -Force -ErrorAction Stop
-            Write-Host "`nAll tests passed. Deleted UnitTestReport.xml."
-        }
-        catch {
-            Write-Warning "Failed to delete $($ReportPath): $($_.Exception.Message)"
-        }
+    try {
+        $artifactDir = Join-Path -Path (Join-Path $PSScriptRoot '..' '..') -ChildPath 'artifacts/unit-tests'
+        New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
+        $dest = Join-Path -Path $artifactDir -ChildPath 'UnitTestReport.xml'
+        Copy-Item -Path $ReportPath -Destination $dest -Force
+        Write-Host "Copied UnitTestReport.xml to $dest."
+    }
+    catch {
+        Write-Warning "Failed to copy UnitTestReport.xml: $($_.Exception.Message)"
     }
 }
 
 # -------------------  EXECUTION FLOW  -------------------
 Setup
 MainSequence
-if (-not $KeepReport) {
-    Cleanup
-}
-else {
-    Write-Host "`nSkipping Cleanup; retaining UnitTestReport.xml."
-}
+Cleanup
 
 # -------------------  FINAL EXIT CODE  ------------------
 if ($Script:OriginalExitCode -ne 0) {

--- a/tests/pester/RunUnitTests.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.Workflow.Tests.ps1
@@ -16,6 +16,7 @@ Describe 'RunUnitTests.Workflow' {
         $job = $wf.jobs.'run-unit-tests'
         $testStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './run-unit-tests/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'UnitTestReport\.xml' } | Select-Object -First 1
+        $summaryStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-test-results@v1' } | Select-Object -First 1
         $checkoutSteps = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq 'actions/checkout@v4' }
         $externalCheckout = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with'].ContainsKey('repository') }
 
@@ -31,6 +32,10 @@ Describe 'RunUnitTests.Workflow' {
 
         $artifactStep | Should -Not -BeNullOrEmpty
         $artifactStep.with.name | Should -Be 'unit-test-results'
-        $artifactStep.with.path | Should -Be 'scripts/run-unit-tests/UnitTestReport.xml'
+        $artifactStep.with.path | Should -Be 'artifacts/unit-tests/UnitTestReport.xml'
+
+        $summaryStep | Should -Not -BeNullOrEmpty
+        $summaryStep.with.files | Should -Be 'artifacts/unit-tests/UnitTestReport.xml'
+        $summaryStep.with.reporter | Should -Be 'junit'
     }
 }


### PR DESCRIPTION
## Summary
- keep LabVIEW UnitTestReport.xml and copy it to `artifacts/unit-tests/`
- upload unit test report to GitHub test summaries and as an artifact
- document new report handling and update tests

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4c122b95483299c45f1667bab9522