### PR TITLE
Handle missing Pester results without failing workflow

### DIFF
--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -42,7 +42,6 @@
 | Unmapped | escapemarkdown-escapes-special-characters | Passed |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed |
 | Unmapped | fails-when-commit-lacks-requirement-reference | Passed |
-| Unmapped | fails-when-no-junit-files-are-found | Passed |
 | Unmapped | fails-when-requirement-lacks-test-coverage | Passed |
 | Unmapped | fails-when-tests-are-unmapped | Passed |
 | Unmapped | fails-when-tests-reference-unknown-requirements | Passed |
@@ -59,6 +58,7 @@
 | Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed |
 | Unmapped | partitions-requirement-groups-by-runner\_type | Passed |
 | Unmapped | passes-with-coverage-and-requirement-reference | Passed |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.61 | 100.00 |
-| linux | 54 | 0 | 0 | 15.61 | 100.00 |
+| overall | 54 | 0 | 0 | 19.80 | 100.00 |
+| linux | 54 | 0 | 0 | 19.80 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.61 | 100.00 |
-| linux | 54 | 0 | 0 | 15.61 | 100.00 |
+| overall | 54 | 0 | 0 | 19.80 | 100.00 |
+| linux | 54 | 0 | 0 | 19.80 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -40,78 +40,78 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
 | Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.896 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.888 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.006 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.105 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.036 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.120 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.018 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.878 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.001 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.881 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.873 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.146 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.054 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.050 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.016 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.072 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.359 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.691 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.818 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.922 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.004 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.952 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.094 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.094 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.935 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.222 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.122 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.466 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.641 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.818 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.005 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.766 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.003 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.301 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.267 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.484 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00699,
+          "duration": 0.010082,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001463,
+          "duration": 0.005663,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005435,
+          "duration": 0.009162,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001169,
+          "duration": 0.001348,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001039,
+          "duration": 0.001231,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001777,
+          "duration": 0.002499,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000872,
+          "duration": 0.002267,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001006,
+          "duration": 0.005244,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000503,
+          "duration": 0.001908,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000402,
+          "duration": 0.000992,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001191,
+          "duration": 0.002834,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012211,
+          "duration": 0.014469,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000942,
+          "duration": 0.002344,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001939,
+          "duration": 0.002091,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000367,
+          "duration": 0.000433,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009314,
+          "duration": 0.005539,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009662,
+          "duration": 0.009586,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004395,
+          "duration": 0.006178,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000718,
+          "duration": 0.000281,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.895611,
+          "duration": 1.105138,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002389,
+          "duration": 0.036492,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.887892,
+          "duration": 1.11958,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001043,
+          "duration": 0.001481,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000185,
+          "duration": 0.000322,
           "requirements": [],
           "os": "linux"
         },
