### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - id: check
+        run: |
+          if [[ -f release.json ]]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+          fi
+      - name: Parse release metadata
+        if: steps.check.outputs.present == 'true'
+        id: meta
+        run: |
+          VERSION=$(jq -r '"\(.major).\(.minor).\(.patch)"' release.json)
+          TITLE=$(jq -r '.title' release.json)
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        if: steps.check.outputs.present == 'true'
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts
+      - name: Create tag
+        if: steps.check.outputs.present == 'true'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag "$TAG" "${{ github.event.workflow_run.head_sha }}"
+          git push origin "$TAG"
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+      - name: Create GitHub release
+        if: steps.check.outputs.present == 'true'
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          release_name: ${{ steps.meta.outputs.title }}
+          body: ${{ steps.meta.outputs.title }}
+      - name: Upload artifacts
+        if: steps.check.outputs.present == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          for file in $(find artifacts -type f); do
+            gh release upload "$TAG" "$file" --clobber
+          done


### PR DESCRIPTION
## Summary
- trigger release workflow after successful CI if `release.json` is present
- tag commit and publish GitHub release including CI artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a512377f9483298caa56b6039ab927