### PR TITLE
docs: pin actionlint installation version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Ensure Node.js 24 or newer is installed (e.g. via the NodeSource setup script).
   - Verify with `node --version`.
 - Install `actionlint` and ensure it is on your `PATH`:
-  - `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
+  - `go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.26`
   - Verify with `actionlint -version`.
 - Ensure PowerShell 7.5.1 is installed and accessible.
   - Verify with `pwsh --version`.


### PR DESCRIPTION
## Summary
- pin actionlint install instructions to version v1.6.26 in AGENTS.md

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint` *(fails: unknown label "ubuntu-24.04" in workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68a50c6afeec8329bf482cf1d5b13b4f