### PR TITLE
chore: prepare release v2.1

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 14.30 | 100.00 |
-| linux | 53 | 0 | 0 | 14.30 | 100.00 |
+| overall | 53 | 0 | 0 | 21.68 | 100.00 |
+| linux | 53 | 0 | 0 | 21.68 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 14.30 | 100.00 |
-| linux | 53 | 0 | 0 | 14.30 | 100.00 |
+| overall | 53 | 0 | 0 | 21.68 | 100.00 |
+| linux | 53 | 0 | 0 | 21.68 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,7 +4,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
@@ -16,13 +16,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.033 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.430 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.921 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.842 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.987 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.851 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.890 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.469 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.290 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.278 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.393 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.025 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.983 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.585 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.673 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.674 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.991 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.987 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.018 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.127 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.290 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.026 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.563 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.949 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.047 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.202 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.990 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.344 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.431 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.667 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007404,
+          "duration": 0.010882,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003283,
+          "duration": 0.002977,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004481,
+          "duration": 0.006175,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001119,
+          "duration": 0.001719,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001379,
+          "duration": 0.001302,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002495,
+          "duration": 0.003358,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000935,
+          "duration": 0.002367,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001095,
+          "duration": 0.001772,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000633,
+          "duration": 0.001575,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000485,
+          "duration": 0.00121,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001205,
+          "duration": 0.003422,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013626,
+          "duration": 0.016381,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00115,
+          "duration": 0.002063,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000817,
+          "duration": 0.001804,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000471,
+          "duration": 0.004705,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003243,
+          "duration": 0.018374,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005827,
+          "duration": 0.014811,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007478,
+          "duration": 0.03297,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000243,
+          "duration": 0.000329,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002607,
+          "duration": 0.004749,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.873548,
+          "duration": 1.429901,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001006,
+          "duration": 0.00229,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00025,
+          "duration": 0.000361,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.920763,
+          "duration": 1.468834,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.841711,
+          "duration": 1.289741,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.987486,
+          "duration": 1.462719,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.850955,
+          "duration": 1.278351,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.890402,
+          "duration": 1.392509,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000379,
+          "duration": 0.000364,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000264,
+          "duration": 0.000297,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002916,
+          "duration": 0.002436,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000483,
+          "duration": 0.000581,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.024922,
+          "duration": 0.037991,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.982954,
+          "duration": 1.58502,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001338,
+          "duration": 0.003823,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000592,
+          "duration": 0.000765,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00052,
+          "duration": 0.000687,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.673491,
+          "duration": 0.986726,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.673576,
+          "duration": 1.144369,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011667,
+          "duration": 0.013216,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005801,
+          "duration": 0.017819,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.652577,
+          "duration": 1.126762,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.991048,
+          "duration": 1.290195,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000349,
+          "duration": 0.000437,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.025666,
+          "duration": 1.563471,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000282,
+          "duration": 0.000413,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000542,
+          "duration": 0.000453,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.618098,
+          "duration": 0.989922,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.948939,
+          "duration": 1.343926,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.047343,
+          "duration": 1.430747,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007846,
+          "duration": 0.007352,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003823,
+          "duration": 0.005843,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.202261,
+          "duration": 1.666957,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 14.303773999999999,
+      "duration": 21.678223,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 14.303773999999999,
+        "duration": 21.678223,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,7 +4,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
@@ -16,13 +16,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.033 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.874 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.430 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.921 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.842 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.987 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.851 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.890 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.469 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 1.290 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.278 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.393 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.025 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.983 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.585 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.673 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.674 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.653 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.991 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.987 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.018 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.127 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.290 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.026 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.563 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.949 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.047 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.202 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.990 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.344 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.431 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.667 |  |  |
 
 </details>

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
   "major": 2,
-  "minor": 0,
+  "minor": 1,
   "patch": 0,
-  "title": "Launch"
+  "title": "v2.1"
 }

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.926063" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.868047" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.913327" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.823509" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.837907" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003595" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001543" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000211" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000295" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000623" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.026798" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001873" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005317" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.008968" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.008448" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.002581" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.004714" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004226" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.006798" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000944" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000359" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000315" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000148" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000298" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000190" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000299" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.095233" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.147529" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.882268" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.857886" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.693369" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.608839" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.635028" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.653306" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.007950" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002895" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.008782" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000793" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000885" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.007889" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000389" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003661" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002079" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001635" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000943" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002484" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.000964" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000150" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.980667" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.860653" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.748811" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001713" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000853" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.462719" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.468834" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.290195" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.278351" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.392509" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.004749" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002436" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000364" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000297" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000581" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.037991" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005843" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.007352" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.016381" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013216" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.017819" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.032970" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014811" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.018374" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003823" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000765" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000437" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000329" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000453" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000413" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.004705" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.666957" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.563471" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.430747" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.429901" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.144369" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.989922" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.126762" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.986726" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010882" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002977" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.006175" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001719" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001302" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003358" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000687" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002367" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001772" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001575" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001210" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.003422" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002290" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000361" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.585020" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="1.289741" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.343926" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.002063" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001804" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7792.982737 -->
+	<!-- duration_ms 12301.896941 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- update release metadata to version 2.1.0
- regenerate summary and traceability artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `RUNNER_OS=linux npm run derive:registry`
- `RUNNER_OS=linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `RUNNER_OS=linux npm run check:traceability`
- `./scripts/check-commit-requirements.sh <base_sha>`

------
https://chatgpt.com/codex/tasks/task_e_68a561e28e3c83298f179f982216b876