### PR TITLE
docs: reinforce requirement traceability guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,19 @@ npx --yes linkinator README.md docs scripts --config linkinator.config.json
 
 ## Requirement Traceability
 
-Each requirement is tracked as an issue or entry in `requirements.json`. Every
-code change must reference the requirement it addresses, and each requirement
-must be covered by at least one automated test. The CI pipeline checks these
-links and reports missing associations.
+Each requirement is tracked as an issue or entry in `requirements.json`. Whenever
+you introduce a new feature or fix, add a new requirement or update an existing
+ID in `requirements.json` accordingly. Every code change must reference the
+requirement it addresses, and each requirement must be covered by at least one
+automated test.
+
+Embed the relevant requirement ID in new test cases; the testing framework
+parses these annotations when generating the traceability report.
+
+During code reviews, missing requirement IDs or missing tests for a change are
+must-fix issues. The CI pipeline checks these links and reports missing
+associations.
 
 ## Commit Messages
 
-Each commit should reference at least one requirement ID defined in `requirements.json` (for example, `REQ-001`). Pull requests are automatically checked for this convention.
+Each commit should reference at least one requirement ID defined in `requirements.json` (for example, `REQ-001`). Pull requests lacking requirement references or associated tests must be updated before merging.

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.14 | 100.00 |
-| linux | 53 | 0 | 0 | 13.14 | 100.00 |
+| overall | 53 | 0 | 0 | 19.10 | 100.00 |
+| linux | 53 | 0 | 0 | 19.10 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.14 | 100.00 |
-| linux | 53 | 0 | 0 | 13.14 | 100.00 |
+| overall | 53 | 0 | 0 | 19.10 | 100.00 |
+| linux | 53 | 0 | 0 | 19.10 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.196 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.004 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.788 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.689 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.909 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.756 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.972 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.236 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.196 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.406 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.105 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.262 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.015 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.024 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.344 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.005 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.648 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.647 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.618 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.934 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.861 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.962 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.014 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.922 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.361 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.935 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.336 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.614 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.859 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.852 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.081 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.802 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.145 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.444 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.346 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009869,
+          "duration": 0.010654,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015337,
+          "duration": 0.002258,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005175,
+          "duration": 0.00565,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001316,
+          "duration": 0.001244,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000979,
+          "duration": 0.00091,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003578,
+          "duration": 0.001612,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001392,
+          "duration": 0.001559,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001158,
+          "duration": 0.003239,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002022,
+          "duration": 0.000726,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001525,
+          "duration": 0.000549,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000997,
+          "duration": 0.001895,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.018877,
+          "duration": 0.018942,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000926,
+          "duration": 0.001637,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000724,
+          "duration": 0.002179,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000732,
+          "duration": 0.000572,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005909,
+          "duration": 0.009305,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004333,
+          "duration": 0.007855,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011202,
+          "duration": 0.009939,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000198,
+          "duration": 0.000858,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002179,
+          "duration": 0.004349,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.873706,
+          "duration": 1.196136,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001514,
+          "duration": 0.003923,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000146,
+          "duration": 0.000209,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.787538,
+          "duration": 1.236475,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.688735,
+          "duration": 1.195666,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.908898,
+          "duration": 1.406053,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.755718,
+          "duration": 1.104866,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.812665,
+          "duration": 1.261696,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000356,
+          "duration": 0.000555,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000221,
+          "duration": 0.00433,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001688,
+          "duration": 0.015097,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000424,
+          "duration": 0.000839,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014794,
+          "duration": 0.023741,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.971555,
+          "duration": 1.34373,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001799,
+          "duration": 0.004553,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000507,
+          "duration": 0.000483,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000686,
+          "duration": 0.000842,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.648048,
+          "duration": 0.861237,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.646948,
+          "duration": 0.961907,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020004,
+          "duration": 0.015092,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011995,
+          "duration": 0.014363,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.617919,
+          "duration": 0.9219,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.933509,
+          "duration": 1.361361,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000288,
+          "duration": 0.000444,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.934641,
+          "duration": 1.335721,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00028,
+          "duration": 0.000486,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000611,
+          "duration": 0.001717,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.614415,
+          "duration": 0.802157,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.85877,
+          "duration": 1.145154,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.851625,
+          "duration": 1.444261,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00663,
+          "duration": 0.004997,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001583,
+          "duration": 0.002732,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.081413,
+          "duration": 1.346136,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 13.138056999999996,
+      "duration": 19.104791000000002,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 13.138056999999996,
+        "duration": 19.104791000000002,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.196 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.004 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.788 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.689 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.909 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.756 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.972 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.236 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.196 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.406 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.105 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.262 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.015 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.024 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.344 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.005 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.648 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.647 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.618 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.934 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.861 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.962 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.014 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.922 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.361 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.935 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.336 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.614 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.859 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.852 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.081 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.802 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.145 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.444 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.346 |  |  |
 
 </details>

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -67,13 +67,13 @@ Commit `test-results/*` and `artifacts/linux/*` along with your source changes. 
 
 ### Pester properties
 
-Pester tests should record traceability metadata by adding `Add-TestResult -Property` calls in each `It` block. At minimum, include an `Owner` and an `Evidence` path:
+Pester tests should record traceability metadata by adding `Add-TestResult -Property` calls in each `It` block. At minimum, include an `Owner`, a `Requirement` ID, and an `Evidence` path so the framework can link tests back to requirements:
 
 ```powershell
-It "does something" {
-    Add-TestResult -Property @{ Owner = 'DevTools'; Evidence = 'tests/pester/example.Tests.ps1' }
+It "[REQ-123] does something" {
+    Add-TestResult -Property @{ Owner = 'DevTools'; Requirement = 'REQ-123'; Evidence = 'tests/pester/example.Tests.ps1' }
     # test body
 }
 ```
 
-These properties are preferred over naming conventions when `scripts/generate-ci-summary.ts` builds the CI report.
+For other test frameworks, prefix the test name with `[REQ-123]` or use an equivalent mechanism to embed the requirement ID. These properties are preferred over naming conventions when `scripts/generate-ci-summary.ts` builds the CI report.

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.908898" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.787538" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.933509" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.755718" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.812665" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002179" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001688" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000356" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000221" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000424" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.014794" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001583" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006630" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.018877" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020004" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.011995" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.011202" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004333" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.005909" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001799" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000507" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000288" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000198" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000611" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000280" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000732" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.081413" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.934641" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.851625" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.873706" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.646948" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.614415" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.617919" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.648048" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009869" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.015337" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.005175" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001316" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000979" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003578" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000686" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001392" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001158" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.002022" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001525" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.000997" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001514" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000146" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.971555" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.688735" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.858770" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000926" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000724" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.406053" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.236475" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.361361" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.104866" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.261696" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.004349" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.015097" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000555" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.004330" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000839" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.023741" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002732" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.004997" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.018942" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015092" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.014363" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009939" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007855" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.009305" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.004553" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000483" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000444" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000858" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001717" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000486" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000572" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.346136" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.335721" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.444261" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.196136" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.961907" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.802157" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.921900" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.861237" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010654" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002258" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.005650" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001244" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000910" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001612" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000842" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001559" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.003239" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000726" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000549" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001895" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.003923" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000209" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.343730" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="1.195666" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.145154" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001637" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002179" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7550.654222 -->
+	<!-- duration_ms 10737.643007 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- require updates to `requirements.json` and embedded IDs in tests when adding features or fixes
- document embedding requirement IDs in Pester test metadata
- flag missing requirement IDs or tests as must-fix in reviews

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability` *(warns: No tests executed for requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68a557b6e9d88329880d0571cef30d8e