### PR TITLE
feat: upload release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,27 @@ on:
     branches: [actions]
 
 jobs:
+  release-check:
+    runs-on: ubuntu-24.04
+    outputs:
+      needs_release: ${{ steps.check.outputs.present }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - id: check
+        run: |
+          if [[ -f release.json ]]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: steps.check.outputs.present == 'true'
+        with:
+          name: release-metadata
+          path: release.json
+
   node-ci:
+    needs: release-check
     runs-on: ubuntu-24.04
     env:
       # Summary artifacts are emitted under artifacts/<os>.
@@ -55,6 +75,7 @@ jobs:
           if-no-files-found: ignore
 
   ps-ci:
+    needs: release-check
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.outputs.needs_release == 'true' }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - id: check
-        run: |
-          if [[ -f release.json ]]; then
-            echo 'present=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'present=false' >> "$GITHUB_OUTPUT"
-          fi
       - name: Parse release metadata
-        if: steps.check.outputs.present == 'true'
         id: meta
         run: |
           VERSION=$(jq -r '"\(.major).\(.minor).\(.patch)"' release.json)
@@ -32,13 +24,12 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        if: steps.check.outputs.present == 'true'
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: release-metadata
           path: artifacts
       - name: Create tag
-        if: steps.check.outputs.present == 'true'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -47,7 +38,6 @@ jobs:
         env:
           TAG: ${{ steps.meta.outputs.tag }}
       - name: Create GitHub release
-        if: steps.check.outputs.present == 'true'
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         with:
@@ -55,7 +45,6 @@ jobs:
           release_name: ${{ steps.meta.outputs.title }}
           body: ${{ steps.meta.outputs.title }}
       - name: Upload artifacts
-        if: steps.check.outputs.present == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- check for release.json during CI and upload as `release-metadata`
- gate release workflow on `needs_release` flag

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a513e0c3988329926d9bbc9555bda5