### PR TITLE
docs: reorganize mkdocs nav

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 19.80 | 100.00 |
-| linux | 54 | 0 | 0 | 19.80 | 100.00 |
+| overall | 54 | 0 | 0 | 24.26 | 100.00 |
+| linux | 54 | 0 | 0 | 24.26 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 19.80 | 100.00 |
-| linux | 54 | 0 | 0 | 19.80 | 100.00 |
+| overall | 54 | 0 | 0 | 24.26 | 100.00 |
+| linux | 54 | 0 | 0 | 24.26 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.018 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.006 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.070 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.022 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.105 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.036 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.120 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.146 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.054 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.050 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.477 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.395 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.290 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.601 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.378 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.489 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.008 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.359 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.031 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.513 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.004 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.952 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.094 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.179 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.222 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.094 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.935 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.222 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.466 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.766 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.003 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.301 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.339 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.157 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.378 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.737 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.010 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.043 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.268 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.628 |  |  |
 | Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.484 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.879 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010082,
+          "duration": 0.018451,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005663,
+          "duration": 0.00714,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009162,
+          "duration": 0.011216,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001348,
+          "duration": 0.002249,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001231,
+          "duration": 0.001802,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002499,
+          "duration": 0.003374,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002267,
+          "duration": 0.002187,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005244,
+          "duration": 0.002402,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001908,
+          "duration": 0.001605,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000992,
+          "duration": 0.000865,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002834,
+          "duration": 0.003557,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014469,
+          "duration": 0.021947,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002344,
+          "duration": 0.002297,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002091,
+          "duration": 0.00215,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000433,
+          "duration": 0.001773,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005539,
+          "duration": 0.010208,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009586,
+          "duration": 0.069604,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006178,
+          "duration": 0.022067,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000281,
+          "duration": 0.000321,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.105138,
+          "duration": 1.477198,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.036492,
+          "duration": 0.006826,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.11958,
+          "duration": 1.395253,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001481,
+          "duration": 0.002067,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000322,
+          "duration": 0.001811,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.146226,
+          "duration": 1.290223,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.462805,
+          "duration": 1.600796,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.053679,
+          "duration": 1.377752,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.050087,
+          "duration": 1.488858,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0004,
+          "duration": 0.002774,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000211,
+          "duration": 0.000374,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004185,
+          "duration": 0.008141,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000509,
+          "duration": 0.000893,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020376,
+          "duration": 0.031059,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.359414,
+          "duration": 1.513361,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001396,
+          "duration": 0.002917,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000543,
+          "duration": 0.000548,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003818,
+          "duration": 0.001247,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.951522,
+          "duration": 1.178691,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.093633,
+          "duration": 1.221995,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010929,
+          "duration": 0.014018,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007079,
+          "duration": 0.007169,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.094434,
+          "duration": 1.339499,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.934896,
+          "duration": 1.156693,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.221751,
+          "duration": 1.378174,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000352,
+          "duration": 0.000858,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.466326,
+          "duration": 1.737334,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000273,
+          "duration": 0.000873,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000736,
+          "duration": 0.010225,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.766417,
+          "duration": 1.042879,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.00279,
+          "duration": 1.267915,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.300662,
+          "duration": 1.628116,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006145,
+          "duration": 0.005978,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002591,
+          "duration": 0.005622,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.484103,
+          "duration": 1.879196,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 19.795452,
+      "duration": 24.262547999999995,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 19.795452,
+        "duration": 24.262547999999995,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.018 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.014 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.006 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.070 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.022 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.105 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.036 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.120 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.146 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.463 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.054 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.050 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.477 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.395 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.290 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.601 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.378 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.489 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.008 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.020 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.359 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.031 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.513 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.004 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.952 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.094 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.179 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.222 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.094 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.935 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.222 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.466 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.766 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.003 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.301 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.339 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.157 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.378 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.737 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.010 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.043 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.268 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.628 |  |  |
 | Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.484 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.879 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"a6e42fa82af6e56070a20c64a027e65420ca6e1f","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"36286315357af8f05c13556efe7df0d07122c211","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,57 +35,61 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.highlight
 nav:
