### PR TITLE
chore: add gitignore for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Dependency directories
+node_modules/
+
+# Build outputs
+dist/
+coverage/


### PR DESCRIPTION
## Summary
- ignore node_modules and build outputs

## Testing
- `npm run check:node` *(fails: Node.js >=24 required)*
- `npm install`
- `npm run test:ci` *(fails: Node.js >=24 required)*
- `npm run derive:registry` *(fails: Node.js >=24 required)*
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary` *(fails: Node.js >=24 required)*
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `/root/go/bin/actionlint`
- `npm run check:traceability` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68a52af897b48329a28a786b5d91f346