### PR TITLE
chore: pin action versions to commits

### DIFF
--- a/.github/workflows/add-token-to-labview-self-hosted.yml
+++ b/.github/workflows/add-token-to-labview-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   add-token:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run add-token-to-labview action
         uses: ./add-token-to-labview/action.yml
         with:
@@ -15,7 +15,7 @@ jobs:
           supported_bitness: '64'
           relative_path: 'scripts/add-token-to-labview'
       - name: Upload token artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: token-artifact
           path: 'scripts/add-token-to-labview/LabVIEW.ini'

--- a/.github/workflows/apply-vipc-self-hosted.yml
+++ b/.github/workflows/apply-vipc-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   apply-vipc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run apply-vipc action (dry_run=true)
         uses: ./apply-vipc/action.yml
         with:

--- a/.github/workflows/build-lvlibp-self-hosted.yml
+++ b/.github/workflows/build-lvlibp-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   build-lvlibp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run build-lvlibp action
         uses: ./build-lvlibp/action.yml
         with:
@@ -22,7 +22,7 @@ jobs:
           build: '1'
           commit: 'abcdef'
       - name: Upload lvlibp artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: build-lvlibp-artifact
           path: 'scripts/build-lvlibp/lv_icon.lvlibp'

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -11,7 +11,7 @@ jobs:
       MINOR: '0'
       PATCH: '0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run build action
         uses: ./build/action.yml
         with:
@@ -34,12 +34,12 @@ jobs:
           printf '{"commit":"%s","build_number":"%s","artifacts":["%s"]}' "$GITHUB_SHA" "$GITHUB_RUN_NUMBER" "$ARTIFACT" > scripts/build/artifact-manifest.json
           echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ steps.record.outputs.artifact }}
           path: scripts/build/${{ steps.record.outputs.artifact }}
       - name: Upload artifact manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: artifact-manifest
           path: scripts/build/artifact-manifest.json

--- a/.github/workflows/build-vi-package-self-hosted.yml
+++ b/.github/workflows/build-vi-package-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   build-vi-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run build-vi-package action
         uses: ./build-vi-package/action.yml
         with:
@@ -23,7 +23,7 @@ jobs:
           commit: 'abcdef'
           display_information_json: '{"Name":"Test"}'
       - name: Upload VI package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: vi-package
           path: 'scripts/build-vi-package/lv_icon.vip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       # This job always runs on Linux, so the directory is fixed.
       ARTIFACT_DIR: artifacts/linux
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
       - run: npm run check:node
