### PR TITLE
ci: add artifact validation

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -13,11 +13,32 @@
     }
   },
   "jobs": {
-    "node-ci": {
+    "release-check": {
       "runs-on": "ubuntu-24.04",
-      "env": {
-        "ARTIFACT_DIR": "artifacts/linux"
+      "outputs": {
+        "needs_release": "${{ steps.check.outputs.present }}"
       },
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "id": "check",
+          "run": "if [[ -f release.json ]]; then\n  echo 'present=true' >> \"$GITHUB_OUTPUT\"\nelse\n  echo 'present=false' >> \"$GITHUB_OUTPUT\"\nfi"
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "steps.check.outputs.present == 'true'",
+          "with": {
+            "name": "release-metadata",
+            "path": "release.json"
+          }
+        }
+      ]
+    },
+    "validate-artifacts": {
+      "needs": "release-check",
+      "runs-on": "ubuntu-24.04",
       "steps": [
         {
           "uses": "actions/checkout@v4"
@@ -29,75 +50,24 @@
           }
         },
         {
-          "run": "npm run check:node"
-        },
-        {
           "run": "npm install"
         },
         {
           "run": "npm run link:check"
         },
         {
-          "run": "npm run test:ci"
-        },
-        {
           "run": "npm run derive:registry"
         },
         {
-          "run": "rm -rf artifacts"
+          "run": "git diff --exit-code -- dispatchers.json"
         },
         {
-          "run": "mkdir -p artifacts && cp test-results/*junit*.xml artifacts/"
-        },
-        {
-          "uses": "actions/upload-artifact@v4",
-          "if": "always()",
-          "with": {
-            "name": "junit-results",
-            "path": "artifacts/**/*junit*.xml"
-          }
-        },
-        {
-          "uses": "EnricoMi/publish-unit-test-result-action@v2",
-          "if": "always()",
-          "with": {
-            "files": "artifacts/**/*junit*.xml"
-          }
-        },
-        {
-          "run": "npm run generate:summary",
-          "env": {
-            "TEST_RESULTS_GLOBS": "test-results/*junit*.xml"
-          }
-        },
-        {
-          "uses": "actions/upload-artifact@v4",
-          "if": "always()",
-          "with": {
-            "name": "traceability",
-            "path": "${{ env.ARTIFACT_DIR }}/traceability.*"
-          }
-        },
-        {
-          "uses": "actions/upload-artifact@v4",
-          "if": "always()",
-          "with": {
-            "name": "action-docs",
-            "path": "${{ env.ARTIFACT_DIR }}/action-docs.*"
-          }
-        },
-        {
-          "uses": "actions/upload-artifact@v4",
-          "if": "always()",
-          "with": {
-            "name": "evidence",
-            "path": "${{ env.ARTIFACT_DIR }}/evidence/**",
-            "if-no-files-found": "ignore"
-          }
+          "run": "npm run check:traceability"
         }
       ]
     },
     "ps-ci": {
+      "needs": "release-check",
       "strategy": {
         "matrix": {
           "include": [
@@ -161,7 +131,7 @@
     },
     "report": {
       "needs": [
-        "node-ci",
+        "validate-artifacts",
         "ps-ci"
       ],
       "runs-on": "ubuntu-24.04",
@@ -183,12 +153,9 @@
           "run": "npm install"
         },
         {
-          "run": "rm -rf artifacts"
-        },
-        {
           "uses": "actions/download-artifact@v4",
           "with": {
-            "path": "./artifacts"
+            "path": "./downloaded-artifacts"
           }
         },
         {
@@ -197,7 +164,7 @@
         {
           "run": "npm run generate:summary",
           "env": {
-            "TEST_RESULTS_GLOBS": "artifacts/junit-results/artifacts/**/*junit*.xml\nartifacts/pester-junit-*/pester-junit.xml\n",
+            "TEST_RESULTS_GLOBS": "test-results/*junit*.xml\ndownloaded-artifacts/pester-junit-*/pester-junit.xml\n",
             "REQ_MAPPING_FILE": "requirements.json",
             "DISPATCHER_REGISTRY": "dispatchers.json",
             "EVIDENCE_DIR": "artifacts/evidence"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,54 +26,19 @@ jobs:
           name: release-metadata
           path: release.json
 
-  node-ci:
+  validate-artifacts:
     needs: release-check
     runs-on: ubuntu-24.04
-    env:
-      # Summary artifacts are emitted under artifacts/<os>.
-      # This job always runs on Linux, so the directory is fixed.
-      ARTIFACT_DIR: artifacts/linux
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
-      - run: npm run check:node
       - run: npm install
       - run: npm run link:check
-      - run: npm run test:ci
       - run: npm run derive:registry
-      - run: rm -rf artifacts
-      - run: mkdir -p artifacts && cp test-results/*junit*.xml artifacts/
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: ${{ (success() || failure()) && !cancelled() }}
-        with:
-          name: junit-results
-          path: artifacts/**/*junit*.xml
-      - uses: EnricoMi/publish-unit-test-result-action@0f06977fde99088e583f6fa8ec622da326e818c3
-        if: ${{ (success() || failure()) && !cancelled() }}
-        with:
-          files: artifacts/**/*junit*.xml
-      - run: npm run generate:summary
-        env:
-          TEST_RESULTS_GLOBS: test-results/*junit*.xml
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: ${{ (success() || failure()) && !cancelled() }}
-        with:
-          name: traceability
-          path: ${{ env.ARTIFACT_DIR }}/traceability.*
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: ${{ (success() || failure()) && !cancelled() }}
-        with:
-          name: action-docs
-          path: ${{ env.ARTIFACT_DIR }}/action-docs.*
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: ${{ (success() || failure()) && !cancelled() }}
-        with:
-          name: evidence
-          path: ${{ env.ARTIFACT_DIR }}/evidence/**
-          if-no-files-found: ignore
-
+      - run: git diff --exit-code -- dispatchers.json
+      - run: npm run check:traceability
   ps-ci:
     needs: release-check
     strategy:
@@ -141,7 +106,7 @@ jobs:
           if-no-files-found: error
 
   report:
-    needs: [node-ci, ps-ci]
+    needs: [validate-artifacts, ps-ci]
     runs-on: ubuntu-24.04
     if: ${{ (success() || failure()) && !cancelled() }}
     steps:
@@ -151,16 +116,15 @@ jobs:
           node-version: 24
       - run: npm run check:node
       - run: npm install
-      - run: rm -rf artifacts
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          path: ./artifacts
+          path: ./downloaded-artifacts
       - run: npm run derive:registry
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
-            artifacts/junit-results/artifacts/**/*junit*.xml
-            artifacts/pester-junit-*/pester-junit.xml
+            test-results/*junit*.xml
+            downloaded-artifacts/pester-junit-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: artifacts/evidence


### PR DESCRIPTION
## Summary
- remove node CI job
- add validate-artifacts job to verify committed outputs and dispatchers registry
- adjust report to consume committed artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a51b63b6948329b5db70ad2aa73867