### PR TITLE
Generate CI evidence file

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.80 | 100.00 |
-| linux | 53 | 0 | 0 | 13.80 | 100.00 |
+| overall | 53 | 0 | 0 | 10.39 | 100.00 |
+| linux | 53 | 0 | 0 | 10.39 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 13.80 | 100.00 |
-| linux | 53 | 0 | 0 | 13.80 | 100.00 |
+| overall | 53 | 0 | 0 | 10.39 | 100.00 |
+| linux | 53 | 0 | 0 | 10.39 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.025 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.774 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.827 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.829 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.898 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.778 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.784 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.014 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.042 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.670 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.650 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.636 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.107 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.119 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.592 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.838 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.998 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.099 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008968,
+          "duration": 0.005646,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001408,
+          "duration": 0.003023,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008306,
+          "duration": 0.000749,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001214,
+          "duration": 0.000839,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000968,
+          "duration": 0.000731,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001494,
+          "duration": 0.00165,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002986,
+          "duration": 0.000859,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001124,
+          "duration": 0.002425,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002088,
+          "duration": 0.001168,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001914,
+          "duration": 0.000319,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00277,
+          "duration": 0.000802,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011462,
+          "duration": 0.007431,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001597,
+          "duration": 0.00093,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001139,
+          "duration": 0.000904,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000557,
+          "duration": 0.002788,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004296,
+          "duration": 0.003964,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007613,
+          "duration": 0.002905,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.02512,
+          "duration": 0.003243,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000251,
+          "duration": 0.000159,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006475,
+          "duration": 0.001715,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.773966,
+          "duration": 0.646581,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001224,
+          "duration": 0.001268,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000183,
+          "duration": 0.000176,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.827186,
+          "duration": 0.609715,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.828824,
+          "duration": 0.580007,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.898053,
+          "duration": 0.623853,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.777777,
+          "duration": 0.552213,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.783701,
+          "duration": 0.567205,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00032,
+          "duration": 0.000266,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0006,
+          "duration": 0.000157,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002669,
+          "duration": 0.002781,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000524,
+          "duration": 0.000296,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013705,
+          "duration": 0.011002,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.04224,
+          "duration": 0.680039,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001577,
+          "duration": 0.000768,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000621,
+          "duration": 0.000258,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000351,
+          "duration": 0.000422,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.669986,
+          "duration": 0.706051,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.64982,
+          "duration": 0.685036,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017783,
+          "duration": 0.005671,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012297,
+          "duration": 0.001624,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.636056,
+          "duration": 0.700181,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.107123,
+          "duration": 0.62333,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000491,
+          "duration": 0.000221,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.119299,
+          "duration": 0.695725,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000299,
+          "duration": 0.000171,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000591,
+          "duration": 0.000364,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.592186,
+          "duration": 0.584806,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.838308,
+          "duration": 0.56796,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.997782,
+          "duration": 0.696729,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00889,
+          "duration": 0.005319,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004416,
+          "duration": 0.001697,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.098893,
+          "duration": 0.794109,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 13.799491,
+      "duration": 10.388251,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 13.799491,
+        "duration": 10.388251,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,83 +34,83 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.025 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.774 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.827 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.829 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.898 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.778 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.784 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.014 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.042 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.670 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.650 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.018 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.636 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.107 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.119 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.592 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.838 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.998 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.099 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,0 +1,1 @@
+{"pipeline":"Unknown","git_sha":"68edd62ba773e0368efdb9cb82676172034aee1b","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -7,12 +7,14 @@ import { pathToFileURL } from 'url';
 import { glob } from 'glob';
 import AdmZip from 'adm-zip';
 import { writeErrorSummary } from './error-handler.ts';
+import { execSync } from 'child_process';
 import {
   buildSummary,
   summaryToMarkdown,
   requirementsSummaryToMarkdown,
   requirementTestsToMarkdown,
   groupToMarkdown,
+  computeStatusCounts,
   TestCase,
   RequirementGroup,
 } from './summary/index.ts';
@@ -135,6 +137,23 @@ async function main() {
       redact(`### Test Traceability Matrix\n\n${groupToMarkdown(list)}`),
     );
   }
+
+  const gitSha =
+    process.env.GITHUB_SHA || execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  const reqStatus: Record<string, string> = {};
+  for (const g of groups) {
+    if (g.id === 'Unmapped') continue;
+    const { failed, total } = computeStatusCounts(g.tests);
+    reqStatus[g.id] = failed > 0 || total === 0 ? 'FAIL' : 'PASS';
+  }
+  const evidence = {
+    pipeline: process.env.PIPELINE_NAME || 'Unknown',
+    git_sha: gitSha,
+    req_status: reqStatus,
+  };
+  const evidenceStr = JSON.stringify(evidence);
+  await fs.writeFile('ci_evidence.txt', evidenceStr);
+  console.log(`CI_EVIDENCE=${evidenceStr}`);
 
   try {
     await fs.access(evidenceDir, fsConstants.R_OK);

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.898053" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.827186" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.107123" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.777777" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.783701" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.006475" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002669" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000320" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000600" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000524" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.013705" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004416" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.008890" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.011462" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.017783" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.012297" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.025120" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007613" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.004296" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001577" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000621" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000491" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000251" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000591" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000299" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000557" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.098893" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.119299" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.997782" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.773966" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.649820" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.592186" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.636056" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.669986" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.008968" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001408" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.008306" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001214" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000968" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001494" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000351" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002986" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001124" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.002088" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001914" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002770" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001224" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000183" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.042240" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.828824" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.838308" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001597" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001139" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.623853" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.609715" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.623330" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.552213" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.567205" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.001715" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002781" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000266" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000157" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000296" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.011002" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001697" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005319" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.007431" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.005671" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.001624" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.003243" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.002905" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.003964" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000768" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000258" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000221" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000159" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000364" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000171" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.002788" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="0.794109" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.695725" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.696729" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.646581" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.685036" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.584806" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.700181" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.706051" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.005646" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003023" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.000749" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000839" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000731" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001650" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000422" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000859" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002425" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001168" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000319" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.000802" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001268" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000176" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.680039" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.580007" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.567960" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000930" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000904" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7807.863601 -->
+	<!-- duration_ms 13396.922998 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- produce a CI evidence JSON file and emit CI_EVIDENCE output

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh HEAD^`
- `npm run check:traceability` *(fails: No tests executed for many requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68a578916c5c83298cff4809d82e1009