### PR TITLE
docs: add test and release mode instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,14 @@
 ### Pester Tests
 
 Pester tests are part of the continuous integration pipeline. The GitHub runner executes them automatically, so agents must not run Pester tests manually.
+
+## Test and Release Mode
+
+- Committing build artifacts along with a `release.json` file triggers the release pipeline.
+- The `release.json` file must follow this schema:
+
+```json
+{"major":1,"minor":0,"patch":2,"title":"Release title"}
+```
+- `ci.yml` runs first and, on success, hands off to `release.yml` for publishing.
+


### PR DESCRIPTION
## Summary
- document Test and Release Mode in AGENTS.md
- clarify release.json schema and workflow handoff from ci.yml to release.yml

## Testing
- `node --version`
- `actionlint -version`
- `pwsh --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint` *(fails: label "ubuntu-24.04" is unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68a51044ae5c832996232a0b943fc3dc