### PR TITLE
docs: document Test and Release Mode

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   labels:
     - icon-editor-windows
     - self-hosted-windows-lv
+    - ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,15 @@
 ### Pester Tests
 
 Pester tests are part of the continuous integration pipeline. The GitHub runner executes them automatically, so agents must not run Pester tests manually.
+
+## Test and Release Mode
+
+Committing build artifacts together with a `release.json` file triggers the release pipeline.
+
+The `release.json` file must follow this schema:
+
+```json
+{"major":1,"minor":0,"patch":2,"title":"Release title"}
+```
+
+The workflow `ci.yml` runs first and, on success, hands off to `release.yml` for publishing.


### PR DESCRIPTION
## Summary
- document Test and Release Mode, including `release.json` schema and handoff from `ci.yml` to `release.yml`
- allow actionlint to recognize `ubuntu-24.04` runner label

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint -config-file .github/actionlint.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a51044ae5c832996232a0b943fc3dc