### PR TITLE
Document CI test workflow and artifact steps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,7 @@
 - REQ-
 
 ## Testing
-- [ ] `npm test`
+- [ ] `npm run test:ci`
+- [ ] `npm run derive:registry`
+- [ ] `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
+- [ ] `npm run check:traceability`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,14 @@
 ## Testing
 - Run `npm run check:node` to verify Node.js satisfies the required version.
 - Run `npm install` to ensure Node dependencies are available.
-- Run `npm test`.
+- Run `npm run test:ci` (JUnit files appear under `test-results/`).
+- Run `npm run derive:registry`.
+- Run `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`.
+- Run `npm run check:traceability` to validate artifacts.
 - Run `npm run lint:md` to lint Markdown files.
 - Run `npx --yes linkinator README.md docs scripts --config linkinator.config.json` to verify links and ensure failures are visible.
 - Run `actionlint` to validate GitHub Actions workflows.
+- Commit `test-results/*` and `artifacts/linux/*` along with source changes.
 
 ### Pester Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,16 @@
 # Contributing
 
-Contributions of all kinds are welcome. Ensure you have Node.js 24 or newer installed, then run `npm install` to set up dependencies. Before submitting pull requests, run the JavaScript tests and any available linters.
+Contributions of all kinds are welcome. Ensure you have Node.js 24 or newer installed, then run the following commands before submitting pull requests:
 
 ```bash
 npm install
-npm test
+npm run test:ci
+npm run derive:registry
+TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary
+npm run check:traceability
 ```
+
+Commit `test-results/*` and `artifacts/linux/*` along with your source changes.
 
 For documentation updates, follow the [documentation contribution guidelines](docs/contributing-docs.md). Run the following to lint Markdown files and verify links before submitting a pull request:
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,17 @@ Workflows distinguish between standard GitHub-hosted images and integration runn
 
 ## Testing
 
-Run the JavaScript tests with:
+Run the JavaScript tests and generate traceability data with:
 
 ```bash
 npm install
-npm test
+npm run test:ci
+npm run derive:registry
+TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary
+npm run check:traceability
 ```
+
+JUnit files appear under `test-results/`. Commit `test-results/*` and `artifacts/linux/*` along with source changes.
 
 For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable. The summary script searches `artifacts/` by default; set `TEST_RESULTS_GLOBS` if your reports are elsewhere.
 

--- a/artifacts/linux/action-docs.json
+++ b/artifacts/linux/action-docs.json
@@ -1,0 +1,1628 @@
+{
+  "action": [],
+  "dispatcher": {
+    "Invoke-AddTokenToLabVIEW": {
+      "description": "Adds an authentication token to a LabVIEW installation. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-ApplyVIPC": {
+      "description": "Applies a VI Package Configuration to a LabVIEW project. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. VIP_LVVersion: LabVIEW version used to build the VIPC. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPCPath: Optional path to the VIPC file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        },
+        "VIP_LVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "LabVIEW version used to build the VIPC"
+        },
+        "VIPCPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path to the VIPC file"
+        }
+      }
+    },
+    "Invoke-Build": {
+      "description": "Builds the project and records version information. RelativePath: Normalized path to the project root relative to the working directory. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. CompanyName: Company name recorded in build metadata. AuthorName: Author name recorded in build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "AuthorName": {
+          "type": "string",
+          "required": true,
+          "description": "Author name recorded in build metadata"
+        },
+        "Build": {
+          "type": "number",
+          "required": true,
+          "description": "Build number component"
+        },
+        "Commit": {
+          "type": "string",
+          "required": true,
+          "description": "Commit identifier used for the build metadata"
+        },
+        "CompanyName": {
+          "type": "string",
+          "required": true,
+          "description": "Company name recorded in build metadata"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEWMinorRevision": {
+          "type": "string",
+          "required": true,
+          "description": "Minor revision of LabVIEW used for the build"
+        },
+        "Major": {
+          "type": "number",
+          "required": true,
+          "description": "Major version component"
+        },
+        "Minor": {
+          "type": "number",
+          "required": true,
+          "description": "Minor version component"
+        },
+        "Patch": {
+          "type": "number",
+          "required": true,
+          "description": "Patch version component"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        }
+      }
+    },
+    "Invoke-BuildLvlibp": {
+      "description": "Builds a LabVIEW Packed Library using a project and build spec. MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "Build": {
+          "type": "number",
+          "required": true,
+          "description": "Build number component"
+        },
+        "Build_Spec": {
+          "type": "string",
+          "required": true,
+          "description": "Name of the build specification within the project"
+        },
+        "Commit": {
+          "type": "string",
+          "required": true,
+          "description": "Commit identifier used for the build metadata"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEW_Project": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the LabVIEW project file"
+        },
+        "Major": {
+          "type": "number",
+          "required": true,
+          "description": "Major version component"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the library supports"
+        },
+        "Minor": {
+          "type": "number",
+          "required": true,
+          "description": "Minor version component"
+        },
+        "Patch": {
+          "type": "number",
+          "required": true,
+          "description": "Patch version component"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-BuildViPackage": {
+      "description": "Builds a VI Package using the provided VIPB file and version metadata. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package. RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "Build": {
+          "type": "number",
+          "required": true,
+          "description": "Build number component"
+        },
+        "Commit": {
+          "type": "string",
+          "required": true,
+          "description": "Commit identifier used for the build metadata"
+        },
+        "DisplayInformationJSON": {
+          "type": "string",
+          "required": true,
+          "description": "JSON string containing display information for the package"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEWMinorRevision": {
+          "type": "string",
+          "required": true,
+          "description": "Minor revision of LabVIEW used to build the package"
+        },
+        "Major": {
+          "type": "number",
+          "required": true,
+          "description": "Major version component"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the package supports"
+        },
+        "Minor": {
+          "type": "number",
+          "required": true,
+          "description": "Minor version component"
+        },
+        "Patch": {
+          "type": "number",
+          "required": true,
+          "description": "Patch version component"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "ReleaseNotesFile": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path to a release notes file"
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        },
+        "VIPBPath": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the VIPB build specification file"
+        }
+      }
+    },
+    "Invoke-CloseLabVIEW": {
+      "description": "Closes any running instance of LabVIEW. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-GenerateReleaseNotes": {
+      "description": "Generates a release notes file from the project's metadata. OutputPath: Path where the release notes should be written. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "OutputPath": {
+          "type": "string",
+          "required": false,
+          "default": "Tooling/deployment/release_notes.md",
+          "description": "Path where the release notes should be written"
+        }
+      }
+    },
+    "Invoke-MissingInProject": {
+      "description": "Lists files referenced in a LabVIEW project that are missing on disk. LVVersion: LabVIEW version of the project. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). ProjectFile: Path to the .lvproj file to analyze. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "LabVIEW version of the project"
+        },
+        "ProjectFile": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the"
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-ModifyVIPBDisplayInfo": {
+      "description": "Updates display information fields in a VIPB build specification. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "Build": {
+          "type": "number",
+          "required": true,
+          "description": "Build number component"
+        },
+        "Commit": {
+          "type": "string",
+          "required": true,
+          "description": "Commit identifier used for the build metadata"
+        },
+        "DisplayInformationJSON": {
+          "type": "string",
+          "required": true,
+          "description": "JSON string containing display information for the package"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEWMinorRevision": {
+          "type": "string",
+          "required": true,
+          "description": "Minor revision of LabVIEW used for the build"
+        },
+        "Major": {
+          "type": "number",
+          "required": true,
+          "description": "Major version component"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the package supports"
+        },
+        "Minor": {
+          "type": "number",
+          "required": true,
+          "description": "Minor version component"
+        },
+        "Patch": {
+          "type": "number",
+          "required": true,
+          "description": "Patch version component"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "ReleaseNotesFile": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path to a release notes file"
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        },
+        "VIPBPath": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the VIPB build specification file"
+        }
+      }
+    },
+    "Invoke-PrepareLabVIEWSource": {
+      "description": "Prepares a LabVIEW project for source distribution. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "Build_Spec": {
+          "type": "string",
+          "required": true,
+          "description": "Name of the build specification within the project"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEW_Project": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the LabVIEW project file"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-RenameFile": {
+      "description": "Renames a file on disk. CurrentFilename: Existing path to the file. NewFilename: New path for the file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "CurrentFilename": {
+          "type": "string",
+          "required": true,
+          "description": "Existing path to the file"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "NewFilename": {
+          "type": "string",
+          "required": true,
+          "description": "New path for the file"
+        }
+      }
+    },
+    "Invoke-RestoreSetupLVSource": {
+      "description": "Restores the Setup LabVIEW source build specification. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "Build_Spec": {
+          "type": "string",
+          "required": true,
+          "description": "Name of the build specification within the project"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "LabVIEW_Project": {
+          "type": "string",
+          "required": true,
+          "description": "Path to the LabVIEW project file"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-RevertDevelopmentMode": {
+      "description": "Returns a repository to its previous development mode state. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        }
+      }
+    },
+    "Invoke-RunPesterTests": {
+      "description": "Runs Pester tests located in the specified working directory. WorkingDirectory: Path containing the Pester tests to execute. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "WorkingDirectory": {
+          "type": "string",
+          "required": true,
+          "description": "Path containing the Pester tests to execute"
+        }
+      }
+    },
+    "Invoke-RunUnitTests": {
+      "description": "Runs LabVIEW unit tests. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "MinimumSupportedLVVersion": {
+          "type": "string",
+          "required": true,
+          "description": "Minimum LabVIEW version that the project supports"
+        },
+        "SupportedBitness": {
+          "type": "string",
+          "required": true,
+          "description": "Target LabVIEW bitness (32- or 64-bit)"
+        }
+      }
+    },
+    "Invoke-SetDevelopmentMode": {
+      "description": "Configures the repository for development mode. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+      "parameters": {
+        "DryRun": {
+          "type": "boolean",
+          "required": false,
+          "description": "If set, prints the command instead of executing it"
+        },
+        "gcliPath": {
+          "type": "string",
+          "required": false,
+          "description": "Optional path prepended to PATH for locating the g CLI"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        }
+      }
+    },
+    "Normalize-RelativePath": {
+      "description": "Normalizes a RelativePath value against an optional base directory. RelativePath: Path to normalize. BaseDirectory: Directory used to resolve the relative path. Defaults to the current location.",
+      "parameters": {
+        "BaseDirectory": {
+          "type": "string",
+          "required": false,
+          "description": "Directory used to resolve the relative path"
+        },
+        "RelativePath": {
+          "type": "string",
+          "required": true,
+          "description": "Path relative to WorkingDirectory that locates the project or repository root."
+        }
+      }
+    },
+    "Set-LogLevel": {
+      "description": "Sets the verbosity for informational and verbose messages. Level: Desired log level (ERROR, WARN, INFO, DEBUG).",
+      "parameters": {
+        "Level": {
+          "type": "string",
+          "required": false,
+          "description": "Desired log level (ERROR, WARN, INFO, DEBUG)"
+        }
+      }
+    }
+  },
+  "wrappers": {
+    "add-token-to-labview": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the token target.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "apply-vipc": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "vip_lv_version",
+        "description": "LabVIEW version associated with the VI Package.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the LabVIEW project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "vipc_path",
+        "description": "Path to the VIPC file.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "build": [
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the LabVIEW project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "major",
+        "description": "Major version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "minor",
+        "description": "Minor version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "patch",
+        "description": "Patch version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build",
+        "description": "Build number.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "commit",
+        "description": "Commit identifier.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_minor_revision",
+        "description": "LabVIEW minor revision.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "company_name",
+        "description": "Company name for the build.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "author_name",
+        "description": "Author name for the build.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "build-lvlibp": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the LabVIEW project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_project",
+        "description": "Path to the LabVIEW project file.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build_spec",
+        "description": "Name of the build specification.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "major",
+        "description": "Major version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "minor",
+        "description": "Minor version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "patch",
+        "description": "Patch version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build",
+        "description": "Build number.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "commit",
+        "description": "Commit identifier.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "build-vi-package": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_minor_revision",
+        "description": "LabVIEW minor revision.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "vipb_path",
+        "description": "Path to the VIPB file.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "major",
+        "description": "Major version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "minor",
+        "description": "Minor version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "patch",
+        "description": "Patch version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build",
+        "description": "Build number.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "commit",
+        "description": "Commit identifier.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "display_information_json",
+        "description": "JSON string of display information.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "release_notes_file",
+        "description": "Optional path to release notes file.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "close-labview": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "generate-release-notes": [
+      {
+        "name": "output_path",
+        "description": "Path to output markdown file.",
+        "required": false,
+        "default": "Tooling/deployment/release_notes.md",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "missing-in-project": [
+      {
+        "name": "lv_version",
+        "description": "LabVIEW version to use.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "Target LabVIEW bitness (32 or 64).",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "project_file",
+        "description": "Path to the LabVIEW project (.lvproj).",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "modify-vipb-display-info": [
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "vipb_path",
+        "description": "Path to the VIPB file.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_minor_revision",
+        "description": "LabVIEW minor revision.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "major",
+        "description": "Major version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "minor",
+        "description": "Minor version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "patch",
+        "description": "Patch version component.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build",
+        "description": "Build number.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "commit",
+        "description": "Commit identifier.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "display_information_json",
+        "description": "JSON string of display information.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "release_notes_file",
+        "description": "Optional path to release notes file.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "prepare-labview-source": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_project",
+        "description": "Path to the LabVIEW project file.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build_spec",
+        "description": "Name of the build specification.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "rename-file": [
+      {
+        "name": "current_filename",
+        "description": "Existing file name.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "new_filename",
+        "description": "New file name.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "restore-setup-lv-source": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "Minimum LabVIEW version supported.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the project.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "labview_project",
+        "description": "Path to the LabVIEW project file.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "build_spec",
+        "description": "Name of the build specification.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "revert-development-mode": [
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the repository.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "run-pester-tests": [
+      {
+        "name": "working_directory",
+        "description": "Directory containing the repository under test.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "run-unit-tests": [
+      {
+        "name": "minimum_supported_lv_version",
+        "description": "LabVIEW version for the test run.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "supported_bitness",
+        "description": "\"32\" or \"64\" bitness of LabVIEW.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "set-development-mode": [
+      {
+        "name": "relative_path",
+        "description": "Relative path containing the repository.",
+        "required": true,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "gcli_path",
+        "description": "Optional path to the g-cli executable.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "working_directory",
+        "description": "Working directory where the action will run.",
+        "required": false,
+        "default": "",
+        "type": "string"
+      },
+      {
+        "name": "log_level",
+        "description": "Verbosity level (ERROR|WARN|INFO|DEBUG).",
+        "required": false,
+        "default": "INFO",
+        "type": "string"
+      },
+      {
+        "name": "dry_run",
+        "description": "If true, simulate the action without side effects.",
+        "required": false,
+        "default": false,
+        "type": "string"
+      }
+    ],
+    "setup-mkdocs": []
+  }
+}

--- a/artifacts/linux/action-docs.md
+++ b/artifacts/linux/action-docs.md
@@ -1,0 +1,482 @@
+### Parameters
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+
+### Dispatcher Functions
+
+#### Invoke-AddTokenToLabVIEW
+Adds an authentication token to a LabVIEW installation. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-AddTokenToLabVIEW -ArgsJson '{}'
+```
+
+#### Invoke-ApplyVIPC
+Applies a VI Package Configuration to a LabVIEW project. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. VIP_LVVersion: LabVIEW version used to build the VIPC. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPCPath: Optional path to the VIPC file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| VIPCPath | string | false |  | Optional path to the VIPC file |
+| VIP_LVVersion | string | true |  | LabVIEW version used to build the VIPC |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-ApplyVIPC -ArgsJson '{}'
+```
+
+#### Invoke-Build
+Builds the project and records version information. RelativePath: Normalized path to the project root relative to the working directory. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. CompanyName: Company name recorded in build metadata. AuthorName: Author name recorded in build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| AuthorName | string | true |  | Author name recorded in build metadata |
+| Build | number | true |  | Build number component |
+| Commit | string | true |  | Commit identifier used for the build metadata |
+| CompanyName | string | true |  | Company name recorded in build metadata |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEWMinorRevision | string | true |  | Minor revision of LabVIEW used for the build |
+| Major | number | true |  | Major version component |
+| Minor | number | true |  | Minor version component |
+| Patch | number | true |  | Patch version component |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-Build -ArgsJson '{}'
+```
+
+#### Invoke-BuildLvlibp
+Builds a LabVIEW Packed Library using a project and build spec. MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Build | number | true |  | Build number component |
+| Build_Spec | string | true |  | Name of the build specification within the project |
+| Commit | string | true |  | Commit identifier used for the build metadata |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEW_Project | string | true |  | Path to the LabVIEW project file |
+| Major | number | true |  | Major version component |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the library supports |
+| Minor | number | true |  | Minor version component |
+| Patch | number | true |  | Patch version component |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-BuildLvlibp -ArgsJson '{}'
+```
+
+#### Invoke-BuildViPackage
+Builds a VI Package using the provided VIPB file and version metadata. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package. RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Build | number | true |  | Build number component |
+| Commit | string | true |  | Commit identifier used for the build metadata |
+| DisplayInformationJSON | string | true |  | JSON string containing display information for the package |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEWMinorRevision | string | true |  | Minor revision of LabVIEW used to build the package |
+| Major | number | true |  | Major version component |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the package supports |
+| Minor | number | true |  | Minor version component |
+| Patch | number | true |  | Patch version component |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| ReleaseNotesFile | string | false |  | Optional path to a release notes file |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| VIPBPath | string | true |  | Path to the VIPB build specification file |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-BuildViPackage -ArgsJson '{}'
+```
+
+#### Invoke-CloseLabVIEW
+Closes any running instance of LabVIEW. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-CloseLabVIEW -ArgsJson '{}'
+```
+
+#### Invoke-GenerateReleaseNotes
+Generates a release notes file from the project's metadata. OutputPath: Path where the release notes should be written. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| OutputPath | string | false | Tooling/deployment/release_notes.md | Path where the release notes should be written |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-GenerateReleaseNotes -ArgsJson '{}'
+```
+
+#### Invoke-MissingInProject
+Lists files referenced in a LabVIEW project that are missing on disk. LVVersion: LabVIEW version of the project. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). ProjectFile: Path to the .lvproj file to analyze. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LVVersion | string | true |  | LabVIEW version of the project |
+| ProjectFile | string | true |  | Path to the |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-MissingInProject -ArgsJson '{}'
+```
+
+#### Invoke-ModifyVIPBDisplayInfo
+Updates display information fields in a VIPB build specification. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Build | number | true |  | Build number component |
+| Commit | string | true |  | Commit identifier used for the build metadata |
+| DisplayInformationJSON | string | true |  | JSON string containing display information for the package |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEWMinorRevision | string | true |  | Minor revision of LabVIEW used for the build |
+| Major | number | true |  | Major version component |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the package supports |
+| Minor | number | true |  | Minor version component |
+| Patch | number | true |  | Patch version component |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| ReleaseNotesFile | string | false |  | Optional path to a release notes file |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| VIPBPath | string | true |  | Path to the VIPB build specification file |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-ModifyVIPBDisplayInfo -ArgsJson '{}'
+```
+
+#### Invoke-PrepareLabVIEWSource
+Prepares a LabVIEW project for source distribution. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Build_Spec | string | true |  | Name of the build specification within the project |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEW_Project | string | true |  | Path to the LabVIEW project file |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-PrepareLabVIEWSource -ArgsJson '{}'
+```
+
+#### Invoke-RenameFile
+Renames a file on disk. CurrentFilename: Existing path to the file. NewFilename: New path for the file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| CurrentFilename | string | true |  | Existing path to the file |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| NewFilename | string | true |  | New path for the file |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-RenameFile -ArgsJson '{}'
+```
+
+#### Invoke-RestoreSetupLVSource
+Restores the Setup LabVIEW source build specification. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Build_Spec | string | true |  | Name of the build specification within the project |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| LabVIEW_Project | string | true |  | Path to the LabVIEW project file |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-RestoreSetupLVSource -ArgsJson '{}'
+```
+
+#### Invoke-RevertDevelopmentMode
+Returns a repository to its previous development mode state. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-RevertDevelopmentMode -ArgsJson '{}'
+```
+
+#### Invoke-RunPesterTests
+Runs Pester tests located in the specified working directory. WorkingDirectory: Path containing the Pester tests to execute. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| WorkingDirectory | string | true |  | Path containing the Pester tests to execute |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-RunPesterTests -ArgsJson '{}'
+```
+
+#### Invoke-RunUnitTests
+Runs LabVIEW unit tests. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| MinimumSupportedLVVersion | string | true |  | Minimum LabVIEW version that the project supports |
+| SupportedBitness | string | true |  | Target LabVIEW bitness (32- or 64-bit) |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-RunUnitTests -ArgsJson '{}'
+```
+
+#### Invoke-SetDevelopmentMode
+Configures the repository for development mode. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| DryRun | boolean | false |  | If set, prints the command instead of executing it |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+| gcliPath | string | false |  | Optional path prepended to PATH for locating the g CLI |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Invoke-SetDevelopmentMode -ArgsJson '{}'
+```
+
+#### Normalize-RelativePath
+Normalizes a RelativePath value against an optional base directory. RelativePath: Path to normalize. BaseDirectory: Directory used to resolve the relative path. Defaults to the current location.
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| BaseDirectory | string | false |  | Directory used to resolve the relative path |
+| RelativePath | string | true |  | Path relative to WorkingDirectory that locates the project or repository root. |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Normalize-RelativePath -ArgsJson '{}'
+```
+
+#### Set-LogLevel
+Sets the verbosity for informational and verbose messages. Level: Desired log level (ERROR, WARN, INFO, DEBUG).
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Level | string | false |  | Desired log level (ERROR, WARN, INFO, DEBUG) |
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName Set-LogLevel -ArgsJson '{}'
+```
+
+### Wrapper Actions
+
+#### add-token-to-labview
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the token target. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### apply-vipc
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| vip_lv_version | string | true |  | LabVIEW version associated with the VI Package. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the LabVIEW project. |
+| vipc_path | string | false |  | Path to the VIPC file. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### build
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| relative_path | string | true |  | Relative path containing the LabVIEW project. |
+| major | string | true |  | Major version component. |
+| minor | string | true |  | Minor version component. |
+| patch | string | true |  | Patch version component. |
+| build | string | true |  | Build number. |
+| commit | string | true |  | Commit identifier. |
+| labview_minor_revision | string | true |  | LabVIEW minor revision. |
+| company_name | string | true |  | Company name for the build. |
+| author_name | string | true |  | Author name for the build. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### build-lvlibp
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the LabVIEW project. |
+| labview_project | string | true |  | Path to the LabVIEW project file. |
+| build_spec | string | true |  | Name of the build specification. |
+| major | string | true |  | Major version component. |
+| minor | string | true |  | Minor version component. |
+| patch | string | true |  | Patch version component. |
+| build | string | true |  | Build number. |
+| commit | string | true |  | Commit identifier. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### build-vi-package
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| labview_minor_revision | string | true |  | LabVIEW minor revision. |
+| relative_path | string | true |  | Relative path containing the project. |
+| vipb_path | string | true |  | Path to the VIPB file. |
+| major | string | true |  | Major version component. |
+| minor | string | true |  | Minor version component. |
+| patch | string | true |  | Patch version component. |
+| build | string | true |  | Build number. |
+| commit | string | true |  | Commit identifier. |
+| display_information_json | string | true |  | JSON string of display information. |
+| release_notes_file | string | false |  | Optional path to release notes file. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### close-labview
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### generate-release-notes
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| output_path | string | false | Tooling/deployment/release_notes.md | Path to output markdown file. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### missing-in-project
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| lv_version | string | true |  | LabVIEW version to use. |
+| supported_bitness | string | true |  | Target LabVIEW bitness (32 or 64). |
+| project_file | string | true |  | Path to the LabVIEW project (.lvproj). |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### modify-vipb-display-info
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the project. |
+| vipb_path | string | true |  | Path to the VIPB file. |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| labview_minor_revision | string | true |  | LabVIEW minor revision. |
+| major | string | true |  | Major version component. |
+| minor | string | true |  | Minor version component. |
+| patch | string | true |  | Patch version component. |
+| build | string | true |  | Build number. |
+| commit | string | true |  | Commit identifier. |
+| display_information_json | string | true |  | JSON string of display information. |
+| release_notes_file | string | false |  | Optional path to release notes file. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### prepare-labview-source
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the project. |
+| labview_project | string | true |  | Path to the LabVIEW project file. |
+| build_spec | string | true |  | Name of the build specification. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### rename-file
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| current_filename | string | true |  | Existing file name. |
+| new_filename | string | true |  | New file name. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### restore-setup-lv-source
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | Minimum LabVIEW version supported. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| relative_path | string | true |  | Relative path containing the project. |
+| labview_project | string | true |  | Path to the LabVIEW project file. |
+| build_spec | string | true |  | Name of the build specification. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### revert-development-mode
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| relative_path | string | true |  | Relative path containing the repository. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### run-pester-tests
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| working_directory | string | true |  | Directory containing the repository under test. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### run-unit-tests
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| minimum_supported_lv_version | string | true |  | LabVIEW version for the test run. |
+| supported_bitness | string | true |  | "32" or "64" bitness of LabVIEW. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### set-development-mode
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| relative_path | string | true |  | Relative path containing the repository. |
+| gcli_path | string | false |  | Optional path to the g-cli executable. |
+| working_directory | string | false |  | Working directory where the action will run. |
+| log_level | string | false | INFO | Verbosity level (ERROR|WARN|INFO|DEBUG). |
+| dry_run | string | false | false | If true, simulate the action without side effects. |
+
+#### setup-mkdocs
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |

--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -1,0 +1,70 @@
+### Requirement Summary
+| Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| REQ-023 | Parser ingests JUnit XML artifacts starting at the testsuites root and iterating through nested suites and testcases. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-024 | Top-level testsuites attributes name, tests, errors, failures, disabled, and time are captured for summary reporting. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-025 | Each testsuite records attributes including name, tests, errors, failures, hostname, id, skipped, disabled, package, and time. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-026 | Suite properties are extracted as name/value pairs for environment details. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-027 | Testcase attributes name, status, classname, assertions, time, and any skip message are preserved. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-028 | Requirement identifiers embedded in testcase names are detected and associated with the test. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-029 | Test results are aggregated by requirement and by suite to count passed, failed, and skipped cases. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-030 | Traceability matrix links requirement IDs to testcases with status, execution time, host properties, and skipped reasons. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 40 | 40 | 0 | 0 | 100.00 |
+
+### Requirement Testcases
+| Requirement ID | Test ID | Status |
+| --- | --- | --- |
+| REQ-023 | parses-nested-junit-structures | Passed |
+| REQ-024 | captures-root-testsuites-attributes | Passed |
+| REQ-025 | captures-testsuite-attributes | Passed |
+| REQ-026 | captures-suite-properties | Passed |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed |
+| REQ-028 | extracts-requirement-identifiers | Passed |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed |
+| REQ-031 | validates-missing-fields | Passed |
+| REQ-032 | preserves-unknown-attributes | Passed |
+| REQ-033 | throws-error-for-malformed-xml | Passed |
+| Unmapped | associates-classname-with-requirement | Passed |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed |
+| Unmapped | buildsummary-splits-totals-by-os | Passed |
+| Unmapped | collecttestcases-captures-requirement-property | Passed |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed |
+| Unmapped | fails-when-no-junit-files-are-found | Passed |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed |
+| Unmapped | formaterror-handles-plain-objects | Passed |
+| Unmapped | formaterror-handles-primitives | Passed |
+| Unmapped | formaterror-handles-real-error-objects | Passed |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed |
+| Unmapped | generate-ci-summary-features | Passed |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed |
+| Unmapped | handles-root-level-testcases | Passed |
+| Unmapped | handles-zipped-junit-artifacts | Passed |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,0 +1,7 @@
+### Test Summary
+| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- |
+| overall | 51 | 0 | 0 | 13.19 | 100.00 |
+| linux | 51 | 0 | 0 | 13.19 | 100.00 |
+
+_For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,0 +1,23 @@
+### Test Summary
+| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- |
+| overall | 51 | 0 | 0 | 13.19 | 100.00 |
+| linux | 51 | 0 | 0 | 13.19 | 100.00 |
+
+### Requirement Summary
+| Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| REQ-023 | Parser ingests JUnit XML artifacts starting at the testsuites root and iterating through nested suites and testcases. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-024 | Top-level testsuites attributes name, tests, errors, failures, disabled, and time are captured for summary reporting. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-025 | Each testsuite records attributes including name, tests, errors, failures, hostname, id, skipped, disabled, package, and time. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-026 | Suite properties are extracted as name/value pairs for environment details. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-027 | Testcase attributes name, status, classname, assertions, time, and any skip message are preserved. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-028 | Requirement identifiers embedded in testcase names are detected and associated with the test. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-029 | Test results are aggregated by requirement and by suite to count passed, failed, and skipped cases. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-030 | Traceability matrix links requirement IDs to testcases with status, execution time, host properties, and skipped reasons. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
+| REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 40 | 40 | 0 | 0 | 100.00 |
+
+_For detailed per-test information, see [traceability.md](traceability.md)._

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -1,0 +1,114 @@
+### Test Traceability Matrix
+
+#### REQ-023 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+
+#### REQ-024 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+
+#### REQ-025 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+
+#### REQ-026 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+
+#### REQ-027 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+
+#### REQ-028 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+
+#### REQ-029 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+
+#### REQ-030 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+
+#### REQ-031 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+
+#### REQ-032 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.009 |  |  |
+
+#### REQ-033 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+
+<details><summary>Unmapped (100% passed)</summary>
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.845 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.041 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.900 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.203 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.032 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.705 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.702 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.019 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.926 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.115 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.636 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.823 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.999 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.432 |  |  |
+
+</details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -1,0 +1,574 @@
+{
+  "requirements": [
+    {
+      "id": "REQ-023",
+      "description": "Parser ingests JUnit XML artifacts starting at the testsuites root and iterating through nested suites and testcases.",
+      "tests": [
+        {
+          "id": "parses-nested-junit-structures",
+          "name": "[REQ-023] parses nested JUnit structures",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.009451,
+          "requirements": [
+            "REQ-023"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-024",
+      "description": "Top-level testsuites attributes name, tests, errors, failures, disabled, and time are captured for summary reporting.",
+      "tests": [
+        {
+          "id": "captures-root-testsuites-attributes",
+          "name": "[REQ-024] captures root testsuites attributes",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001882,
+          "requirements": [
+            "REQ-024"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-025",
+      "description": "Each testsuite records attributes including name, tests, errors, failures, hostname, id, skipped, disabled, package, and time.",
+      "tests": [
+        {
+          "id": "captures-testsuite-attributes",
+          "name": "[REQ-025] captures testsuite attributes",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.007282,
+          "requirements": [
+            "REQ-025"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-026",
+      "description": "Suite properties are extracted as name/value pairs for environment details.",
+      "tests": [
+        {
+          "id": "captures-suite-properties",
+          "name": "[REQ-026] captures suite properties",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.002554,
+          "requirements": [
+            "REQ-026"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-027",
+      "description": "Testcase attributes name, status, classname, assertions, time, and any skip message are preserved.",
+      "tests": [
+        {
+          "id": "captures-testcase-attributes-and-skipped-message",
+          "name": "[REQ-027] captures testcase attributes and skipped message",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001366,
+          "requirements": [
+            "REQ-027"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-028",
+      "description": "Requirement identifiers embedded in testcase names are detected and associated with the test.",
+      "tests": [
+        {
+          "id": "extracts-requirement-identifiers",
+          "name": "[REQ-028] extracts requirement identifiers",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.004448,
+          "requirements": [
+            "REQ-028"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-029",
+      "description": "Test results are aggregated by requirement and by suite to count passed, failed, and skipped cases.",
+      "tests": [
+        {
+          "id": "aggregates-status-by-requirement-and-suite",
+          "name": "[REQ-029] aggregates status by requirement and suite",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.002232,
+          "requirements": [
+            "REQ-029"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-030",
+      "description": "Traceability matrix links requirement IDs to testcases with status, execution time, host properties, and skipped reasons.",
+      "tests": [
+        {
+          "id": "builds-traceability-matrix-with-skipped-reasons",
+          "name": "[REQ-030] builds traceability matrix with skipped reasons",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001936,
+          "requirements": [
+            "REQ-030"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-031",
+      "description": "Parsing logic validates presence of required fields and reports missing or malformed data.",
+      "tests": [
+        {
+          "id": "validates-missing-fields",
+          "name": "[REQ-031] validates missing fields",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000974,
+          "requirements": [
+            "REQ-031"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-032",
+      "description": "Parser tolerates and retains unknown attributes for future extensibility.",
+      "tests": [
+        {
+          "id": "preserves-unknown-attributes",
+          "name": "[REQ-032] preserves unknown attributes",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.009231,
+          "requirements": [
+            "REQ-032"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "REQ-033",
+      "description": "Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": [
+        {
+          "id": "throws-error-for-malformed-xml",
+          "name": "[REQ-033] throws error for malformed XML",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.004685,
+          "requirements": [
+            "REQ-033"
+          ],
+          "os": "linux"
+        }
+      ]
+    },
+    {
+      "id": "Unmapped",
+      "tests": [
+        {
+          "id": "associates-classname-with-requirement",
+          "name": "associates classname with requirement",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.011703,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildissuebranchname-formats-branch-name",
+          "name": "buildIssueBranchName formats branch name",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001578,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildissuebranchname-rejects-non-numeric-input",
+          "name": "buildIssueBranchName rejects non-numeric input",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001739,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildsummary-splits-totals-by-os",
+          "name": "buildSummary splits totals by OS",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000516,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "collecttestcases-captures-requirement-property",
+          "name": "collectTestCases captures requirement property",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.004614,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan",
+          "name": "collectTestCases uses evidence property and falls back to directory scan",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.005585,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "collecttestcases-uses-machine-name-property-for-owner",
+          "name": "collectTestCases uses machine-name property for owner",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.016374,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "computestatuscounts-tallies-test-statuses",
+          "name": "computeStatusCounts tallies test statuses",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000196,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "dispatchers-and-parameters-include-descriptions",
+          "name": "Dispatchers and parameters include descriptions",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.002,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "errors-when-strict-unmapped-mode-enabled",
+          "name": "errors when strict unmapped mode enabled",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.84452,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "escapemarkdown-escapes-special-characters",
+          "name": "escapeMarkdown escapes special characters",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001416,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "escapemarkdown-leaves-plain-text-untouched",
+          "name": "escapeMarkdown leaves plain text untouched",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000198,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "fails-when-commit-lacks-requirement-reference",
+          "name": "fails when commit lacks requirement reference",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.040994,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "fails-when-no-junit-files-are-found",
+          "name": "fails when no JUnit files are found",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.900328,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "fails-when-requirement-lacks-test-coverage",
+          "name": "fails when requirement lacks test coverage",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.202912,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "formaterror-handles-plain-objects",
+          "name": "formatError handles plain objects",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000347,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "formaterror-handles-primitives",
+          "name": "formatError handles primitives",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000337,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "formaterror-handles-real-error-objects",
+          "name": "formatError handles real Error objects",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001854,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "formaterror-handles-unstringifiable-values",
+          "name": "formatError handles unstringifiable values",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000539,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "generate-ci-summary-features",
+          "name": "generate-ci-summary features",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.015053,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "groups-owners-and-includes-requirements-and-evidence",
+          "name": "groups owners and includes requirements and evidence",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.031548,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "grouptomarkdown-omits-numeric-identifiers",
+          "name": "groupToMarkdown omits numeric identifiers",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001498,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "grouptomarkdown-supports-optional-limit-for-truncation",
+          "name": "groupToMarkdown supports optional limit for truncation",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000389,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "handles-root-level-testcases",
+          "name": "handles root-level testcases",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.001203,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "handles-zipped-junit-artifacts",
+          "name": "handles zipped JUnit artifacts",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.704791,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "ignores-stale-junit-files-outside-artifacts-path",
+          "name": "ignores stale JUnit files outside artifacts path",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.701523,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "loadrequirements-logs-warning-on-invalid-json",
+          "name": "loadRequirements logs warning on invalid JSON",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.010521,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "loadrequirements-warns-and-skips-invalid-entries",
+          "name": "loadRequirements warns and skips invalid entries",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.019016,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "partitions-requirement-groups-by-runner_type",
+          "name": "partitions requirement groups by runner_type",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.688288,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "passes-with-coverage-and-requirement-reference",
+          "name": "passes with coverage and requirement reference",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.925525,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "requirementssummarytomarkdown-escapes-pipes-in-description",
+          "name": "requirementsSummaryToMarkdown escapes pipes in description",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000289,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "skips-invalid-junit-files-and-still-generates-summary",
+          "name": "skips invalid JUnit files and still generates summary",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.114881,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "summarytomarkdown-handles-no-tests",
+          "name": "summaryToMarkdown handles no tests",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.00029,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters",
+          "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.000324,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "throws-when-no-junit-files-found-and-strict-mode-enabled",
+          "name": "throws when no JUnit files found and strict mode enabled",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.635862,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "uses-latest-artifact-directory-when-multiple-are-present",
+          "name": "uses latest artifact directory when multiple are present",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.823146,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "warns-when-all-tests-are-unmapped",
+          "name": "warns when all tests are unmapped",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.998936,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "writeerrorsummary-appends-error-details-to-summary-file",
+          "name": "writeErrorSummary appends error details to summary file",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.002518,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "writeerrorsummary-skips-summary-file-for-non-error-throws",
+          "name": "writeErrorSummary skips summary file for non-Error throws",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.002491,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "writes-outputs-to-os-specific-directory",
+          "name": "writes outputs to OS-specific directory",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.431683,
+          "requirements": [],
+          "os": "linux"
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "overall": {
+      "passed": 51,
+      "failed": 0,
+      "skipped": 0,
+      "duration": 13.193565999999999,
+      "rate": 100
+    },
+    "byOs": {
+      "linux": {
+        "passed": 51,
+        "failed": 0,
+        "skipped": 0,
+        "duration": 13.193565999999999,
+        "rate": 100
+      }
+    }
+  }
+}

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -1,0 +1,114 @@
+### Test Traceability Matrix
+
+#### REQ-023 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+
+#### REQ-024 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+
+#### REQ-025 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+
+#### REQ-026 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+
+#### REQ-027 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+
+#### REQ-028 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+
+#### REQ-029 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+
+#### REQ-030 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+
+#### REQ-031 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+
+#### REQ-032 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.009 |  |  |
+
+#### REQ-033 (100% passed)
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+
+<details><summary>Unmapped (100% passed)</summary>
+
+| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.845 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.041 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.900 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.203 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.032 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.705 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.702 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.019 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.926 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.115 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.636 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.823 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.999 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.432 |  |  |
+
+</details>

--- a/dispatchers.json
+++ b/dispatchers.json
@@ -1,6 +1,6 @@
 {
   "Invoke-AddTokenToLabVIEW": {
-    "description": "Adds an authentication token to a LabVIEW installation. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Adds an authentication token to a LabVIEW installation. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -30,7 +30,7 @@
     }
   },
   "Invoke-ApplyVIPC": {
-    "description": "Applies a VI Package Configuration to a LabVIEW project. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. VIP_LVVersion: LabVIEW version used to build the VIPC. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. VIPCPath: Optional path to the VIPC file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Applies a VI Package Configuration to a LabVIEW project. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. VIP_LVVersion: LabVIEW version used to build the VIPC. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPCPath: Optional path to the VIPC file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -70,7 +70,7 @@
     }
   },
   "Invoke-Build": {
-    "description": "Builds the project and records version information. RelativePath: Path to the project root relative to the working directory. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. CompanyName: Company name recorded in build metadata. AuthorName: Author name recorded in build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Builds the project and records version information. RelativePath: Normalized path to the project root relative to the working directory. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. CompanyName: Company name recorded in build metadata. AuthorName: Author name recorded in build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "AuthorName": {
         "type": "string",
@@ -130,7 +130,7 @@
     }
   },
   "Invoke-BuildLvlibp": {
-    "description": "Builds a LabVIEW Packed Library using a project and build spec. MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Builds a LabVIEW Packed Library using a project and build spec. MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -195,7 +195,7 @@
     }
   },
   "Invoke-BuildViPackage": {
-    "description": "Builds a VI Package using the provided VIPB file and version metadata. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package. RelativePath: Path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Builds a VI Package using the provided VIPB file and version metadata. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package. RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -346,7 +346,7 @@
     }
   },
   "Invoke-ModifyVIPBDisplayInfo": {
-    "description": "Updates display information fields in a VIPB build specification. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Updates display information fields in a VIPB build specification. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -421,7 +421,7 @@
     }
   },
   "Invoke-PrepareLabVIEWSource": {
-    "description": "Prepares a LabVIEW project for source distribution. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Prepares a LabVIEW project for source distribution. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build_Spec": {
         "type": "string",
@@ -486,7 +486,7 @@
     }
   },
   "Invoke-RestoreSetupLVSource": {
-    "description": "Restores the Setup LabVIEW source build specification. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Restores the Setup LabVIEW source build specification. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Normalized path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build_Spec": {
         "type": "string",
@@ -526,7 +526,7 @@
     }
   },
   "Invoke-RevertDevelopmentMode": {
-    "description": "Returns a repository to its previous development mode state. RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Returns a repository to its previous development mode state. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -591,7 +591,7 @@
     }
   },
   "Invoke-SetDevelopmentMode": {
-    "description": "Configures the repository for development mode. RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
+    "description": "Configures the repository for development mode. RelativePath: Normalized path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -602,6 +602,21 @@
         "type": "string",
         "required": false,
         "description": "Optional path prepended to PATH for locating the g CLI"
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": "Path relative to WorkingDirectory that locates the project or repository root."
+      }
+    }
+  },
+  "Normalize-RelativePath": {
+    "description": "Normalizes a RelativePath value against an optional base directory. RelativePath: Path to normalize. BaseDirectory: Directory used to resolve the relative path. Defaults to the current location.",
+    "parameters": {
+      "BaseDirectory": {
+        "type": "string",
+        "required": false,
+        "description": "Directory used to resolve the relative path"
       },
       "RelativePath": {
         "type": "string",

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+	<testcase name="fails when requirement lacks test coverage" time="1.202912" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.040994" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.925525" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002000" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001854" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000347" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000337" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000539" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.015053" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002491" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.002518" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.011703" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.010521" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.019016" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.016374" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.005585" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.004614" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001498" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000389" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000289" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000196" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000324" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000290" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000516" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.431683" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.114881" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.998936" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.844520" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.701523" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.635862" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.688288" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.704791" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009451" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001882" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.007282" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.002554" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001366" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004448" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001203" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002232" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001936" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000974" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.009231" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.004685" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001416" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000198" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.031548" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.900328" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.823146" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001578" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001739" classname="test"/>
+	<!-- tests 51 -->
+	<!-- suites 0 -->
+	<!-- pass 51 -->
+	<!-- fail 0 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 0 -->
+	<!-- todo 0 -->
+	<!-- duration_ms 8619.015531 -->
+</testsuites>


### PR DESCRIPTION
## Summary
- clarify testing instructions to use `npm run test:ci`
- document steps for deriving registry and generating CI summary
- add guidance on committing `test-results/` and `artifacts/linux/`

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run check:traceability` (fails: No tests executed for requirements)
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`

------
https://chatgpt.com/codex/tasks/task_e_68a5209d92ac8329bd3df90f6be5753f