### PR TITLE
docs: require committing JUnit outputs

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 16.25 | 100.00 |
-| linux | 51 | 0 | 0 | 16.25 | 100.00 |
+| overall | 51 | 0 | 0 | 15.52 | 100.00 |
+| linux | 51 | 0 | 0 | 15.52 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 16.25 | 100.00 |
-| linux | 51 | 0 | 0 | 16.25 | 100.00 |
+| overall | 51 | 0 | 0 | 15.52 | 100.00 |
+| linux | 51 | 0 | 0 | 15.52 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -10,31 +10,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.007 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,51 +64,51 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.029 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.026 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.976 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.962 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.246 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.056 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.365 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.059 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.997 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.314 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.388 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.030 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.283 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.914 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.902 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.027 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.910 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.332 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.433 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.902 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.889 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.939 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.198 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.387 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.839 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.986 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.562 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.836 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.960 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.104 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.545 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013259,
+          "duration": 0.012601,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002237,
+          "duration": 0.003015,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00655,
+          "duration": 0.004565,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005587,
+          "duration": 0.001266,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00159,
+          "duration": 0.001288,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007333,
+          "duration": 0.002318,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001345,
+          "duration": 0.001407,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004344,
+          "duration": 0.001758,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001301,
+          "duration": 0.000784,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001025,
+          "duration": 0.00056,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005405,
+          "duration": 0.001195,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.028819,
+          "duration": 0.010942,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002983,
+          "duration": 0.001871,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001545,
+          "duration": 0.001186,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001259,
+          "duration": 0.000425,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005227,
+          "duration": 0.013375,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.026207,
+          "duration": 0.008694,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015746,
+          "duration": 0.006808,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000522,
+          "duration": 0.000297,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002964,
+          "duration": 0.003493,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.976478,
+          "duration": 0.962279,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001349,
+          "duration": 0.002,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000193,
+          "duration": 0.000212,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.24615,
+          "duration": 1.058788,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.05571,
+          "duration": 0.996731,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.365107,
+          "duration": 1.313549,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000707,
+          "duration": 0.0005,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000477,
+          "duration": 0.00033,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003329,
+          "duration": 0.003452,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000846,
+          "duration": 0.000669,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022945,
+          "duration": 0.030138,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.387939,
+          "duration": 1.283306,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002391,
+          "duration": 0.00327,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000969,
+          "duration": 0.000561,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000489,
+          "duration": 0.000566,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.913593,
+          "duration": 0.902185,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.9023,
+          "duration": 0.889391,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.026948,
+          "duration": 0.011607,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006879,
+          "duration": 0.004316,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.910109,
+          "duration": 0.939413,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.332491,
+          "duration": 1.198012,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000614,
+          "duration": 0.0004,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.432661,
+          "duration": 1.3874,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000401,
+          "duration": 0.000241,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000946,
+          "duration": 0.000496,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.839314,
+          "duration": 0.835939,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.986089,
+          "duration": 0.960009,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.129753,
+          "duration": 1.10399,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005928,
+          "duration": 0.004587,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003117,
+          "duration": 0.004117,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.56202,
+          "duration": 1.545291,
           "requirements": [],
           "os": "linux"
         }
@@ -558,7 +558,7 @@
       "passed": 51,
       "failed": 0,
       "skipped": 0,
-      "duration": 16.253490000000003,
+      "duration": 15.521593000000005,
       "rate": 100
     },
     "byOs": {
@@ -566,7 +566,7 @@
         "passed": 51,
         "failed": 0,
         "skipped": 0,
-        "duration": 16.253490000000003,
+        "duration": 15.521593000000005,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -10,31 +10,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.007 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,51 +64,51 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.029 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.026 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.976 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.962 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.246 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.056 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.365 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.059 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.997 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.314 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.388 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.030 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.283 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.914 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.902 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.027 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.910 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.332 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.433 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.902 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.889 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.939 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.198 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.387 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.839 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.986 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.562 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.836 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.960 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.104 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.545 |  |  |
 
 </details>

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -55,7 +55,7 @@ MkDocs serves the site at <http://127.0.0.1:8000/> by default. The server automa
 
 ## JUnit integration
 
-The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates; the results appear under `test-results/`. Then run:
+The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates; the results appear under `test-results/` and must be committed with your pull request. Then run:
 
 ```bash
 npm run derive:registry
@@ -63,7 +63,7 @@ TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary
 npm run check:traceability
 ```
 
-Commit `test-results/*` and `artifacts/linux/*` along with your source changes. By default, the summary script only searches `artifacts/` for JUnit XML files; if your results are elsewhere, pass a glob via `TEST_RESULTS_GLOBS`.
+Commit `test-results/*` and `artifacts/linux/*` along with your source changes. The `validate-artifacts` job in CI verifies these files but does not generate them. By default, the summary script only searches `artifacts/` for JUnit XML files; if your results are elsewhere, pass a glob via `TEST_RESULTS_GLOBS`.
 
 ### Pester properties
 

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,56 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.365107" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.246150" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.332491" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002964" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.003329" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000707" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000477" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000846" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022945" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003117" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005928" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.028819" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.026948" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006879" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.015746" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.026207" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.005227" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002391" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000969" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000614" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000522" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000946" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000401" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001259" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.562020" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.432661" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.129753" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.976478" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.902300" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.839314" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.910109" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.913593" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.013259" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002237" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.006550" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.005587" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001590" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.007333" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000489" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001345" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004344" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001301" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001025" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.005405" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001349" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000193" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.387939" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="1.055710" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.986089" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.002983" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001545" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.313549" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.058788" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.198012" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.003493" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003452" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000500" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000330" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000669" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.030138" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004117" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.004587" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.010942" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.011607" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.004316" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.006808" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008694" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.013375" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003270" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000561" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000400" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000297" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000496" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000241" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000425" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.545291" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.387400" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.103990" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.962279" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.889391" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.835939" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.939413" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.902185" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012601" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003015" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.004565" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001266" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001288" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002318" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000566" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001407" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001758" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000784" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000560" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001195" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002000" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000212" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.283306" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.996731" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.960009" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001871" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001186" classname="test"/>
 	<!-- tests 51 -->
 	<!-- suites 0 -->
 	<!-- pass 51 -->
@@ -58,5 +58,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 10537.947818 -->
+	<!-- duration_ms 10404.209095 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- clarify that test-generated `test-results` and `artifacts` must be committed
- mention the `validate-artifacts` job that verifies those files

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a525fe71c08329a429eade7160734b