### PR TITLE
Add spec reporter to CI test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prederive:registry": "npm run check:node",
     "pregenerate:summary": "npm run check:node",
     "test": "tsx --test scripts/**/*.test.js scripts/*.test.js",
-    "test:ci": "mkdir -p test-results && tsx --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml",
+    "test:ci": "mkdir -p test-results && tsx --test --test-reporter=spec --test-reporter=junit --test-reporter-destination test-results/node-junit.xml",
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",
     "generate:summary": "tsx scripts/generate-ci-summary.ts",
     "generate:traceability-matrix": "tsx scripts/generate-traceability-matrix.ts",


### PR DESCRIPTION
## Summary
- run CI tests with both spec and junit reporters

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a4cdc88fac8329855093b13086dc5f