### PR TITLE
Publish traceability results for visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,4 +136,12 @@ jobs:
         with:
           name: traceability-matrix
           path: artifacts/linux/traceability-matrix.md
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          name: traceability-report
+          path: |
+            artifacts/linux/summary.md
+            artifacts/linux/traceability.md
+            artifacts/linux/traceability.json
       - run: npx tsx scripts/print-pester-traceability.ts >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-traceability.yml
+++ b/.github/workflows/publish-traceability.yml
@@ -1,0 +1,34 @@
+name: Publish Traceability
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: traceability-report
+          path: artifacts/linux
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - run: npm install
+      - run: npx tsx scripts/generate-traceability-badge.ts
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: artifacts/linux
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: release-metadata
           path: artifacts
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: traceability-report
+          path: artifacts
       - name: Create tag
         run: |
           git config user.name github-actions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Source LabVIEW Actions
 
+[![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/open-source-actions/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/open-source-actions/summary.md)
+
 Open Source LabVIEW Actions provides typed GitHub Action wrappers around a unified PowerShell dispatcher for LabVIEW CI/CD tasks. Each adapter (for example `run-unit-tests`) is exposed as its own action and can be called from workflows with `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1`.
 
 For setup and action reference, see the [documentation](docs/index.md). The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md). For a mapping of high-level requirements to the tests that verify them, see [docs/requirements.md](docs/requirements.md).

--- a/artifacts/linux/badge-summary.json
+++ b/artifacts/linux/badge-summary.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"requirements","message":"53/53 (100%)","color":"green"}

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 18.25 | 100.00 |
-| linux | 53 | 0 | 0 | 18.25 | 100.00 |
+| overall | 53 | 0 | 0 | 13.17 | 100.00 |
+| linux | 53 | 0 | 0 | 13.17 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 18.25 | 100.00 |
-| linux | 53 | 0 | 0 | 18.25 | 100.00 |
+| overall | 53 | 0 | 0 | 13.17 | 100.00 |
+| linux | 53 | 0 | 0 | 13.17 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.014 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,19 +46,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
@@ -70,47 +70,47 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.023 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.012 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.146 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.798 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.306 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.103 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.217 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.035 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.042 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.813 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.830 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.919 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.779 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.787 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.029 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.309 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.961 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.903 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.923 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.911 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.120 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.675 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.648 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.915 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.317 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.002 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.834 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.087 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.217 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.600 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.759 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.862 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.051 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010681,
+          "duration": 0.007659,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004203,
+          "duration": 0.005117,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005869,
+          "duration": 0.013914,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001099,
+          "duration": 0.001501,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001371,
+          "duration": 0.002075,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005027,
+          "duration": 0.003369,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001224,
+          "duration": 0.001221,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003946,
+          "duration": 0.004631,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000926,
+          "duration": 0.001628,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00062,
+          "duration": 0.000459,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00191,
+          "duration": 0.001567,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.023062,
+          "duration": 0.015307,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001585,
+          "duration": 0.000892,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001339,
+          "duration": 0.000797,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003864,
+          "duration": 0.000644,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006153,
+          "duration": 0.0054,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011965,
+          "duration": 0.005212,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010128,
+          "duration": 0.009992,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000283,
+          "duration": 0.000785,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004627,
+          "duration": 0.003309,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.146393,
+          "duration": 0.798023,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001411,
+          "duration": 0.00093,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000239,
+          "duration": 0.000878,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.305622,
+          "duration": 0.812814,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.10271,
+          "duration": 0.830033,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.216621,
+          "duration": 0.919245,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.034922,
+          "duration": 0.779453,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.041508,
+          "duration": 0.786544,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000397,
+          "duration": 0.000139,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000258,
+          "duration": 0.000409,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002689,
+          "duration": 0.001759,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000624,
+          "duration": 0.000293,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.02875,
+          "duration": 0.025857,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.308587,
+          "duration": 0.961042,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002196,
+          "duration": 0.001704,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000501,
+          "duration": 0.00072,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000831,
+          "duration": 0.001098,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.903192,
+          "duration": 0.674674,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.92315,
+          "duration": 0.648154,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.019895,
+          "duration": 0.011615,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006382,
+          "duration": 0.001907,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.911206,
+          "duration": 0.653365,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.120242,
+          "duration": 0.914584,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000611,
+          "duration": 0.000533,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.317312,
+          "duration": 1.001683,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00036,
+          "duration": 0.000393,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00073,
+          "duration": 0.000717,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.83369,
+          "duration": 0.572142,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.086652,
+          "duration": 0.758758,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.217445,
+          "duration": 0.862284,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009038,
+          "duration": 0.004749,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002926,
+          "duration": 0.002454,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.59958,
+          "duration": 1.051012,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 18.246552,
+      "duration": 13.165444000000004,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 18.246552,
+        "duration": 13.165444000000004,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.014 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.005 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,19 +46,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
@@ -70,47 +70,47 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.023 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.012 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.146 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.798 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.306 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.103 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.217 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.035 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.042 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.813 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.830 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.919 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.779 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.787 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.029 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.309 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.961 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.903 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.923 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.911 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.120 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.675 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.648 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.915 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.317 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.002 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.834 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.087 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.217 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.600 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.759 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.862 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.051 |  |  |
 
 </details>

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -7,6 +7,8 @@
   "directoryListing": true,
   "skip": [
     "https://open-source-actions.github.io/open-source-actions/",
-    "http://127.0.0.1:8000/"
+    "http://127.0.0.1:8000/",
+    "https://LabVIEW-Community-CI-CD.github.io/open-source-actions/summary.md",
+    "https://labview-community-ci-cd.github.io/open-source-actions/summary.md"
   ]
 }