-  - Home:
-    - Overview: index.md
-    - Architecture: architecture.md
-  - Quickstart: quickstart.md
-  - Action Calls: action-call-reference.md
-  - Common Parameters: common-parameters.md
-  - Troubleshooting: troubleshooting.md
-  - Unified Dispatcher: UnifiedDispatcher.md
-  - Adapter Authoring: adapter-authoring.md
-  - Versioning: versioning.md
-  - Changelog: CHANGELOG.md
-  - Contributing: contributing-docs.md
-  - Requirements: requirements.md
-  - Testing with Pester: testing-pester.md
-  - Actions:
-    - Setup:
-      - Add Token to LabVIEW: actions/add-token-to-labview.md
-      - Apply VIPC: actions/apply-vipc.md
-      - Close LabVIEW: actions/close-labview.md
-      - Missing in Project: actions/missing-in-project.md
-      - Prepare LabVIEW Source: actions/prepare-labview-source.md
-      - Rename File: actions/rename-file.md
-      - Restore Setup LV Source: actions/restore-setup-lv-source.md
-      - Set Development Mode: actions/set-development-mode.md
-      - Revert Development Mode: actions/revert-development-mode.md
-    - Build:
-      - Build: actions/build.md
-      - Build LVLIBP: actions/build-lvlibp.md
-      - Build VI Package: actions/build-vi-package.md
-      - Generate Release Notes: actions/generate-release-notes.md
-      - Modify VIPB Display Info: actions/modify-vipb-display-info.md
-    - Testing:
-      - Run Unit Tests: actions/run-unit-tests.md
-  - Workflows:
-    - Add Token to LabVIEW: workflows/add-token-to-labview.md
-    - Apply VIPC: workflows/apply-vipc.md
-    - Build LVLIBP: workflows/build-lvlibp.md
-    - Build VI Package: workflows/build-vi-package.md
-    - Build: workflows/build.md
-    - Close LabVIEW: workflows/close-labview.md
-    - Generate Release Notes: workflows/generate-release-notes.md
-    - Missing in Project: workflows/missing-in-project.md
-    - Modify VIPB Display Info: workflows/modify-vipb-display-info.md
-    - Prepare LabVIEW Source: workflows/prepare-labview-source.md
-    - Rename File: workflows/rename-file.md
-    - Restore Setup LV Source: workflows/restore-setup-lv-source.md
-    - Revert Development Mode: workflows/revert-development-mode.md
-    - Run Pester Tests: workflows/run-pester-tests.md
-    - Run Unit Tests: workflows/run-unit-tests.md
-    - Set Development Mode: workflows/set-development-mode.md
-    - Setup MkDocs: workflows/setup-mkdocs.md
+  - Overview:
+      - Overview: index.md
+      - Architecture: architecture.md
+      - Unified Dispatcher: UnifiedDispatcher.md
+  - Guides:
+      - Quickstart: quickstart.md
+      - Environment Setup: environment-setup.md
+      - Troubleshooting: troubleshooting.md
+  - Reference:
+      - Action Calls: action-call-reference.md
+      - Common Parameters: common-parameters.md
+      - Actions:
+          - Setup:
+              - Add Token to LabVIEW: actions/add-token-to-labview.md
+              - Apply VIPC: actions/apply-vipc.md
+              - Close LabVIEW: actions/close-labview.md
+              - Missing in Project: actions/missing-in-project.md
+              - Prepare LabVIEW Source: actions/prepare-labview-source.md
+              - Rename File: actions/rename-file.md
+              - Restore Setup LV Source: actions/restore-setup-lv-source.md
+              - Set Development Mode: actions/set-development-mode.md
+              - Revert Development Mode: actions/revert-development-mode.md
+          - Build:
+              - Build: actions/build.md
+              - Build LVLIBP: actions/build-lvlibp.md
+              - Build VI Package: actions/build-vi-package.md
+              - Generate Release Notes: actions/generate-release-notes.md
+              - Modify VIPB Display Info: actions/modify-vipb-display-info.md
+          - Testing:
+              - Run Unit Tests: actions/run-unit-tests.md
+      - Workflows:
+          - Add Token to LabVIEW: workflows/add-token-to-labview.md
+          - Apply VIPC: workflows/apply-vipc.md
+          - Build LVLIBP: workflows/build-lvlibp.md
+          - Build VI Package: workflows/build-vi-package.md
+          - Build: workflows/build.md
+          - Close LabVIEW: workflows/close-labview.md
+          - Generate Release Notes: workflows/generate-release-notes.md
+          - Missing in Project: workflows/missing-in-project.md
+          - Modify VIPB Display Info: workflows/modify-vipb-display-info.md
+          - Prepare LabVIEW Source: workflows/prepare-labview-source.md
+          - Rename File: workflows/rename-file.md
+          - Restore Setup LV Source: workflows/restore-setup-lv-source.md
+          - Revert Development Mode: workflows/revert-development-mode.md
+          - Run Pester Tests: workflows/run-pester-tests.md
+          - Run Unit Tests: workflows/run-unit-tests.md
+          - Set Development Mode: workflows/set-development-mode.md
+          - Setup MkDocs: workflows/setup-mkdocs.md
+  - Developer Docs:
+      - Adapter Authoring: adapter-authoring.md
+      - Versioning: versioning.md
+      - Changelog: CHANGELOG.md
+      - Contributing: contributing-docs.md
+      - Requirements: requirements.md
+      - Testing with Pester: testing-pester.md
 plugins:
   - search
   - autorefs

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.462805" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.146226" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.221751" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.053679" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.050087" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.036492" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004185" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000400" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000211" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000509" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.020376" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002591" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006145" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.014469" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.010929" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.007079" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.006178" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009586" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.005539" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001396" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000543" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000352" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000281" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000736" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000273" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000433" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.484103" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.466326" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.300662" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.119580" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.093633" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.766417" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.934896" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.951522" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010082" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005663" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.009162" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001348" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001231" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002499" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.003818" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002267" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.005244" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001908" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000992" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002834" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001481" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000322" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.359414" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.094434" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.105138" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.002790" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.002344" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002091" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.600796" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.290223" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.378174" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.377752" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.488858" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.006826" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.008141" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.002774" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000374" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000893" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.031059" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005622" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005978" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.021947" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.014018" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.007169" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.022067" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.069604" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.010208" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002917" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000548" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000858" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000321" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.010225" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000873" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001773" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.879196" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.737334" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.628116" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.395253" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.221995" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.042879" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.156693" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.178691" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.018451" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007140" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.011216" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.002249" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001802" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003374" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001247" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002187" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002402" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001605" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000865" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.003557" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002067" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.001811" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.513361" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.339499" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.477198" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.267915" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.002297" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002150" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 10979.74518 -->
+	<!-- duration_ms 13638.529268 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- organize mkdocs nav into Overview, Guides, Reference, and Developer Docs categories
- add environment setup and quickstart under Guides

## Testing
- `apt-get update && apt-get install -y apt-utils`
- `node --version`
- `go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.26`
- `pwsh --version`
- `mkdocs serve` *(fails: Config value 'plugins': The "redirects" plugin is not installed; after installing dependencies, fails with 32 warnings)*
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_68a5857d38d4832998078e16643766ff