@@ -25,29 +25,29 @@ jobs:
       - run: npm run derive:registry
       - run: rm -rf artifacts
       - run: mkdir -p artifacts && cp test-results/*junit*.xml artifacts/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: junit-results
           path: artifacts/**/*junit*.xml
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@0f06977fde99088e583f6fa8ec622da326e818c3
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           files: artifacts/**/*junit*.xml
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: test-results/*junit*.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: traceability
           path: ${{ env.ARTIFACT_DIR }}/traceability.*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: action-docs
           path: ${{ env.ARTIFACT_DIR }}/action-docs.*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: evidence
@@ -71,7 +71,7 @@ jobs:
     env:
       RUNNER_TYPE: ${{ matrix.runner_type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Ensure PowerShell 7.5.1
         if: matrix.runner_type != 'linux'
         shell: pwsh
@@ -112,7 +112,7 @@ jobs:
             $cfg.Run.Exit = $true
             Invoke-Pester -Configuration $cfg
           }
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: test-results-pester-${{ matrix.os }}-${{ matrix.runner_type }}
@@ -124,14 +124,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ (success() || failure()) && !cancelled() }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
       - run: npm run check:node
       - run: npm install
       - run: rm -rf artifacts
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: ./artifacts
       - run: npm run derive:registry
@@ -145,7 +145,7 @@ jobs:
           EVIDENCE_DIR: artifacts/evidence
       - run: npx tsx scripts/generate-traceability-matrix.ts
       - run: cat artifacts/linux/traceability-matrix.md >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           name: traceability-matrix

--- a/.github/workflows/close-labview-external.yml
+++ b/.github/workflows/close-labview-external.yml
@@ -7,7 +7,7 @@ jobs:
   close-labview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Close LabVIEW (32-bit)
         uses: ./close-labview/action.yml
         with:
@@ -16,7 +16,7 @@ jobs:
           working_directory: '${{ github.workspace }}/scripts/close-labview'
           dry_run: true
       - name: Upload log (32-bit)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: close-labview-32.log
           path: '${{ github.workspace }}/scripts/close-labview/close-labview.log'
@@ -29,7 +29,7 @@ jobs:
           working_directory: '${{ github.workspace }}/scripts/close-labview'
           dry_run: true
       - name: Upload log (64-bit)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: close-labview-64.log
           path: '${{ github.workspace }}/scripts/close-labview/close-labview.log'

--- a/.github/workflows/missing-in-project-self-hosted.yml
+++ b/.github/workflows/missing-in-project-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   missing-in-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run missing-in-project action
         uses: ./missing-in-project/action.yml
         with:
@@ -16,7 +16,7 @@ jobs:
           project_file: 'scripts/missing-in-project/Missing in Project.lvproj'
           relative_path: 'scripts/missing-in-project'
       - name: Upload missing findings
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: missing-files
           path: 'scripts/missing-in-project/missing_files.txt'

--- a/.github/workflows/modify-vipb-display-info-self-hosted.yml
+++ b/.github/workflows/modify-vipb-display-info-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   modify-vipb-display-info:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run modify-vipb-display-info action
         uses: ./modify-vipb-display-info/action.yml
         with:
@@ -23,7 +23,7 @@ jobs:
           commit: 'abcdef'
           display_information_json: '{"Name":"Test"}'
       - name: Upload vipb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: vipb-display-info
           path: 'scripts/modify-vipb-display-info/lv_icon.vipb'

--- a/.github/workflows/prepare-labview-source-self-hosted.yml
+++ b/.github/workflows/prepare-labview-source-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   prepare-labview-source:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run prepare-labview-source action
         uses: ./prepare-labview-source/action.yml
         with:
@@ -17,7 +17,7 @@ jobs:
           labview_project: 'scripts/prepare-labview-source/lv_icon.lvproj'
           build_spec: 'PackageSource'
       - name: Upload prepared source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: prepared-source
           path: 'scripts/prepare-labview-source/prepared-source.zip'

--- a/.github/workflows/rename-file-self-hosted.yml
+++ b/.github/workflows/rename-file-self-hosted.yml
@@ -7,14 +7,14 @@ jobs:
   rename-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run rename-file action
         uses: ./rename-file/action.yml
         with:
           current_filename: 'scripts/rename-file/README.md'
           new_filename: 'scripts/rename-file/README-renamed.md'
       - name: Upload renamed file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: renamed-file
           path: 'scripts/rename-file/README-renamed.md'

--- a/.github/workflows/requirement-id-check.yml
+++ b/.github/workflows/requirement-id-check.yml
@@ -8,7 +8,7 @@ jobs:
   requirement-id:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
       - name: Ensure commits reference requirement IDs

--- a/.github/workflows/restore-setup-lv-source-self-hosted.yml
+++ b/.github/workflows/restore-setup-lv-source-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   restore-setup-lv-source:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run restore-setup-lv-source action
         uses: ./restore-setup-lv-source/action.yml
         with:
@@ -19,7 +19,7 @@ jobs:
         env:
           GCLI_SUPPRESS_PROMPTS: '1'
       - name: Upload restore logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: restore-logs
           path: 'scripts/restore-setup-lv-source/restore.log'

--- a/.github/workflows/revert-development-mode-self-hosted.yml
+++ b/.github/workflows/revert-development-mode-self-hosted.yml
@@ -7,13 +7,13 @@ jobs:
   revert-development-mode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run revert-development-mode action
         uses: ./revert-development-mode/action.yml
         with:
           relative_path: './'
       - name: Upload config artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: devmode-config
           path: 'devmode-config.txt'

--- a/.github/workflows/run-pester-tests.yml
+++ b/.github/workflows/run-pester-tests.yml
@@ -15,9 +15,9 @@ jobs:
   run-pester-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}

--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run unit tests action
         uses: ./run-unit-tests/action.yml
         with:
@@ -17,12 +17,12 @@ jobs:
           test_config: 'scripts/run-unit-tests/unittest-config.cfg'
           working_directory: 'scripts/run-unit-tests'
       - name: Upload test results to GitHub
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@0f06977fde99088e583f6fa8ec622da326e818c3
         if: ${{ (success() || failure()) && !cancelled() }}
         with:
           files: 'artifacts/unit-tests/UnitTestReport.xml'
       - name: Upload unit test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: unit-test-results
           path: 'artifacts/unit-tests/UnitTestReport.xml'

--- a/.github/workflows/set-development-mode-self-hosted.yml
+++ b/.github/workflows/set-development-mode-self-hosted.yml
@@ -7,7 +7,7 @@ jobs:
   set-development-mode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run set-development-mode action
         uses: ./set-development-mode/action.yml
         with:
@@ -17,7 +17,7 @@ jobs:
           log_level: 'INFO'
           dry_run: 'true'
       - name: Upload dev mode logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dev-mode-config
           path: 'scripts/set-development-mode/dev-mode.log'


### PR DESCRIPTION
## Summary
- pin GitHub and third-party actions to exact commit SHAs across workflows

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a50877181083299ff463e1f12057e5