--- a/scripts/generate-traceability-badge.ts
+++ b/scripts/generate-traceability-badge.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { writeErrorSummary } from './error-handler.ts';
+
+async function main() {
+  const traceFile = process.env.TRACEABILITY_JSON ?? 'artifacts/linux/traceability.json';
+  const outFile = process.env.BADGE_JSON ?? 'artifacts/linux/badge-summary.json';
+  const raw = await fs.readFile(traceFile, 'utf8');
+  const { totals } = JSON.parse(raw);
+  const overall = totals.overall;
+  const total = overall.passed + overall.failed + overall.skipped;
+  const rate = overall.rate ?? (total === 0 ? 0 : Math.round((overall.passed / total) * 100));
+  const color = rate === 100 ? 'green' : rate >= 80 ? 'yellow' : 'red';
+  const badge = {
+    schemaVersion: 1,
+    label: 'requirements',
+    message: `${overall.passed}/${total} (${rate}%)`,
+    color,
+  };
+  await fs.mkdir(path.dirname(outFile), { recursive: true });
+  await fs.writeFile(outFile, JSON.stringify(badge));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch(async err => {
+    await writeErrorSummary(err);
+    process.exit(1);
+  });
+}

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.216621" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.305622" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.120242" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.034922" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.041508" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.004627" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002689" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000397" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000258" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000624" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.028750" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002926" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.009038" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.023062" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.019895" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006382" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.010128" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.011965" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.006153" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002196" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000501" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000611" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000283" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000730" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000360" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.003864" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.599580" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.317312" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.217445" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.146393" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.923150" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.833690" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.911206" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.903192" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010681" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004203" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.005869" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001099" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001371" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.005027" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000831" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001224" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.003946" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000926" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000620" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001910" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001411" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000239" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.308587" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="1.102710" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.086652" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001585" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001339" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.919245" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.812814" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.914584" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.779453" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.786544" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.003309" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001759" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000139" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000409" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000293" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.025857" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002454" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.004749" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.015307" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.011615" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.001907" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009992" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.005212" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.005400" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001704" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000720" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000533" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000785" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000717" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000393" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000644" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.051012" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.001683" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.862284" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.798023" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.648154" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.572142" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.653365" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.674674" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.007659" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005117" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.013914" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001501" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002075" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003369" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001098" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001221" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004631" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001628" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000459" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001567" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.000930" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000878" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.961042" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.830033" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.758758" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000892" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000797" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 10515.067014 -->
+	<!-- duration_ms 7572.134351 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- add badge generator script and link in README
- upload traceability artifacts in CI and release
- publish summary and traceability reports to GitHub Pages with a workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npx tsx scripts/generate-traceability-badge.ts`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a552d03fd4832999a47498a9f07699