### PR TITLE
ci: pin Pester version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,9 @@ jobs:
         shell: pwsh
         run: |
           if (-not (Get-Module -ListAvailable -Name Pester |
-                    Where-Object { $_.Version -ge [Version]'5.0.0' })) {
+                    Where-Object { $_.Version -ge [Version]'5.7.1' })) {
             Remove-Module Pester -ErrorAction SilentlyContinue
-            Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
+            Install-Module -Name Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck
           }
       - name: Run Pester
         shell: pwsh


### PR DESCRIPTION
## Summary
- pin Pester module to version 5.7.1 in CI workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`

------
https://chatgpt.com/codex/tasks/task_e_68a506da4c4c83298d4d7e01238e8dca