### PR TITLE
chore: enforce strict link checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,6 @@
 - Run `npm install` to ensure Node dependencies are available.
 - Run `npm test`.
 - Run `npm run lint:md` to lint Markdown files.
-- Run `npx --yes linkinator README.md docs scripts --markdown --skip "https://open-source-actions.github.io/open-source-actions/" --skip "http://127.0.0.1:8000/" --skip "https://github.com/ni/g-cli" --skip "^docs$" --skip "^scripts$"` to verify links and ensure failures are visible.
+- Run `npx --yes linkinator README.md docs scripts --config linkinator.config.json` to verify links and ensure failures are visible.
 - Run `actionlint` to validate GitHub Actions workflows.
 - Run `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` and ensure all tests pass (XML output is intentionally disabled).

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,0 +1,14 @@
+{
+  "markdown": true,
+  "recurse": true,
+  "retry": true,
+  "retryErrors": true,
+  "verbosity": "error",
+  "skip": [
+    "https://open-source-actions.github.io/open-source-actions/",
+    "http://127.0.0.1:8000/",
+    "https://github.com/ni/g-cli",
+    "docs$",
+    "scripts$"
+  ]
+}


### PR DESCRIPTION
## Summary
- enforce strict link checks via linkinator config
- document strict link validator in AGENTS instructions

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration $cfg"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ecec7be483298199d2d3b829faf6