### PR TITLE
docs: de-duplicate icon editor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,42 +57,7 @@ Enable debug logging and perform a dry run:
     dry_run: true
   ```
 
-Build Icon Editor:
-
-Chain the [apply-vipc](docs/actions/apply-vipc.md), [set-development-mode](docs/actions/set-development-mode.md), [build](docs/actions/build.md), and [revert-development-mode](docs/actions/revert-development-mode.md) actions to build the LabVIEW Icon Editor:
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    repository: LabVIEW-Community-CI-CD/labview-icon-editor
-    path: labview-icon-editor
-- uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
-  with:
-    minimum_supported_lv_version: '2021'
-    vip_lv_version: '2021'
-    supported_bitness: '64'
-    relative_path: labview-icon-editor
-    vipc_path: labview-icon-editor/.github/actions/apply-vipc/runner_dependencies.vipc
-- uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
-  with:
-    minimum_supported_lv_version: '2021'
-    supported_bitness: '64'
-    relative_path: labview-icon-editor
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
-  with:
-    relative_path: labview-icon-editor
-    major: 1
-    minor: 0
-    patch: 0
-    build: 0
-    commit: abcdef
-    labview_minor_revision: '3'
-    company_name: 'Acme Corp'
-    author_name: 'Jane Doe'
-- uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
-  with:
-    relative_path: labview-icon-editor
-```
+For a full workflow example that chains multiple actions to build the LabVIEW Icon Editor, see [docs/quickstart.md#build-icon-editor](docs/quickstart.md#build-icon-editor).
 
 ## CLI/dispatcher usage
 


### PR DESCRIPTION
## Summary
- remove verbose Icon Editor build example from README to avoid duplication
- reference quickstart for detailed workflow steps

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68a4f4ae2aa083299f251cdbe5c58a5b