### PR TITLE
Use local node test results in CI summary

### DIFF
--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -155,6 +155,7 @@
         {
           "uses": "actions/download-artifact@v4",
           "with": {
+            "pattern": "pester-junit-*",
             "path": "./downloaded-artifacts"
           }
         },
@@ -168,6 +169,20 @@
             "REQ_MAPPING_FILE": "requirements.json",
             "DISPATCHER_REGISTRY": "dispatchers.json",
             "EVIDENCE_DIR": "artifacts/evidence"
+          }
+        },
+        {
+          "run": "npx tsx scripts/generate-traceability-matrix.ts"
+        },
+        {
+          "run": "cat artifacts/linux/traceability-matrix.md >> \"$GITHUB_STEP_SUMMARY\""
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "(success() || failure()) && !cancelled()",
+          "with": {
+            "name": "traceability-matrix",
+            "path": "artifacts/linux/traceability-matrix.md"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,14 @@ jobs:
       - run: npm install
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
+          pattern: test-results-pester-*
           path: ./downloaded-artifacts
       - run: npm run derive:registry
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
             test-results/*junit*.xml
-            downloaded-artifacts/pester-junit-*/pester-junit.xml
+            downloaded-artifacts/test-results-pester-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: artifacts/evidence


### PR DESCRIPTION
## Summary
- limit report job to validate-artifacts and ps-ci outputs
- gather node junit files from repository and pester results from downloaded artifacts
- keep traceability matrix upload and pester traceability in generated summary

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68a51db55c3483298c264f81b33b47ec