### PR TITLE
chore: remove proxy config from npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-proxy=http://proxy:8080
-https-proxy=http://proxy:8080

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.12 | 100.00 |
-| linux | 53 | 0 | 0 | 13.12 | 100.00 |
+| overall | 53 | 0 | 0 | 13.33 | 100.00 |
+| linux | 53 | 0 | 0 | 13.33 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.12 | 100.00 |
-| linux | 53 | 0 | 0 | 13.12 | 100.00 |
+| overall | 53 | 0 | 0 | 13.33 | 100.00 |
+| linux | 53 | 0 | 0 | 13.33 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -16,7 +16,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -58,13 +58,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
@@ -72,45 +72,45 @@
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.012 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.790 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.823 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.932 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.719 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.951 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.715 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.732 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.822 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.824 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.007 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.800 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.899 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.028 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.024 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.007 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.955 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.599 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.608 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.605 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.855 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.655 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.627 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.815 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.990 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.002 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.554 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.826 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.902 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.010 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.194 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.999 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.548 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.796 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.934 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.063 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010755,
+          "duration": 0.010948,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002216,
+          "duration": 0.00183,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004175,
+          "duration": 0.004994,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001226,
+          "duration": 0.001459,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00103,
+          "duration": 0.001188,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001918,
+          "duration": 0.002027,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000868,
+          "duration": 0.000928,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001232,
+          "duration": 0.001268,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000927,
+          "duration": 0.000851,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000431,
+          "duration": 0.000677,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001136,
+          "duration": 0.002002,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011155,
+          "duration": 0.010554,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001078,
+          "duration": 0.000906,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002202,
+          "duration": 0.000754,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000372,
+          "duration": 0.00435,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010242,
+          "duration": 0.008069,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00505,
+          "duration": 0.009072,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003827,
+          "duration": 0.012034,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000124,
+          "duration": 0.000245,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003522,
+          "duration": 0.005693,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.789602,
+          "duration": 0.822725,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001688,
+          "duration": 0.000959,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000368,
+          "duration": 0.000197,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.931927,
+          "duration": 0.822134,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.71893,
+          "duration": 0.823542,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.951202,
+          "duration": 1.006851,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.714522,
+          "duration": 0.800267,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.731856,
+          "duration": 0.899081,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000398,
+          "duration": 0.000434,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000863,
+          "duration": 0.000176,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001448,
+          "duration": 0.006811,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000328,
+          "duration": 0.00063,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.027973,
+          "duration": 0.015084,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.02414,
+          "duration": 0.955353,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000857,
+          "duration": 0.001302,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000211,
+          "duration": 0.000462,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000363,
+          "duration": 0.000515,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.599006,
+          "duration": 0.654671,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.608476,
+          "duration": 0.626721,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005638,
+          "duration": 0.008513,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00173,
+          "duration": 0.012493,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.604866,
+          "duration": 0.620521,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.855243,
+          "duration": 0.814654,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000151,
+          "duration": 0.000267,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.989587,
+          "duration": 0.998619,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001607,
+          "duration": 0.000217,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000863,
+          "duration": 0.000351,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.55395,
+          "duration": 0.548336,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.82557,
+          "duration": 0.795783,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.901581,
+          "duration": 0.933954,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004081,
+          "duration": 0.008362,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009655,
+          "duration": 0.002118,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.194424,
+          "duration": 1.063374,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 13.116590000000002,
+      "duration": 13.325325999999999,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 13.116590000000002,
+        "duration": 13.325325999999999,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -16,7 +16,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -58,13 +58,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
@@ -72,45 +72,45 @@
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.012 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.790 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.823 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.932 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.719 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.951 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.715 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.732 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.822 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.824 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.007 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.800 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.899 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.028 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.024 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.007 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.955 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.599 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.608 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.605 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.855 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.655 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.627 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.621 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.815 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.990 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.002 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.554 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.826 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.902 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.010 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.194 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.999 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.548 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.796 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.934 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.063 |  |  |
 
 </details>

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.951202" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.931927" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.855243" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.714522" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.731856" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003522" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001448" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000398" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000863" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000328" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.027973" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.009655" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.004081" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.011155" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.005638" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.001730" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.003827" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.005050" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.010242" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000857" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000211" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000151" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000124" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000863" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.001607" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000372" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.194424" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.989587" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.901581" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.789602" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.608476" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.553950" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.604866" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.599006" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010755" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002216" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004175" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001226" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001030" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001918" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000363" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000868" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001232" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000927" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000431" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001136" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001688" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000368" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.024140" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.718930" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.825570" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001078" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002202" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.006851" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.822134" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.814654" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.800267" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.899081" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.005693" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.006811" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000434" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000176" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000630" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.015084" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002118" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.008362" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.010554" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.008513" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.012493" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.012034" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009072" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.008069" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001302" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000462" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000267" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000245" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000351" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000217" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.004350" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.063374" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.998619" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.933954" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.822725" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.626721" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.548336" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.620521" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.654671" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010948" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001830" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.004994" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001459" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001188" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002027" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000515" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000928" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001268" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000851" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000677" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002002" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.000959" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000197" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.955353" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.823542" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.795783" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000906" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000754" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7408.182483 -->
+	<!-- duration_ms 7601.712673 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- remove obsolete proxy settings to allow npm install to run cleanly
- regenerate CI summary and traceability artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' RUNNER_OS=linux npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh badc2afd8e0e19ac232f4e44c7170c08082e4b05`


------
https://chatgpt.com/codex/tasks/task_e_68a570d0e6c0832986c36288286025ef