### PR TITLE
chore: use publish unit test results action

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -58,10 +58,10 @@
           }
         },
         {
-          "uses": "actions/upload-test-results@v1",
+          "uses": "EnricoMi/publish-unit-test-result-action@v2",
           "if": "always()",
           "with": {
-            "junit-files": "artifacts/**/*junit*.xml"
+            "files": "artifacts/**/*junit*.xml"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           name: junit-results
           path: artifacts/**/*junit*.xml
-      - uses: actions/upload-test-results@v1
+      - uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
-          junit-files: artifacts/**/*junit*.xml
+          files: artifacts/**/*junit*.xml
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: test-results/*junit*.xml

--- a/.github/workflows/run-unit-tests-self-hosted.json
+++ b/.github/workflows/run-unit-tests-self-hosted.json
@@ -23,11 +23,10 @@
         },
         {
           "name": "Upload test results to GitHub",
-          "uses": "actions/upload-test-results@v1",
+          "uses": "EnricoMi/publish-unit-test-result-action@v2",
           "if": "${{ (success() || failure()) && !cancelled() }}",
           "with": {
-            "files": "artifacts/unit-tests/UnitTestReport.xml",
-            "reporter": "junit"
+            "files": "artifacts/unit-tests/UnitTestReport.xml"
           }
         },
         {

--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -17,11 +17,10 @@ jobs:
           test_config: 'scripts/run-unit-tests/unittest-config.cfg'
           working_directory: 'scripts/run-unit-tests'
       - name: Upload test results to GitHub
-        uses: actions/upload-test-results@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           files: 'artifacts/unit-tests/UnitTestReport.xml'
-          reporter: junit
       - name: Upload unit test results
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prederive:registry": "npm run check:node",
     "pregenerate:summary": "npm run check:node",
     "test": "tsx --test scripts/**/*.test.js scripts/*.test.js",
-    "test:ci": "mkdir -p test-results && tsx --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml",
+    "test:ci": "mkdir -p test-results && tsx --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml scripts/**/*.test.js scripts/*.test.js",
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",
     "generate:summary": "tsx scripts/generate-ci-summary.ts",
     "generate:traceability-matrix": "tsx scripts/generate-traceability-matrix.ts",

--- a/tests/pester/RunUnitTests.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.Workflow.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'RunUnitTests.Workflow' {
         $job = $wf.jobs.'run-unit-tests'
         $testStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './run-unit-tests/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'UnitTestReport\.xml' } | Select-Object -First 1
-        $summaryStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-test-results@v1' } | Select-Object -First 1
+        $publishStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'EnricoMi/publish-unit-test-result-action@v2' } | Select-Object -First 1
         $checkoutSteps = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq 'actions/checkout@v4' }
         $externalCheckout = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with'].ContainsKey('repository') }
 
@@ -34,8 +34,7 @@ Describe 'RunUnitTests.Workflow' {
         $artifactStep.with.name | Should -Be 'unit-test-results'
         $artifactStep.with.path | Should -Be 'artifacts/unit-tests/UnitTestReport.xml'
 
-        $summaryStep | Should -Not -BeNullOrEmpty
-        $summaryStep.with.files | Should -Be 'artifacts/unit-tests/UnitTestReport.xml'
-        $summaryStep.with.reporter | Should -Be 'junit'
+        $publishStep | Should -Not -BeNullOrEmpty
+        $publishStep.with.files | Should -Be 'artifacts/unit-tests/UnitTestReport.xml'
     }
 }


### PR DESCRIPTION
## Summary
- replace deprecated upload-test-results action with EnricoMi/publish-unit-test-result-action
- adjust workflows and tests for new `files` input

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Import-Module Pester; $cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5a20b4083298dfba6701584f2f9