### PR TITLE
Enable JUnit output for Pester tests

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 10.39 | 100.00 |
-| linux | 53 | 0 | 0 | 10.39 | 100.00 |
+| overall | 53 | 0 | 0 | 14.72 | 100.00 |
+| linux | 53 | 0 | 0 | 14.72 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 10.39 | 100.00 |
-| linux | 53 | 0 | 0 | 10.39 | 100.00 |
+| overall | 53 | 0 | 0 | 14.72 | 100.00 |
+| linux | 53 | 0 | 0 | 14.72 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,25 +4,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.022 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.005 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,13 +34,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,65 +52,65 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.005 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.852 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.003 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.815 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.873 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.858 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.975 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.020 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.704 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.677 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.841 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.912 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.053 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.654 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.967 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.171 |  |  |
 | Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.207 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005646,
+          "duration": 0.021933,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003023,
+          "duration": 0.002481,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000749,
+          "duration": 0.001787,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000839,
+          "duration": 0.004715,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000731,
+          "duration": 0.001244,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00165,
+          "duration": 0.003127,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000859,
+          "duration": 0.0016,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002425,
+          "duration": 0.001703,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001168,
+          "duration": 0.001875,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000319,
+          "duration": 0.000691,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000802,
+          "duration": 0.002472,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007431,
+          "duration": 0.010589,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00093,
+          "duration": 0.001177,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000904,
+          "duration": 0.000902,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002788,
+          "duration": 0.000315,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003964,
+          "duration": 0.010642,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002905,
+          "duration": 0.009311,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003243,
+          "duration": 0.005139,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000159,
+          "duration": 0.000204,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001715,
+          "duration": 0.003672,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.646581,
+          "duration": 0.851717,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001268,
+          "duration": 0.001087,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000176,
+          "duration": 0.000139,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.609715,
+          "duration": 1.002962,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.580007,
+          "duration": 0.81481,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.623853,
+          "duration": 0.873456,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.552213,
+          "duration": 0.85822,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.567205,
+          "duration": 0.974517,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000266,
+          "duration": 0.000461,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000157,
+          "duration": 0.000195,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002781,
+          "duration": 0.003467,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000296,
+          "duration": 0.000319,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011002,
+          "duration": 0.01969,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.680039,
+          "duration": 1.019858,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000768,
+          "duration": 0.001569,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000258,
+          "duration": 0.000476,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000422,
+          "duration": 0.00061,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.706051,
+          "duration": 0.704068,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.685036,
+          "duration": 0.677472,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005671,
+          "duration": 0.015126,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001624,
+          "duration": 0.003244,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.700181,
+          "duration": 0.840874,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.62333,
+          "duration": 0.912244,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000221,
+          "duration": 0.000386,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.695725,
+          "duration": 1.053016,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000171,
+          "duration": 0.000223,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000364,
+          "duration": 0.000342,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.584806,
+          "duration": 0.653956,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.56796,
+          "duration": 0.966558,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.696729,
+          "duration": 1.171314,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005319,
+          "duration": 0.004862,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001697,
+          "duration": 0.003848,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 0.794109,
+          "duration": 1.20675,
           "requirements": [],
           "os": "linux"
         }
@@ -576,7 +576,7 @@
       "passed": 53,
       "failed": 0,
       "skipped": 0,
-      "duration": 10.388251,
+      "duration": 14.723414999999996,
       "rate": 100
     },
     "byOs": {
@@ -584,7 +584,7 @@
         "passed": 53,
         "failed": 0,
         "skipped": 0,
-        "duration": 10.388251,
+        "duration": 14.723414999999996,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,25 +4,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.022 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.005 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,13 +34,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -52,65 +52,65 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.005 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.852 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.003 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.815 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.873 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.858 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.975 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.020 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.704 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.677 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.841 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.912 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.053 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.654 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.967 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.171 |  |  |
 | Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.207 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"68edd62ba773e0368efdb9cb82676172034aee1b","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"248bf55e2e93924accb10337f63abf00e5716059","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/scripts/run-pester-tests/RunPesterTests.ps1
+++ b/scripts/run-pester-tests/RunPesterTests.ps1
@@ -27,7 +27,13 @@ if ($cfg.Output.PSObject.Properties.Name -contains 'NoColor') {
     $cfg.Output.NoColor = $true
 }
 $cfg.Run.Path = $testPath
-$cfg.TestResult.Enabled = $false
+$cfg.TestResult.Enabled = $true
+$cfg.TestResult.OutputFormat = 'JUnitXml'
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$artifactDir = Join-Path $WorkingDirectory "artifacts/pester-junit-$timestamp"
+New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
+$cfg.TestResult.OutputPath = Join-Path $artifactDir 'pester-junit.xml'
+$env:PESTER_JUNIT_PATH = $artifactDir
 
 $run = Invoke-Pester -Configuration $cfg
 $exitCode = $LASTEXITCODE

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,58 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.623853" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.609715" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.623330" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.552213" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.567205" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.001715" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002781" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000266" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000157" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000296" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.011002" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001697" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005319" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.007431" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.005671" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.001624" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.003243" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.002905" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.003964" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000768" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000258" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000221" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000159" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000364" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000171" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.002788" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="0.794109" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.695725" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.696729" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.646581" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.685036" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.584806" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.700181" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.706051" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.005646" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003023" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.000749" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000839" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000731" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001650" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000422" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000859" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002425" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001168" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000319" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.000802" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001268" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000176" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.680039" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.580007" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.567960" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000930" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000904" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.873456" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.002962" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.912244" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.858220" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.974517" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.003672" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003467" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000461" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000195" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000319" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.019690" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003848" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.004862" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.010589" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015126" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003244" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.005139" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009311" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.010642" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001569" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000476" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000386" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000204" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000342" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000223" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000315" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.206750" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.053016" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.171314" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.851717" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.677472" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.653956" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.840874" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.704068" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.021933" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002481" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.001787" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.004715" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001244" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003127" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000610" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001600" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001703" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001875" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000691" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002472" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001087" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000139" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.019858" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.814810" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.966558" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001177" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000902" classname="test"/>
 	<!-- tests 53 -->
 	<!-- suites 0 -->
 	<!-- pass 53 -->
@@ -60,5 +60,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 13396.922998 -->
+	<!-- duration_ms 8350.099289 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- generate JUnit test results when running Pester tests
- export test output location for downstream traceability tooling

## Testing
- `node --version`
- `actionlint -version`
- `pwsh --version`
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_68a57b9d15c083298cb1b219826f2f6c