@@ -312,16 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.018081,
-          "requirements": [],
-          "os": "linux"
-        },
-        {
-          "id": "fails-when-no-junit-files-are-found",
-          "name": "fails when no JUnit files are found",
-          "className": "test",
-          "status": "Passed",
-          "duration": 0.878337,
+          "duration": 1.146226,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.000952,
+          "duration": 1.462805,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.880797,
+          "duration": 1.053679,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.872653,
+          "duration": 1.050087,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000265,
+          "duration": 0.0004,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000258,
+          "duration": 0.000211,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002521,
+          "duration": 0.004185,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000753,
+          "duration": 0.000509,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016316,
+          "duration": 0.020376,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.072435,
+          "duration": 1.359414,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000866,
+          "duration": 0.001396,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000256,
+          "duration": 0.000543,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000845,
+          "duration": 0.003818,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.690657,
+          "duration": 0.951522,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.818282,
+          "duration": 1.093633,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015384,
+          "duration": 0.010929,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +456,16 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002789,
+          "duration": 0.007079,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "logs-a-warning-when-no-junit-files-are-found",
+          "name": "logs a warning when no JUnit files are found",
+          "className": "test",
+          "status": "Passed",
+          "duration": 1.094434,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.69993,
+          "duration": 0.934896,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.922192,
+          "duration": 1.221751,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000326,
+          "duration": 0.000352,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.122222,
+          "duration": 1.466326,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000361,
+          "duration": 0.000273,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000602,
+          "duration": 0.000736,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.640916,
+          "duration": 0.766417,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.818186,
+          "duration": 1.00279,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.004689,
+          "duration": 1.300662,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006609,
+          "duration": 0.006145,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002711,
+          "duration": 0.002591,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.267141,
+          "duration": 1.484103,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.606847,
+      "duration": 19.795452,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.606847,
+        "duration": 19.795452,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -40,78 +40,78 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
 | Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.896 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.888 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.006 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.105 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.036 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.120 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.018 |  |  |
-| Unmapped | fails-when-no-junit-files-are-found | Passed | 0.878 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.001 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.881 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.873 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.146 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.054 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.050 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.016 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.072 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.359 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.691 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.818 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.700 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.922 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.004 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.952 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.094 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.094 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.935 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.222 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.122 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.466 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.641 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.818 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.005 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.766 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.003 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.301 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.267 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.484 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"248bf55e2e93924accb10337f63abf00e5716059","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"a6e42fa82af6e56070a20c64a027e65420ca6e1f","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -47,18 +47,12 @@ test('groups owners and includes requirements and evidence', async () => {
   );
 });
 
-test('fails when no JUnit files are found', async () => {
+test('logs a warning when no JUnit files are found', async () => {
   const env = { ...process.env, RUNNER_OS: 'Linux' };
   const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
   const cwd = path.join(fixtureDir, 'no-artifacts');
-  await assert.rejects(
-    execFileP(tsxPath, [scriptFile], { cwd, env }),
-    (err) => {
-      assert.equal(err.code, 1);
-      assert.match(err.stderr, /No JUnit files found/);
-      return true;
-    }
-  );
+  const { stderr } = await execFileP(tsxPath, [scriptFile], { cwd, env });
+  assert.match(stderr, /No JUnit files found/);
 });
 
 test('detects downloaded artifacts path', async () => {

--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -23,7 +23,7 @@ async function main() {
   }
   if (junitFiles.length === 0) {
     console.warn('No JUnit files found');
-    process.exit(1);
+    return;
   }
   const tests = [];
   for (const file of junitFiles) {

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.000952" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.018081" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.922192" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.880797" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.872653" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002389" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002521" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000265" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000258" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000753" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.016316" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002711" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006609" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.012211" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015384" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.002789" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.004395" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009662" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.009314" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000866" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000256" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000326" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000718" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000602" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000361" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000367" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.267141" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.122222" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.004689" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.887892" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.818282" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.640916" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.699930" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.690657" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.006990" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001463" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.005435" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001169" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001039" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001777" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000845" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000872" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001006" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000503" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000402" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001191" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001043" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000185" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.072435" classname="test"/>
-	<testcase name="fails when no JUnit files are found" time="0.878337" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.895611" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.818186" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000942" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001939" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.462805" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.146226" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.221751" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.053679" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.050087" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.036492" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004185" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000400" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000211" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000509" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.020376" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002591" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006145" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.014469" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.010929" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.007079" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.006178" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009586" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.005539" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001396" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000543" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000352" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000281" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000736" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000273" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000433" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.484103" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.466326" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.300662" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.119580" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.093633" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.766417" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.934896" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.951522" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010082" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005663" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.009162" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001348" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001231" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002499" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.003818" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002267" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.005244" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001908" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000992" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002834" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001481" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000322" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.359414" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.094434" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.105138" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.002790" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.002344" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002091" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8426.000357 -->
+	<!-- duration_ms 10979.74518 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- keep print-pester-traceability from failing when no Pester JUnit files exist
- add test validating the graceful handling

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD^)`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a5814576dc8329a09ebcb982abc18e