### PR TITLE
ci: publish junit results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
         with:
           path: ./artifacts
       - run: npm run derive:registry
+      - uses: actions/upload-artifact@v4
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          name: junit-results
+          path: artifacts/**/*junit*.xml
+      - uses: actions/upload-test-results@v1
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          junit-files: artifacts/**/*junit*.xml
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |


### PR DESCRIPTION
## Summary
- upload junit XML results to workflow artifacts and Test Reporting
- run generate-ci-summary after uploading results to keep traceability files in sync

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4c61fcee88329a4385a5d9704d024