### PR TITLE
chore: append requirement tags to Pester test names

### DIFF
--- a/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'AddTokenToLabview.Workflow' {
         Evidence    = 'tests/pester/AddTokenToLabview.Workflow.Tests.ps1'
     }
 
-    It 'runs add-token-to-labview action and uploads token artifact' -Tag 'REQ-008' {
+    It 'runs add-token-to-labview action and uploads token artifact [REQ-008]' -Tag 'REQ-008' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/add-token-to-labview-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/ApplyVipc.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'ApplyVipc.DryRunTrue.Workflow' {
         Evidence    = 'tests/pester/ApplyVipc.Workflow.Tests.ps1'
     }
 
-    It 'runs apply-vipc action with dry_run true' -Tag 'REQ-006' {
+    It 'runs apply-vipc action with dry_run true [REQ-006]' -Tag 'REQ-006' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/Build.Workflow.Tests.ps1
+++ b/tests/pester/Build.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Build.Workflow' {
         Evidence    = 'tests/pester/Build.Workflow.Tests.ps1'
     }
 
-    It 'runs build action with required inputs' -Tag 'REQ-009' {
+    It 'runs build action with required inputs [REQ-009]' -Tag 'REQ-009' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/BuildLvlibp.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'BuildLvlibp.Workflow' {
         Evidence    = 'tests/pester/BuildLvlibp.Workflow.Tests.ps1'
     }
 
-    It 'runs build-lvlibp action and uploads lvlibp artifact' -Tag 'REQ-010' {
+    It 'runs build-lvlibp action and uploads lvlibp artifact [REQ-010]' -Tag 'REQ-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/BuildViPackage.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'BuildViPackage.Workflow' {
         Evidence    = 'tests/pester/BuildViPackage.Workflow.Tests.ps1'
     }
 
-    It 'runs build-vi-package action and uploads vi package artifact' -Tag 'REQ-011' {
+    It 'runs build-vi-package action and uploads vi package artifact [REQ-011]' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.json'
         if (-not (Test-Path $workflowPath)) {

--- a/tests/pester/CloseLabview.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'CloseLabview.Workflow' {
         Evidence    = 'tests/pester/CloseLabview.Workflow.Tests.ps1'
     }
 
-    It 'runs close-labview action for 32-bit and 64-bit and uploads logs' -Tag 'REQ-012' {
+    It 'runs close-labview action for 32-bit and 64-bit and uploads logs [REQ-012]' -Tag 'REQ-012' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfFile = Join-Path $repoRoot '.github/workflows/close-labview-external.json'
 

--- a/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
+++ b/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Dispatcher Args Inputs' {
         Evidence    = 'tests/pester/Dispatcher.ArgsInputs.Tests.ps1'
     }
 
-    It 'accepts ArgsJson and warns on unknown parameters' -Tag 'REQ-000' {
+    It 'accepts ArgsJson and warns on unknown parameters [REQ-000]' -Tag 'REQ-000' {
         $params = Get-LabVIEWIconEditorArgsJson
         $projectRoot = $params.WorkingDirectory
 
@@ -32,7 +32,7 @@ Describe 'Dispatcher Args Inputs' {
         $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
     }
 
-    It 'accepts ArgsFile and warns on unknown parameters' -Tag 'REQ-000' {
+    It 'accepts ArgsFile and warns on unknown parameters [REQ-000]' -Tag 'REQ-000' {
         $params = Get-LabVIEWIconEditorArgsJson
         $projectRoot = $params.WorkingDirectory
 
@@ -46,7 +46,7 @@ Describe 'Dispatcher Args Inputs' {
         $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
     }
 
-    It 'uses inline args to override file and warns on all unknown parameters' -Tag 'REQ-000' {
+    It 'uses inline args to override file and warns on all unknown parameters [REQ-000]' -Tag 'REQ-000' {
         $params = Get-LabVIEWIconEditorArgsJson
         $projectRoot = $params.WorkingDirectory
 

--- a/tests/pester/Dispatcher.FailOnUnknown.Tests.ps1
+++ b/tests/pester/Dispatcher.FailOnUnknown.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Dispatcher FailOnUnknown' {
         Evidence    = 'tests/pester/Dispatcher.FailOnUnknown.Tests.ps1'
     }
 
-    It 'warns on unknown parameters by default' -Tag 'REQ-000' {
+    It 'warns on unknown parameters by default [REQ-000]' -Tag 'REQ-000' {
         $params = Get-LabVIEWIconEditorArgsJson
         $json = @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '64'; Extra = 'value' } | ConvertTo-Json -Compress
         $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $params.WorkingDirectory -DryRun *>&1 | Out-String
@@ -24,7 +24,7 @@ Describe 'Dispatcher FailOnUnknown' {
         $out | Should -Match "Ignored unknown parameters for 'close-labview': Extra"
     }
 
-    It 'throws on unknown parameters when FailOnUnknown is set' -Tag 'REQ-000' {
+    It 'throws on unknown parameters when FailOnUnknown is set [REQ-000]' -Tag 'REQ-000' {
         $params = Get-LabVIEWIconEditorArgsJson
         $json = @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '64'; Extra = 'value' } | ConvertTo-Json -Compress
         { & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $params.WorkingDirectory -DryRun -FailOnUnknown } | Should -Throw "Ignored unknown parameters for 'close-labview': Extra"

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -20,14 +20,14 @@ Describe 'Invalid RelativePath handling' {
         Evidence    = 'tests/pester/Dispatcher.InvalidPaths.Tests.ps1'
     }
 
-    It 'fails when RelativePath does not exist' -Tag 'REQ-005' {
+    It 'fails when RelativePath does not exist [REQ-005]' -Tag 'REQ-005' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json -WorkingDirectory $projectRoot *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match $errorText
     }
 
-    It 'fails when RelativePath is missing' -Tag 'REQ-005' {
+    It 'fails when RelativePath is missing [REQ-005]' -Tag 'REQ-005' {
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' -WorkingDirectory $projectRoot *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'missing mandatory'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -21,7 +21,7 @@ $meta = @{
 }
 
 Describe 'Unified Dispatcher — discovery and validation' {
-  It 'lists available actions' -Tag 'REQ-001' {
+  It 'lists available actions [REQ-001]' -Tag 'REQ-001' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
@@ -31,7 +31,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
-  It 'registry includes all Invoke* adapters in module' -Tag 'REQ-001' {
+  It 'registry includes all Invoke* adapters in module [REQ-001]' -Tag 'REQ-001' {
     $modulePath = Join-Path (Split-Path $global:dispatcher -Parent) 'OpenSourceActions.psm1'
     $module = Import-Module $modulePath -PassThru
     $fnNames = (Get-Command -Module $module | Where-Object { $_.Name -like 'Invoke*' -and $_.Name -ne 'Invoke-OpenSourceActionScript' }).Name
@@ -49,7 +49,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
       $listed | Should -Match " - $action"
     }
   }
-  It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' {
+  It 'describes a known action (build-lvlibp) [REQ-001]' -Tag 'REQ-001' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
@@ -61,7 +61,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'Commit'
   }
 
-  It 'fails gracefully on unknown action' -Tag 'REQ-001' {
+  It 'fails gracefully on unknown action [REQ-001]' -Tag 'REQ-001' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
@@ -71,7 +71,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 }
 
 Describe 'ArgsJson path handling' {
-  It 'handles Windows paths without manual escaping' -Tag 'REQ-001' {
+  It 'handles Windows paths without manual escaping [REQ-001]' -Tag 'REQ-001' {
     $params = Get-LabVIEWIconEditorArgsJson
     $json = $params.ArgsJson
     $projectRoot = $params.WorkingDirectory
@@ -81,7 +81,7 @@ Describe 'ArgsJson path handling' {
 }
 
 Describe 'ArgsFile handling' {
-  It 'merges file arguments with inline overrides' -Tag 'REQ-001' {
+  It 'merges file arguments with inline overrides [REQ-001]' -Tag 'REQ-001' {
     $jsonFile = Join-Path $TestDrive 'args.json'
     @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
 
@@ -96,7 +96,7 @@ Describe 'ArgsFile handling' {
 
 
 Describe 'Filter-Args helper' {
-  It 'returns UnknownParams when requested' -Tag 'REQ-001' {
+  It 'returns UnknownParams when requested [REQ-001]' -Tag 'REQ-001' {
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($global:dispatcher, [ref]$null, [ref]$null)
     $funcAst = $ast.Find({ param($a) $a -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $a.Name -eq 'Filter-Args' }, $true)
     Invoke-Expression $funcAst.Extent.Text
@@ -113,7 +113,7 @@ Describe 'Filter-Args helper' {
 }
 
   Describe 'close-labview parameter aliases' {
-    It 'accepts camelCase args' -Tag 'REQ-001' {
+    It 'accepts camelCase args [REQ-001]' -Tag 'REQ-001' {
       $params = Get-LabVIEWIconEditorArgsJson
       $base = $params.ArgsJson | ConvertFrom-Json
       $projectRoot = $params.WorkingDirectory
@@ -125,7 +125,7 @@ Describe 'Filter-Args helper' {
       $LASTEXITCODE | Should -Be 0
     }
 
-    It 'accepts snake_case args without warnings' -Tag 'REQ-001' {
+    It 'accepts snake_case args without warnings [REQ-001]' -Tag 'REQ-001' {
       $params = Get-LabVIEWIconEditorArgsJson
       $base = $params.ArgsJson | ConvertFrom-Json
       $projectRoot = $params.WorkingDirectory

--- a/tests/pester/MissingInProject.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'MissingInProject.Workflow' {
         Evidence    = 'tests/pester/MissingInProject.Workflow.Tests.ps1'
     }
 
-    It 'runs missing-in-project action and uploads findings report' -Tag 'REQ-014' {
+    It 'runs missing-in-project action and uploads findings report [REQ-014]' -Tag 'REQ-014' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/missing-in-project-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'ModifyVipbDisplayInfo.Workflow' {
         Evidence    = 'tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1'
     }
 
-    It 'runs modify-vipb-display-info action and uploads VIPB artifact' -Tag 'REQ-015' {
+    It 'runs modify-vipb-display-info action and uploads VIPB artifact [REQ-015]' -Tag 'REQ-015' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/modify-vipb-display-info-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'PrepareLabviewSource.Workflow' {
         Evidence    = 'tests/pester/PrepareLabviewSource.Workflow.Tests.ps1'
     }
 
-    It 'runs prepare-labview-source action and uploads prepared source artifact' -Tag 'REQ-016' {
+    It 'runs prepare-labview-source action and uploads prepared source artifact [REQ-016]' -Tag 'REQ-016' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/prepare-labview-source-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -16,7 +16,7 @@ $meta = @{
 }
 
 Describe 'add-token-to-labview resolves RelativePath' {
-    It 'dry-runs without warnings' -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $obj = $params.ArgsJson | ConvertFrom-Json
         $obj.RelativePath = './'
@@ -32,7 +32,7 @@ Describe 'add-token-to-labview resolves RelativePath' {
 }
 
 Describe 'apply-vipc resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -47,7 +47,7 @@ Describe 'apply-vipc resolves RelativePath' {
 }
 
 Describe 'build-vi-package resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -62,7 +62,7 @@ Describe 'build-vi-package resolves RelativePath' {
 }
 
 Describe 'build resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -77,7 +77,7 @@ Describe 'build resolves RelativePath' {
 }
 
 Describe 'build-lvlibp resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -92,7 +92,7 @@ Describe 'build-lvlibp resolves RelativePath' {
 }
 
 Describe 'modify-vipb-display-info resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -107,7 +107,7 @@ Describe 'modify-vipb-display-info resolves RelativePath' {
 }
 
 Describe 'prepare-labview-source resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -122,7 +122,7 @@ Describe 'prepare-labview-source resolves RelativePath' {
 }
 
 Describe 'restore-setup-lv-source resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -137,7 +137,7 @@ Describe 'restore-setup-lv-source resolves RelativePath' {
 }
 
 Describe 'revert-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory
@@ -152,7 +152,7 @@ Describe 'revert-development-mode resolves RelativePath' {
 }
 
 Describe 'set-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' {
+    It 'dry-runs without warnings [REQ-003]' -Tag 'REQ-003' {
         $params = Get-LabVIEWIconEditorArgsJson
         $b = $params.ArgsJson | ConvertFrom-Json
         $projectRoot = $params.WorkingDirectory

--- a/tests/pester/RenameFile.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'RenameFile.Workflow' {
         Evidence    = 'tests/pester/RenameFile.Workflow.Tests.ps1'
     }
 
-    It 'runs rename-file action and uploads renamed file artifact' -Tag 'REQ-017' {
+    It 'runs rename-file action and uploads renamed file artifact [REQ-017]' -Tag 'REQ-017' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/rename-file-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'RestoreSetupLvSource.Workflow' {
         Evidence    = 'tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1'
     }
 
-    It 'runs restore-setup-lv-source action and uploads restoration artifacts' -Tag 'REQ-018' {
+    It 'runs restore-setup-lv-source action and uploads restoration artifacts [REQ-018]' -Tag 'REQ-018' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/restore-setup-lv-source-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'RevertDevelopmentMode.Workflow' {
         Evidence    = 'tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1'
     }
 
-    It 'runs revert-development-mode action and uploads configuration artifact' -Tag 'REQ-019' {
+    It 'runs revert-development-mode action and uploads configuration artifact [REQ-019]' -Tag 'REQ-019' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.json'

--- a/tests/pester/RunUnitTests.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'RunUnitTests.Workflow' {
         Evidence    = 'tests/pester/RunUnitTests.Workflow.Tests.ps1'
     }
 
-    It 'runs run-unit-tests action and uploads unit-test results' -Tag 'REQ-011' {
+    It 'runs run-unit-tests action and uploads unit-test results [REQ-011]' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Action script paths' {
         Evidence    = 'tests/pester/ScriptPath.Tests.ps1'
     }
 
-    It 'has script for <Name>' -Tag 'REQ-004' -TestCases $cases {
+    It 'has script for <Name> [REQ-004]' -Tag 'REQ-004' -TestCases $cases {
         param($Name, $Path)
         Test-Path $Path | Should -BeTrue
     }

--- a/tests/pester/SetDevelopmentMode.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.Workflow.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'SetDevelopmentMode.Workflow' {
         Evidence    = 'tests/pester/SetDevelopmentMode.Workflow.Tests.ps1'
     }
 
-    It 'runs set-development-mode action and uploads logs' -Tag 'REQ-021' {
+    It 'runs set-development-mode action and uploads logs [REQ-021]' -Tag 'REQ-021' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/set-development-mode-self-hosted.json'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable


### PR DESCRIPTION
## Summary
- include requirement IDs in Pester `It` descriptions for traceability

## Testing
- `node --version`
- `pwsh --version`
- `actionlint -version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $true; $cfg.TestResult.OutputPath = "junit.xml"; $cfg.TestResult.OutputFormat = "JUnitXml"; Invoke-Pester -Configuration $cfg'`
- `TEST_RESULTS_GLOB=junit.xml npx tsx scripts/generate-ci-summary.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3a0e8a8832984fc0a85a25ed7db