### PR TITLE
chore: upload junit results in CI

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -47,6 +47,24 @@
           "run": "rm -rf artifacts"
         },
         {
+          "run": "mkdir -p artifacts && cp test-results/*junit*.xml artifacts/"
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "junit-results",
+            "path": "artifacts/**/*junit*.xml"
+          }
+        },
+        {
+          "uses": "actions/upload-test-results@v1",
+          "if": "always()",
+          "with": {
+            "junit-files": "artifacts/**/*junit*.xml"
+          }
+        },
+        {
           "run": "npm run generate:summary",
           "env": {
             "TEST_RESULTS_GLOBS": "test-results/*junit*.xml"
@@ -179,7 +197,7 @@
         {
           "run": "npm run generate:summary",
           "env": {
-            "TEST_RESULTS_GLOBS": "artifacts/test-results/**/*junit*.xml\nartifacts/pester-junit-*/pester-junit.xml\n",
+            "TEST_RESULTS_GLOBS": "artifacts/junit-results/artifacts/**/*junit*.xml\nartifacts/pester-junit-*/pester-junit.xml\n",
             "REQ_MAPPING_FILE": "requirements.json",
             "DISPATCHER_REGISTRY": "dispatchers.json",
             "EVIDENCE_DIR": "artifacts/evidence"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,19 @@ jobs:
       - run: npm run test:ci
       - run: npm run derive:registry
       - run: rm -rf artifacts
-      - run: npm run generate:summary
-        env:
-          TEST_RESULTS_GLOBS: test-results/*junit*.xml
+      - run: mkdir -p artifacts && cp test-results/*junit*.xml artifacts/
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          name: test-results
-          path: test-results
+          name: junit-results
+          path: artifacts/**/*junit*.xml
+      - uses: actions/upload-test-results@v1
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          junit-files: artifacts/**/*junit*.xml
+      - run: npm run generate:summary
+        env:
+          TEST_RESULTS_GLOBS: test-results/*junit*.xml
       - uses: actions/upload-artifact@v4
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
@@ -133,7 +138,8 @@ jobs:
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
-            artifacts/test-results*/**/*junit*.xml
+            artifacts/junit-results/artifacts/**/*junit*.xml
+            artifacts/pester-junit-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: artifacts/evidence


### PR DESCRIPTION
## Summary
- upload junit test results and publish to GitHub test reporting
- run traceability summary after uploading results
- adjust report job to collect new junit-results artifact

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a4c61fcee88329a4385a5d9704d024