### PR TITLE
feat: enforce traceability mapping completeness (REQ-001)

### DIFF
--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -12,7 +12,7 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 40 | 40 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 42 | 42 | 0 | 0 | 100.00 |
 
 ### Requirement Testcases
 | Requirement ID | Test ID | Status |
@@ -43,6 +43,8 @@
 | Unmapped | fails-when-commit-lacks-requirement-reference | Passed |
 | Unmapped | fails-when-no-junit-files-are-found | Passed |
 | Unmapped | fails-when-requirement-lacks-test-coverage | Passed |
+| Unmapped | fails-when-tests-are-unmapped | Passed |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed |
 | Unmapped | formaterror-handles-plain-objects | Passed |
 | Unmapped | formaterror-handles-primitives | Passed |
 | Unmapped | formaterror-handles-real-error-objects | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 16.25 | 100.00 |
-| linux | 51 | 0 | 0 | 16.25 | 100.00 |
+| overall | 53 | 0 | 0 | 13.70 | 100.00 |
+| linux | 53 | 0 | 0 | 13.70 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 51 | 0 | 0 | 16.25 | 100.00 |
-| linux | 51 | 0 | 0 | 16.25 | 100.00 |
+| overall | 53 | 0 | 0 | 13.70 | 100.00 |
+| linux | 53 | 0 | 0 | 13.70 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
@@ -18,6 +18,6 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 40 | 40 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 42 | 42 | 0 | 0 | 100.00 |
 
 _For detailed per-test information, see [traceability.md](traceability.md)._

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,43 +4,43 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.003 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,7 +52,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,51 +64,53 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.035 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.022 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.001 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.787 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.205 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.071 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.400 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.354 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.899 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.799 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.012 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.827 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.775 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.019 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.982 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.931 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.903 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.965 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.238 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.650 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.611 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.992 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.437 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.107 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.827 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.974 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.118 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.576 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.834 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.942 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.154 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014145,
+          "duration": 0.006727,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003878,
+          "duration": 0.001342,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007493,
+          "duration": 0.003369,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003224,
+          "duration": 0.000716,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00532,
+          "duration": 0.002451,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005081,
+          "duration": 0.001488,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001872,
+          "duration": 0.00104,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001498,
+          "duration": 0.000999,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003841,
+          "duration": 0.000649,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001286,
+          "duration": 0.001328,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00273,
+          "duration": 0.001299,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.032757,
+          "duration": 0.020451,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001437,
+          "duration": 0.001826,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001194,
+          "duration": 0.001342,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001111,
+          "duration": 0.000863,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007862,
+          "duration": 0.008411,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.035213,
+          "duration": 0.007365,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017654,
+          "duration": 0.021843,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000501,
+          "duration": 0.000658,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004691,
+          "duration": 0.005663,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.000897,
+          "duration": 0.786981,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001533,
+          "duration": 0.001174,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000315,
+          "duration": 0.000157,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.204988,
+          "duration": 0.899146,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.071221,
+          "duration": 0.799025,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,25 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.399962,
+          "duration": 1.011833,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "fails-when-tests-are-unmapped",
+          "name": "fails when tests are unmapped",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.826665,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "fails-when-tests-reference-unknown-requirements",
+          "name": "fails when tests reference unknown requirements",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.774857,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000533,
+          "duration": 0.000166,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000506,
+          "duration": 0.000129,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00444,
+          "duration": 0.0016,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000826,
+          "duration": 0.00035,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020652,
+          "duration": 0.01851,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.353626,
+          "duration": 0.981827,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002043,
+          "duration": 0.00193,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000702,
+          "duration": 0.000668,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001775,
+          "duration": 0.000377,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.930704,
+          "duration": 0.649531,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.902764,
+          "duration": 0.610868,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017613,
+          "duration": 0.012777,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014571,
+          "duration": 0.004025,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.964606,
+          "duration": 0.621238,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.237895,
+          "duration": 0.992016,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000833,
+          "duration": 0.001054,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.436938,
+          "duration": 1.106529,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000609,
+          "duration": 0.000423,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00097,
+          "duration": 0.000781,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.826977,
+          "duration": 0.571827,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.973806,
+          "duration": 0.83399,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.117893,
+          "duration": 0.941703,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.023541,
+          "duration": 0.005284,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004649,
+          "duration": 0.002962,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.575574,
+          "duration": 1.153789,
           "requirements": [],
           "os": "linux"
         }
