### PR TITLE
Integrate CI evidence into release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,4 +144,10 @@ jobs:
             artifacts/linux/summary.md
             artifacts/linux/traceability.md
             artifacts/linux/traceability.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: ${{ (success() || failure()) && !cancelled() }}
+        with:
+          name: ci-evidence
+          path: ci_evidence.txt
+          if-no-files-found: error
       - run: npx tsx scripts/print-pester-traceability.ts >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,36 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: traceability-report
           path: artifacts
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: ci-evidence
+          path: artifacts
+      - name: Evaluate CI evidence
+        id: evidence
+        run: |
+          CI_EVIDENCE=$(cat artifacts/ci_evidence.txt)
+          echo "ci_evidence=$CI_EVIDENCE" >> "$GITHUB_OUTPUT"
+          if echo "$CI_EVIDENCE" | jq -e '.req_status | to_entries | any(.value == "FAIL")'; then
+            echo 'Requirement failure detected in CI evidence.' >&2
+            exit 1
+          fi
+      - name: Prepare release notes
+        id: notes
+        run: |
+          TITLE="${{ steps.meta.outputs.title }}"
+          CI_EVIDENCE=$(jq . artifacts/ci_evidence.txt)
+          {
+            echo "body<<'EOF'"
+            echo "$TITLE"
+            echo ""
+            echo "CI Evidence:"
+            echo '```json'
+            echo "$CI_EVIDENCE"
+            echo '```'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Create tag
         run: |
           git config user.name github-actions
@@ -49,7 +79,7 @@ jobs:
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           release_name: ${{ steps.meta.outputs.title }}
-          body: ${{ steps.meta.outputs.title }}
+          body: ${{ steps.notes.outputs.body }}
       - name: Upload artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/artifacts/linux/badge-summary.json
+++ b/artifacts/linux/badge-summary.json
@@ -1,1 +1,0 @@
-{"schemaVersion":1,"label":"requirements","message":"53/53 (100%)","color":"green"}

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.17 | 100.00 |
-| linux | 53 | 0 | 0 | 13.17 | 100.00 |
+| overall | 53 | 0 | 0 | 13.14 | 100.00 |
+| linux | 53 | 0 | 0 | 13.14 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.17 | 100.00 |
-| linux | 53 | 0 | 0 | 13.17 | 100.00 |
+| overall | 53 | 0 | 0 | 13.14 | 100.00 |
+| linux | 53 | 0 | 0 | 13.14 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.014 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,59 +58,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.813 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.830 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.919 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.779 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.787 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.788 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.689 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.909 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.756 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.961 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.972 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.675 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.648 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.915 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.648 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.647 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.618 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.934 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.935 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.759 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.862 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.614 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.859 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.852 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.051 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.081 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007659,
+          "duration": 0.009869,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005117,
+          "duration": 0.015337,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013914,
+          "duration": 0.005175,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001501,
+          "duration": 0.001316,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002075,
+          "duration": 0.000979,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003369,
+          "duration": 0.003578,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001221,
+          "duration": 0.001392,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004631,
+          "duration": 0.001158,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001628,
+          "duration": 0.002022,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000459,
+          "duration": 0.001525,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001567,
+          "duration": 0.000997,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015307,
+          "duration": 0.018877,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000892,
+          "duration": 0.000926,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000797,
+          "duration": 0.000724,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000644,
+          "duration": 0.000732,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0054,
+          "duration": 0.005909,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005212,
+          "duration": 0.004333,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009992,
+          "duration": 0.011202,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000785,
+          "duration": 0.000198,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003309,
+          "duration": 0.002179,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.798023,
+          "duration": 0.873706,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00093,
+          "duration": 0.001514,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000878,
+          "duration": 0.000146,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.812814,
+          "duration": 0.787538,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.830033,
+          "duration": 0.688735,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.919245,
+          "duration": 0.908898,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.779453,
+          "duration": 0.755718,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.786544,
+          "duration": 0.812665,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000139,
+          "duration": 0.000356,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000409,
+          "duration": 0.000221,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001759,
+          "duration": 0.001688,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000293,
+          "duration": 0.000424,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.025857,
+          "duration": 0.014794,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.961042,
+          "duration": 0.971555,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001704,
+          "duration": 0.001799,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00072,
+          "duration": 0.000507,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001098,
+          "duration": 0.000686,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.674674,
+          "duration": 0.648048,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.648154,
+          "duration": 0.646948,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011615,
+          "duration": 0.020004,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001907,
+          "duration": 0.011995,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.653365,
+          "duration": 0.617919,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.914584,
+          "duration": 0.933509,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000533,
+          "duration": 0.000288,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.001683,
+          "duration": 0.934641,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000393,
+          "duration": 0.00028,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000717,
+          "duration": 0.000611,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.572142,
+          "duration": 0.614415,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.758758,
+          "duration": 0.85877,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.862284,
+          "duration": 0.851625,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004749,
+          "duration": 0.00663,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002454,
+          "duration": 0.001583,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.051012,
+          "duration": 1.081413,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 13.165444000000004,
+      "duration": 13.138056999999996,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 13.165444000000004,
+        "duration": 13.138056999999996,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.014 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,59 +58,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.813 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.830 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.919 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.779 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.787 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.788 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.689 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.909 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.756 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.961 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.972 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.675 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.648 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.915 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.648 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.647 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.618 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.934 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.935 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.572 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.759 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.862 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.614 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.859 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.852 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.051 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.081 |  |  |
 
 </details>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,6 +2,8 @@
 
 The **OpenSourceActions** module and composite action follow [Semantic Versioning](https://semver.org/) in the format **MAJOR.MINOR.PATCH**. The version is stored in `OpenSourceActions.psd1` and mirrored in repository tags.
 
+Each release automatically embeds the CI evidence JSON in the release notes, providing a summary of tested requirements and the commit used. The publish job validates this evidence and aborts the release if any requirement reports `FAIL`.
+
 ## MAJOR version
 
 Used for incompatible changes such as removing or renaming actions, changing required inputs, or altering behavior in a way that breaks existing workflows.

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.919245" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.812814" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.914584" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.779453" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.786544" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003309" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001759" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000139" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000409" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000293" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.025857" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002454" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.004749" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.015307" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.011615" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.001907" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.009992" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.005212" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.005400" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001704" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000720" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000533" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000785" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000717" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000393" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000644" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.051012" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.001683" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.862284" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.798023" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.648154" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.572142" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.653365" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.674674" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.007659" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005117" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.013914" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001501" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002075" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003369" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001098" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001221" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004631" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001628" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000459" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001567" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.000930" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000878" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.961042" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.830033" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.758758" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000892" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000797" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.908898" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.787538" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.933509" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.755718" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.812665" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002179" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001688" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000356" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000221" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000424" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.014794" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001583" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006630" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.018877" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020004" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.011995" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.011202" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004333" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.005909" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001799" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000507" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000288" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000198" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000611" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000280" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000732" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.081413" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.934641" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.851625" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.873706" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.646948" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.614415" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.617919" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.648048" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009869" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.015337" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.005175" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001316" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000979" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003578" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000686" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001392" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001158" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.002022" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001525" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.000997" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001514" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000146" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.971555" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.688735" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.858770" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000926" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000724" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7572.134351 -->
+	<!-- duration_ms 7550.654222 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- upload CI evidence from CI report job
- gate releases on CI evidence and embed evidence into release notes
- document release validation with CI evidence

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a5554f4860832999ebcb3dee5f19bb