### PR TITLE
ci: generate SLSA provenance

### DIFF
--- a/.github/workflows/build-lvlibp-self-hosted.yml
+++ b/.github/workflows/build-lvlibp-self-hosted.yml
@@ -26,3 +26,7 @@ jobs:
         with:
           name: build-lvlibp-artifact
           path: 'scripts/build-lvlibp/lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'
+      - name: Generate SLSA provenance
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018
+        with:
+          subject-path: 'scripts/build-lvlibp/lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -43,3 +43,7 @@ jobs:
         with:
           name: artifact-manifest
           path: scripts/build/artifact-manifest.json
+      - name: Generate SLSA provenance
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018
+        with:
+          subject-path: scripts/build/${{ steps.record.outputs.artifact }}

--- a/.github/workflows/build-vi-package-self-hosted.yml
+++ b/.github/workflows/build-vi-package-self-hosted.yml
@@ -27,3 +27,7 @@ jobs:
         with:
           name: vi-package
           path: 'scripts/build-vi-package/lv_icon_v1.0.0.1+gabcdef.vip'
+      - name: Generate SLSA provenance
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018
+        with:
+          subject-path: 'scripts/build-vi-package/lv_icon_v1.0.0.1+gabcdef.vip'

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 11.39 | 100.00 |
-| linux | 51 | 0 | 0 | 11.39 | 100.00 |
+| overall | 51 | 0 | 0 | 16.25 | 100.00 |
+| linux | 51 | 0 | 0 | 16.25 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 11.39 | 100.00 |
-| linux | 51 | 0 | 0 | 11.39 | 100.00 |
+| overall | 51 | 0 | 0 | 16.25 | 100.00 |
+| linux | 51 | 0 | 0 | 16.25 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,43 +4,43 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,13 +52,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
@@ -70,45 +70,45 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.018 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.674 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.035 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.001 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.828 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.821 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.959 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.205 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.071 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.400 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.027 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.014 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.354 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.005 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.608 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.629 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.931 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.903 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.905 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.979 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.581 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.691 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.835 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.079 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.965 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.238 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.437 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.827 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.974 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.118 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.576 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006546,
+          "duration": 0.014145,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001742,
+          "duration": 0.003878,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003805,
+          "duration": 0.007493,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000941,
+          "duration": 0.003224,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000843,
+          "duration": 0.00532,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001921,
+          "duration": 0.005081,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001307,
+          "duration": 0.001872,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001099,
+          "duration": 0.001498,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000775,
+          "duration": 0.003841,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000457,
+          "duration": 0.001286,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003276,
+          "duration": 0.00273,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013674,
+          "duration": 0.032757,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0015,
+          "duration": 0.001437,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000822,
+          "duration": 0.001194,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000358,
+          "duration": 0.001111,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010441,
+          "duration": 0.007862,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.018364,
+          "duration": 0.035213,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00725,
+          "duration": 0.017654,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000245,
+          "duration": 0.000501,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002371,
+          "duration": 0.004691,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.673898,
+          "duration": 1.000897,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000949,
+          "duration": 0.001533,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000188,
+          "duration": 0.000315,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.827548,
+          "duration": 1.204988,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.820632,
+          "duration": 1.071221,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.9589,
+          "duration": 1.399962,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000299,
+          "duration": 0.000533,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000228,
+          "duration": 0.000506,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002176,
+          "duration": 0.00444,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000525,
+          "duration": 0.000826,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.027424,
+          "duration": 0.020652,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.01405,
+          "duration": 1.353626,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001827,
+          "duration": 0.002043,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004554,
+          "duration": 0.000702,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000416,
+          "duration": 0.001775,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.607746,
+          "duration": 0.930704,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.628725,
+          "duration": 0.902764,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020461,
+          "duration": 0.017613,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014533,
+          "duration": 0.014571,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.621193,
+          "duration": 0.964606,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.905017,
+          "duration": 1.237895,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000228,
+          "duration": 0.000833,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.979095,
+          "duration": 1.436938,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000173,
+          "duration": 0.000609,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000368,
+          "duration": 0.00097,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.581217,
+          "duration": 0.826977,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.691398,
+          "duration": 0.973806,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.834639,
+          "duration": 1.117893,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006861,
+          "duration": 0.023541,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003728,
+          "duration": 0.004649,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.078986,
+          "duration": 1.575574,
           "requirements": [],
           "os": "linux"
         }
@@ -558,7 +558,7 @@
       "passed": 51,
       "failed": 0,
       "skipped": 0,
-      "duration": 11.385719,
+      "duration": 16.246750000000002,
       "rate": 100
     },
     "byOs": {
@@ -566,7 +566,7 @@
         "passed": 51,
         "failed": 0,
         "skipped": 0,
-        "duration": 11.385719,
+        "duration": 16.246750000000002,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,43 +4,43 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,13 +52,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
@@ -70,45 +70,45 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.018 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.674 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.035 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.001 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.828 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.821 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.959 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.205 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.071 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.400 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.027 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.014 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.354 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.005 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.608 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.629 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.931 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.903 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.905 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.979 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.581 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.691 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.835 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.079 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.965 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.238 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.437 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.827 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.974 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.118 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.576 |  |  |
 
 </details>

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,56 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.958900" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.827548" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.905017" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002371" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002176" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000299" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000228" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000525" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.027424" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003728" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006861" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.013674" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020461" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.014533" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.007250" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.018364" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.010441" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001827" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.004554" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000228" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000245" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000368" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000173" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000358" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.078986" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.979095" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.834639" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.673898" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.628725" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.581217" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.621193" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.607746" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.006546" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001742" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.003805" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000941" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000843" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001921" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000416" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001307" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001099" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000775" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000457" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.003276" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.000949" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000188" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.014050" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.820632" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.691398" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001500" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000822" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.399962" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.204988" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.237895" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.004691" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004440" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000533" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000506" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000826" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.020652" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004649" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.023541" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.032757" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.017613" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.014571" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.017654" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.035213" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.007862" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002043" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000702" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000833" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000501" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000970" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000609" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001111" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.575574" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.436938" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.117893" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.000897" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.902764" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.826977" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.964606" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.930704" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.014145" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003878" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.007493" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.003224" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.005320" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.005081" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001775" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001872" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001498" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.003841" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001286" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002730" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001533" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000315" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.353626" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="1.071221" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.973806" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001437" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001194" classname="test"/>
 	<!-- tests 51 -->
 	<!-- suites 0 -->
 	<!-- pass 51 -->
@@ -58,5 +58,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7306.999849 -->
+	<!-- duration_ms 10651.255379 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- generate a SLSA build-provenance attestation for each build artifact

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a54ad9b470832983e1bc6f85b542ee