### PR TITLE
ci: delete npm proxy settings before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
+      - run: npm config delete proxy
+      - run: npm config delete https-proxy
       - run: npm install
       - run: npm run link:check
       - run: npm run derive:registry


### PR DESCRIPTION
## Summary
- delete npm proxy and https-proxy configs in validate-artifacts workflow before running npm install

## Testing
- `npm config delete proxy`
- `npm config delete https-proxy`
- `npm install`
- `npm run check:node`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh 301d8f75ed9edcc0210216f98065c83b144513aa`


------
https://chatgpt.com/codex/tasks/task_e_68a56bf50ac083299e0f80b26247f82f