### PR TITLE
docs: clarify Pester tests run only in CI (REQIE-005)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,4 +33,4 @@
 - Run `npm run lint:md` to lint Markdown files.
 - Run `npx --yes linkinator README.md docs scripts --config linkinator.config.json` to verify links and ensure failures are visible.
 - Run `actionlint` to validate GitHub Actions workflows.
-- Run `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` and ensure all tests pass (XML output is intentionally disabled).
+- Pester tests are executed by the GitHub runner; do not run them locally.


### PR DESCRIPTION
## Summary
- clarify that Pester tests are executed by GitHub runner and shouldn't be run locally

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff1ac0bc8329b01a5f3d6e7cf3a8