### PR TITLE
Fix documentation links and add directory READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ For documentation updates, follow the [documentation contribution guidelines](do
 
 ```bash
 npm run lint:md
-npx --yes linkinator README.md docs scripts --markdown --skip "https://open-source-actions.github.io/open-source-actions/" --skip "http://127.0.0.1:8000/" --skip "https://github.com/ni/g-cli" --skip "^docs$" --skip "^scripts$"
+npx --yes linkinator README.md docs scripts --config linkinator.config.json
 ```
 
 ## Requirement Traceability

--- a/actions/README.md
+++ b/actions/README.md
@@ -1,0 +1,3 @@
+# actions
+
+PowerShell dispatcher and modules backing the GitHub Action wrappers.

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -13,7 +13,7 @@ See [Common Parameters](common-parameters.md) for a complete list of dispatcher 
 
 ## Cross‑platform
 
-Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_json`.
+Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/G-CLI/G-CLI) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_json`.
 
 ## Example (CLI)
 

--- a/docs/actions/README.md
+++ b/docs/actions/README.md
@@ -1,0 +1,3 @@
+# Action Documentation
+
+Reference pages for each GitHub Action adapter live in this directory. Each file documents the inputs and behavior of the corresponding action.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ Each action lives in a `scripts/<action-name>` folder. These PowerShell scripts 
 
 ## Repository layout
 
-- [`actions/`](../actions/) – dispatcher scripts and PowerShell module
-- [`docs/`](.) – MkDocs documentation, including this page
-- [`scripts/`](../scripts/) – adapter scripts invoked by the dispatcher
-- [`tests/`](../tests/) – Pester tests and other verification scripts
-- [`tools/`](../tools/) – utilities for building or testing actions
+- [`actions/`](../actions/README.md) – dispatcher scripts and PowerShell module
+- [`docs/`](index.md) – MkDocs documentation, including this page
+- [`scripts/`](../scripts/README.md) – adapter scripts invoked by the dispatcher
+- [`tests/`](../tests/README.md) – Pester tests and other verification scripts
+- [`tools/`](../tools/README.md) – utilities for building or testing actions

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,14 +4,14 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-Action documentation lives under [docs/actions/](actions/). Keep these files in sync with their corresponding implementations in [scripts/](../scripts).
+Action documentation lives under [docs/actions](actions/README.md). Keep these files in sync with their corresponding implementations in [scripts](../scripts/README.md).
 
 - Run `npm run verify:docs` to check that documented inputs match each action's action.yml.
 
 ## Markdown linting
 
 - Run `npm run lint:md` to lint Markdown formatting.
-- Run `npx --yes linkinator README.md docs scripts --markdown --skip "https://open-source-actions.github.io/open-source-actions/" --skip "http://127.0.0.1:8000/" --skip "https://github.com/ni/g-cli" --skip "^docs$" --skip "^scripts$"` to check links before submitting changes.
+- Run `npx --yes linkinator README.md docs scripts --config linkinator.config.json` to check links before submitting changes.
 - Keep one `#`-level heading at the top of each file and increment heading levels sequentially; do not skip levels.
 
 ## Heading levels

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Open Source LabVIEW Actions
 
-Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Most users should call the adapter-specific GitHub Actions (for example `run-unit-tests`) directly in workflows. The dispatcher script ([actions/Invoke-OSAction.ps1](../actions/Invoke-OSAction.ps1)) remains available for CLI scenarios. Adapter implementations live under [scripts/](../scripts), and each wrapper resides in its own folder at the repository root. Discovery commands (`-ListActions` and `-Describe`) and standard exit codes are preserved, and `-DryRun` is supported for safe previews on Windows or Linux runners with LabVIEW and g-cli available.
+Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Most users should call the adapter-specific GitHub Actions (for example `run-unit-tests`) directly in workflows. The dispatcher script ([actions/Invoke-OSAction.ps1](../actions/Invoke-OSAction.ps1)) remains available for CLI scenarios. Adapter implementations live under [scripts](../scripts/README.md), and each wrapper resides in its own folder at the repository root. Discovery commands (`-ListActions` and `-Describe`) and standard exit codes are preserved, and `-DryRun` is supported for safe previews on Windows or Linux runners with LabVIEW and g-cli available.
 
 ## Get Started
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -4,6 +4,9 @@
   "retry": true,
   "retryErrors": true,
   "verbosity": "error",
+  "directoryListing": true,
   "skip": [
+    "https://open-source-actions.github.io/open-source-actions/",
+    "http://127.0.0.1:8000/"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate:traceability-matrix": "tsx scripts/generate-traceability-matrix.ts",
     "check:traceability": "tsx scripts/check-traceability.ts",
     "lint:md": "markdownlint-cli2 README.md \"docs/**/*.md\" \"scripts/**/*.md\"",
-    "link:check": "linkinator README.md docs scripts --markdown --skip \"https://open-source-actions.github.io/open-source-actions/\" --skip \"http://127\\.0\\.0\\.1:8000/\" --skip \"https://github.com/ni/g-cli\" --skip \"^docs$\" --skip \"^scripts$\""
+    "link:check": "linkinator README.md docs scripts --config linkinator.config.json"
   },
   "dependencies": {
     "adm-zip": "^0.5.10",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# scripts
+
+TypeScript and PowerShell helper scripts invoked by the GitHub Action wrappers.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# tests
+
+Node and Pester tests verifying the dispatcher and helper modules.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# tools
+
+Utilities for building or testing actions.


### PR DESCRIPTION
## Summary
- add README indexes for actions, scripts, tests and tools directories
- fix broken doc links and update linkinator config
- point g-cli references to working repository

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a4f4ae2aa083299f251cdbe5c58a5b