### PR TITLE
chore: pin mkdocs dependencies

### DIFF
--- a/setup-mkdocs/action.yml
+++ b/setup-mkdocs/action.yml
@@ -10,9 +10,9 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-mkdocs-1.5.3
+        key: ${{ runner.os }}-pip-mkdocs-1.5.3-mkdocs-material-9.6.17-pymdown-extensions-10.16.1-mkdocs-autorefs-1.4.2-mkdocs-redirects-1.2.2
         restore-keys: |
           ${{ runner.os }}-pip-mkdocs-
     - name: Install MkDocs
       shell: bash
-      run: pip install mkdocs==1.5.3 mkdocs-material pymdown-extensions mkdocs-autorefs mkdocs-redirects
+      run: pip install mkdocs==1.5.3 mkdocs-material==9.6.17 pymdown-extensions==10.16.1 mkdocs-autorefs==1.4.2 mkdocs-redirects==1.2.2


### PR DESCRIPTION
## Summary
- pin mkdocs-related dependencies in setup-mkdocs action
- include dependency versions in pip cache key

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a50a9e1a348329bd750aa577e7a46c