### PR TITLE
Support Node 20 runtime

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 15.52 | 100.00 |
-| linux | 51 | 0 | 0 | 15.52 | 100.00 |
+| overall | 51 | 0 | 0 | 11.52 | 100.00 |
+| linux | 51 | 0 | 0 | 11.52 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 15.52 | 100.00 |
-| linux | 51 | 0 | 0 | 15.52 | 100.00 |
+| overall | 51 | 0 | 0 | 11.52 | 100.00 |
+| linux | 51 | 0 | 0 | 11.52 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,57 +58,57 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.962 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.681 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.059 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.997 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.314 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.944 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.770 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.052 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.030 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.283 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.934 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.902 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.889 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.939 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.198 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.649 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.621 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.707 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.821 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.387 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.947 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.836 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.960 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.104 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.545 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.593 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.709 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.846 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.095 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012601,
+          "duration": 0.007578,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003015,
+          "duration": 0.005149,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004565,
+          "duration": 0.007573,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001266,
+          "duration": 0.002404,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001288,
+          "duration": 0.003658,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002318,
+          "duration": 0.003573,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001407,
+          "duration": 0.001203,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001758,
+          "duration": 0.00108,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000784,
+          "duration": 0.000584,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00056,
+          "duration": 0.000499,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001195,
+          "duration": 0.001559,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010942,
+          "duration": 0.028454,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001871,
+          "duration": 0.001007,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001186,
+          "duration": 0.000739,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000425,
+          "duration": 0.000378,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013375,
+          "duration": 0.013096,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008694,
+          "duration": 0.007947,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006808,
+          "duration": 0.006991,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000297,
+          "duration": 0.000272,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003493,
+          "duration": 0.004168,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.962279,
+          "duration": 0.680912,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002,
+          "duration": 0.001334,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000212,
+          "duration": 0.000242,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.058788,
+          "duration": 0.944408,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.996731,
+          "duration": 0.770248,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.313549,
+          "duration": 1.051612,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0005,
+          "duration": 0.000277,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00033,
+          "duration": 0.000215,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003452,
+          "duration": 0.00373,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000669,
+          "duration": 0.000442,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.030138,
+          "duration": 0.019607,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.283306,
+          "duration": 0.933771,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00327,
+          "duration": 0.002809,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000561,
+          "duration": 0.000563,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000566,
+          "duration": 0.000822,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.902185,
+          "duration": 0.649232,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.889391,
+          "duration": 0.620574,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011607,
+          "duration": 0.011485,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004316,
+          "duration": 0.003021,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.939413,
+          "duration": 0.706712,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.198012,
+          "duration": 0.820786,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0004,
+          "duration": 0.00035,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.3874,
+          "duration": 0.94739,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000241,
+          "duration": 0.000243,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000496,
+          "duration": 0.000391,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.835939,
+          "duration": 0.592587,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.960009,
+          "duration": 0.709266,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.10399,
+          "duration": 0.846379,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004587,
+          "duration": 0.009249,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004117,
+          "duration": 0.002852,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.545291,
+          "duration": 1.09501,
           "requirements": [],
           "os": "linux"
         }
@@ -558,7 +558,7 @@
       "passed": 51,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.521593000000005,
+      "duration": 11.524431000000002,
       "rate": 100
     },
     "byOs": {
@@ -566,7 +566,7 @@
         "passed": 51,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.521593000000005,
+        "duration": 11.524431000000002,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,57 +58,57 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.962 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.681 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.059 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.997 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.314 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.944 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.770 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.052 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.030 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.283 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.934 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.902 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.889 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.939 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.198 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.649 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.621 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.707 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.821 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.387 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.947 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.836 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.960 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.104 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.545 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.593 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.709 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.846 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.095 |  |  |
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "scripts": {
     "check:node": "node scripts/check-node-version.js",


### PR DESCRIPTION
## Summary
- relax Node.js engine requirement to v20+
- regenerate summary and traceability artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a53050b05c83299a16daf15e11ad8c