### PR TITLE
Clarify CI handling of Pester tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,4 +33,7 @@
 - Run `npm run lint:md` to lint Markdown files.
 - Run `npx --yes linkinator README.md docs scripts --config linkinator.config.json` to verify links and ensure failures are visible.
 - Run `actionlint` to validate GitHub Actions workflows.
-- Pester tests are executed by the GitHub runner; do not run them locally.
+
+### Pester Tests
+
+Pester tests are part of the continuous integration pipeline. The GitHub runner executes them automatically, so agents must not run Pester tests manually.


### PR DESCRIPTION
## Summary
- Clarify that Pester tests run in CI and must not be executed manually

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a5007171888329a100c4c9ab2ad4d6