@@ -555,18 +573,18 @@
   ],
   "totals": {
     "overall": {
-      "passed": 51,
+      "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 16.246750000000002,
+      "duration": 13.704022,
       "rate": 100
     },
     "byOs": {
       "linux": {
-        "passed": 51,
+        "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 16.246750000000002,
+        "duration": 13.704022,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,43 +4,43 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.003 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,7 +52,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,51 +64,53 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.035 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.022 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.001 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.787 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.205 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.071 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.400 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.354 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.899 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.799 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.012 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.827 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.775 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.019 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.982 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.931 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.903 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.965 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.238 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.650 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.611 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.992 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.437 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.107 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.827 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.974 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.118 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.576 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.834 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.942 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.154 |  |  |
 
 </details>

--- a/scripts/__tests__/check-traceability.test.js
+++ b/scripts/__tests__/check-traceability.test.js
@@ -64,3 +64,47 @@ test('passes with coverage and requirement reference', async () => {
   });
   await fs.rm(dir, { recursive: true, force: true });
 });
+
+test('fails when tests are unmapped', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-'));
+  const req = { requirements: [{ id: 'REQ-1', tests: ['t1'] }] };
+  await fs.writeFile(path.join(dir, 'requirements.json'), JSON.stringify(req));
+  const trace = {
+    requirements: [
+      { id: 'REQ-1', tests: [{ id: 't1', status: 'Passed' }] },
+      { id: 'Unmapped', tests: [{ id: 't2', status: 'Passed' }] },
+    ],
+  };
+  await fs.writeFile(path.join(dir, 'trace.json'), JSON.stringify(trace));
+  await initRepo(dir, 'initial REQ-1');
+  await assert.rejects(
+    execFileP(tsx, [script], {
+      cwd: dir,
+      env: { ...process.env, REQ_MAPPING_FILE: 'requirements.json', TRACEABILITY_FILE: 'trace.json' },
+    }),
+    /Tests missing requirement mapping/,
+  );
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('fails when tests reference unknown requirements', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'trace-'));
+  const req = { requirements: [{ id: 'REQ-1', tests: ['t1'] }] };
+  await fs.writeFile(path.join(dir, 'requirements.json'), JSON.stringify(req));
+  const trace = {
+    requirements: [
+      { id: 'REQ-1', tests: [{ id: 't1', status: 'Passed' }] },
+      { id: 'REQ-2', tests: [{ id: 't2', status: 'Passed' }] },
+    ],
+  };
+  await fs.writeFile(path.join(dir, 'trace.json'), JSON.stringify(trace));
+  await initRepo(dir, 'initial REQ-1');
+  await assert.rejects(
+    execFileP(tsx, [script], {
+      cwd: dir,
+      env: { ...process.env, REQ_MAPPING_FILE: 'requirements.json', TRACEABILITY_FILE: 'trace.json' },
+    }),
+    /Tests reference unknown requirements/,
+  );
+  await fs.rm(dir, { recursive: true, force: true });
+});

--- a/scripts/check-traceability.ts
+++ b/scripts/check-traceability.ts
@@ -27,6 +27,21 @@ async function main() {
     process.exit(1);
   }
 
+  const unmapped = groups.find((g) => g.id === 'Unmapped');
+  if (unmapped && Array.isArray(unmapped.tests) && unmapped.tests.length > 0) {
+    const testIds = unmapped.tests.map((t: any) => t.id).join(', ');
+    console.error(`Tests missing requirement mapping: ${testIds}`);
+    process.exit(1);
+  }
+
+  const unknown = groups
+    .filter((g) => g.id !== 'Unmapped' && !reqIds.includes(g.id))
+    .map((g) => g.id);
+  if (unknown.length > 0) {
+    console.error(`Tests reference unknown requirements: ${unknown.join(', ')}`);
+    process.exit(1);
+  }
+
   const commitMsg = execSync('git log -1 --pretty=%B', { encoding: 'utf8' });
   const prBody = process.env.PR_BODY || process.env.GITHUB_PR_BODY || '';
   const combined = commitMsg + '\n' + prBody;

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,62 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.399962" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.204988" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.237895" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.004691" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004440" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000533" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000506" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000826" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.020652" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004649" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.023541" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.032757" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.017613" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.014571" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.017654" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.035213" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.007862" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002043" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000702" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000833" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000501" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000970" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000609" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001111" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.575574" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.436938" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.117893" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.000897" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.902764" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.826977" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.964606" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.930704" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.014145" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003878" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.007493" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.003224" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.005320" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.005081" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001775" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001872" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001498" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.003841" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001286" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002730" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001533" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000315" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.353626" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="1.071221" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.973806" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001437" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001194" classname="test"/>
-	<!-- tests 51 -->
+	<testcase name="fails when requirement lacks test coverage" time="1.011833" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.899146" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.992016" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.826665" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.774857" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.005663" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001600" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000166" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000129" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000350" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.018510" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002962" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005284" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.020451" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.012777" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.004025" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.021843" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007365" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.008411" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001930" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000668" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.001054" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000658" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000781" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000423" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000863" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.153789" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.106529" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.941703" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.786981" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.610868" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.571827" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.621238" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.649531" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.006727" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001342" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.003369" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000716" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002451" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001488" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000377" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001040" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.000999" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000649" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001328" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001299" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001174" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000157" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.981827" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.799025" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.833990" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001826" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001342" classname="test"/>
+	<!-- tests 53 -->
 	<!-- suites 0 -->
-	<!-- pass 51 -->
+	<!-- pass 53 -->
 	<!-- fail 0 -->
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 10651.255379 -->
+	<!-- duration_ms 7772.729043 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- fail traceability check when tests lack requirement mapping or reference unknown requirement IDs
- add unit tests for new traceability validation

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' RUNNER_OS=Linux npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability` *(fails: No tests executed for requirements ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a54e4d55a483299a3655e1903afb14