### PR TITLE
Expand Pester JUnit glob to downloaded artifacts

### DIFF
--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -12,7 +12,7 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 42 | 42 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 43 | 43 | 0 | 0 | 100.00 |
 
 ### Requirement Testcases
 | Requirement ID | Test ID | Status |
@@ -36,6 +36,7 @@
 | Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed |
+| Unmapped | detects-downloaded-artifacts-path | Passed |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed |
 | Unmapped | errors-when-strict-unmapped-mode-enabled | Passed |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 10.39 | 100.00 |
-| linux | 53 | 0 | 0 | 10.39 | 100.00 |
+| overall | 54 | 0 | 0 | 15.61 | 100.00 |
+| linux | 54 | 0 | 0 | 15.61 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 53 | 0 | 0 | 10.39 | 100.00 |
-| linux | 53 | 0 | 0 | 10.39 | 100.00 |
+| overall | 54 | 0 | 0 | 15.61 | 100.00 |
+| linux | 54 | 0 | 0 | 15.61 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
@@ -18,6 +18,6 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 42 | 42 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 43 | 43 | 0 | 0 | 100.00 |
 
 _For detailed per-test information, see [traceability.md](traceability.md)._

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -70,47 +70,48 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.896 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.888 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.018 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.878 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.001 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.881 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.873 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.016 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.072 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.691 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.818 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
 | Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.922 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.122 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.641 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.818 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.005 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.267 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005646,
+          "duration": 0.00699,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003023,
+          "duration": 0.001463,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000749,
+          "duration": 0.005435,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000839,
+          "duration": 0.001169,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000731,
+          "duration": 0.001039,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00165,
+          "duration": 0.001777,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000859,
+          "duration": 0.000872,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002425,
+          "duration": 0.001006,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001168,
+          "duration": 0.000503,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000319,
+          "duration": 0.000402,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000802,
+          "duration": 0.001191,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007431,
+          "duration": 0.012211,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00093,
+          "duration": 0.000942,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000904,
+          "duration": 0.001939,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002788,
+          "duration": 0.000367,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003964,
+          "duration": 0.009314,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002905,
+          "duration": 0.009662,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003243,
+          "duration": 0.004395,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,16 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000159,
+          "duration": 0.000718,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "detects-downloaded-artifacts-path",
+          "name": "detects downloaded artifacts path",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.895611,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001715,
+          "duration": 0.002389,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.646581,
+          "duration": 0.887892,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001268,
+          "duration": 0.001043,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000176,
+          "duration": 0.000185,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.609715,
+          "duration": 1.018081,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +321,7 @@
           "name": "fails when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.580007,
+          "duration": 0.878337,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +330,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.623853,
+          "duration": 1.000952,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +339,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.552213,
+          "duration": 0.880797,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +348,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.567205,
+          "duration": 0.872653,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +357,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000266,
+          "duration": 0.000265,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +366,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000157,
+          "duration": 0.000258,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +375,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002781,
+          "duration": 0.002521,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +384,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000296,
+          "duration": 0.000753,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +393,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011002,
+          "duration": 0.016316,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +402,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.680039,
+          "duration": 1.072435,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +411,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000768,
+          "duration": 0.000866,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +420,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000258,
+          "duration": 0.000256,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +429,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000422,
+          "duration": 0.000845,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +438,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.706051,
+          "duration": 0.690657,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +447,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.685036,
+          "duration": 0.818282,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +456,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005671,
+          "duration": 0.015384,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001624,
+          "duration": 0.002789,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.700181,
+          "duration": 0.69993,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.62333,
+          "duration": 0.922192,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000221,
+          "duration": 0.000326,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.695725,
+          "duration": 1.122222,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000171,
+          "duration": 0.000361,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000364,
+          "duration": 0.000602,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.584806,
+          "duration": 0.640916,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.56796,
+          "duration": 0.818186,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.696729,
+          "duration": 1.004689,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005319,
+          "duration": 0.006609,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001697,
+          "duration": 0.002711,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 0.794109,
+          "duration": 1.267141,
           "requirements": [],
           "os": "linux"
         }
