### PR TITLE
docs: clarify optional Pester install

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ npm test
 
 For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable. The summary script searches `artifacts/` by default; set `TEST_RESULTS_GLOBS` if your reports are elsewhere.
 
-Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
+Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. The GitHub runner installs Pester automatically; install it locally only if you plan to run the tests yourself:
 
 ```powershell
-Install-Module Pester -Force -Scope CurrentUser  # if Pester isn't already available
+Install-Module Pester -Force -Scope CurrentUser
 ```
 
 ```powershell

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -30,7 +30,7 @@ actionlint -version
 
 ## Pester
 
-[Pester](https://pester.dev/) runs the PowerShell test suite. Install it and confirm the module is available:
+[Pester](https://pester.dev/) runs the PowerShell test suite. The GitHub runner installs it automatically; install it only if you plan to run tests locally and confirm the module is available:
 
 ```powershell
 Install-Module Pester -Force -Scope CurrentUser

--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -18,19 +18,19 @@ export LABVIEW_ICON_EDITOR_PATH=/path/to/labview-icon-editor
 
 To enforce that the project exists, set `LABVIEW_ICON_EDITOR_REQUIRED=1` or call `Get-LabVIEWIconEditorArgsJson -RequireProject` in your test.
 
-Required tooling:
+Tooling for local runs:
 
 - PowerShell 7.5.1
 - Node.js 24 or newer
 - [`actionlint`](https://github.com/rhysd/actionlint)
-- [Pester](https://pester.dev/) (install with `Install-Module Pester -Force -Scope CurrentUser`)
+- Optional: [Pester](https://pester.dev/) (install with `Install-Module Pester -Force -Scope CurrentUser` for local runs; CI installs it automatically)
 
-Sample command sequence to run the suite:
+Sample command sequence to run the suite locally:
 
 ```powershell
 npm install
 actionlint
-Install-Module Pester -Force -Scope CurrentUser
+Install-Module Pester -Force -Scope CurrentUser  # only if Pester isn't already installed
 $cfg = New-PesterConfiguration
 $cfg.Run.Path = './tests/pester'
 $cfg.TestResult.Enabled = $false


### PR DESCRIPTION
## Summary
- clarify that Pester is only needed to run tests locally
- note CI runners provide Pester by default

## Testing
- `env PATH=/usr/bin:$PATH npm run check:node`
- `env PATH=/usr/bin:$PATH npm install`
- `env PATH=/usr/bin:$PATH npm test`
- `env PATH=/usr/bin:$PATH npm run lint:md`
- `env PATH=/usr/bin:$PATH npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `env PATH=$HOME/go/bin:/usr/bin:$PATH actionlint`
- `pwsh --version` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a504d255448329a70092fdfa5f2ddf