@@ -573,18 +582,18 @@
   ],
   "totals": {
     "overall": {
-      "passed": 53,
+      "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 10.388251,
+      "duration": 15.606847,
       "rate": 100
     },
     "byOs": {
       "linux": {
-        "passed": 53,
+        "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 10.388251,
+        "duration": 15.606847,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -70,47 +70,48 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.007 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.896 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.647 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.888 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.610 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.580 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.624 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.552 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.567 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.018 |  |  |
+| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.878 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.001 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.881 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.873 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.011 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.680 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.016 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.072 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.706 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.685 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.691 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.818 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
 | Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.623 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.922 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.696 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.122 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.585 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.568 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.697 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.794 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.641 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.818 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.005 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.267 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"68edd62ba773e0368efdb9cb82676172034aee1b","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"248bf55e2e93924accb10337f63abf00e5716059","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/scripts/__tests__/fixtures/downloaded-only/downloaded-artifacts/test-results-pester-sample/pester-junit.xml
+++ b/scripts/__tests__/fixtures/downloaded-only/downloaded-artifacts/test-results-pester-sample/pester-junit.xml
@@ -1,0 +1,20 @@
+<testsuite>
+  <testcase name="[Owner:alice] Alpha" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/alpha.log"/>
+      <property name="requirement" value="REQ-123"/>
+    </properties>
+  </testcase>
+  <testcase name="[Owner:bob] Beta" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/beta.log"/>
+      <property name="requirement" value="REQ-456"/>
+    </properties>
+  </testcase>
+  <testcase name="[Owner:alice] Gamma" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/gamma.log"/>
+      <property name="requirement" value="REQ-789"/>
+    </properties>
+  </testcase>
+</testsuite>

--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -61,6 +61,14 @@ test('fails when no JUnit files are found', async () => {
   );
 });
 
+test('detects downloaded artifacts path', async () => {
+  const env = { ...process.env, RUNNER_OS: 'Linux' };
+  const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
+  const cwd = path.join(fixtureDir, 'downloaded-only');
+  const { stdout } = await execFileP(tsxPath, [scriptFile], { cwd, env });
+  assert.match(stdout, /<details><summary>alice<\/summary>/);
+});
+
 test('uses latest artifact directory when multiple are present', async () => {
   const env = { ...process.env, RUNNER_OS: 'Linux' };
   const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -10,7 +10,9 @@ async function main() {
   if (overrideDir) {
     junitFiles = await glob(path.join(overrideDir, 'pester-junit.xml'));
   } else {
-    const matches = await glob('artifacts/pester-junit-*/pester-junit.xml');
+    const matches = await glob(
+      '{artifacts/pester-junit-*/pester-junit.xml,downloaded-artifacts/test-results-pester-*/pester-junit.xml}'
+    );
     if (matches.length > 0) {
       const latestDir = matches
         .map((f) => path.dirname(f))

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,64 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.623853" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.609715" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.623330" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.552213" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.567205" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.001715" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002781" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000266" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000157" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000296" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.011002" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001697" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005319" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.007431" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.005671" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.001624" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.003243" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.002905" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.003964" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000768" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000258" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000221" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000159" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000364" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000171" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.002788" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="0.794109" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.695725" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.696729" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.646581" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.685036" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.584806" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.700181" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.706051" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.005646" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003023" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.000749" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000839" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000731" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001650" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000422" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000859" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002425" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001168" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000319" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.000802" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001268" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000176" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.680039" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.580007" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.567960" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000930" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000904" classname="test"/>
-	<!-- tests 53 -->
+	<testcase name="fails when requirement lacks test coverage" time="1.000952" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.018081" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.922192" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.880797" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.872653" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002389" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002521" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000265" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000258" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000753" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.016316" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002711" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006609" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.012211" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015384" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.002789" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.004395" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009662" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.009314" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000866" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000256" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000326" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000718" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000602" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000361" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000367" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.267141" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.122222" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.004689" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.887892" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.818282" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.640916" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.699930" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.690657" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.006990" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001463" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.005435" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001169" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001039" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001777" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000845" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000872" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001006" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000503" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000402" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001191" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001043" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000185" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.072435" classname="test"/>
+	<testcase name="fails when no JUnit files are found" time="0.878337" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.895611" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.818186" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000942" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001939" classname="test"/>
+	<!-- tests 54 -->
 	<!-- suites 0 -->
-	<!-- pass 53 -->
+	<!-- pass 54 -->
 	<!-- fail 0 -->
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 13396.922998 -->
+	<!-- duration_ms 8426.000357 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- extend Pester traceability script to search downloaded artifacts for JUnit files
- cover downloaded artifacts scenario in tests

## Testing
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh HEAD~1`
- `npm run check:traceability`
- `npx tsx scripts/print-pester-traceability.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a57f1cbc4483298210c8e640d44f59