### PR TITLE
docs: cross-link actions and workflows

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 20.78 | 100.00 |
-| linux | 54 | 0 | 0 | 20.78 | 100.00 |
+| overall | 54 | 0 | 0 | 15.04 | 100.00 |
+| linux | 54 | 0 | 0 | 15.04 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 20.78 | 100.00 |
-| linux | 54 | 0 | 0 | 20.78 | 100.00 |
+| overall | 54 | 0 | 0 | 15.04 | 100.00 |
+| linux | 54 | 0 | 0 | 15.04 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -10,7 +10,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
@@ -22,7 +22,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,25 +34,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.007 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.005 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.192 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.253 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.797 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.810 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.167 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.274 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.080 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.166 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.801 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.837 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.864 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.814 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.035 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.478 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.075 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.005 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.026 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.096 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.693 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.832 |  |  |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.152 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.065 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.359 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.971 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.987 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.472 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.118 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.809 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.043 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.390 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.015 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.008 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.555 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.604 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.783 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.006 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.218 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008218,
+          "duration": 0.00836,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00534,
+          "duration": 0.002228,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003829,
+          "duration": 0.003601,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006395,
+          "duration": 0.000836,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001214,
+          "duration": 0.000952,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006857,
+          "duration": 0.003543,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00136,
+          "duration": 0.00198,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001307,
+          "duration": 0.002017,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004908,
+          "duration": 0.001587,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000682,
+          "duration": 0.000565,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001434,
+          "duration": 0.001518,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.033537,
+          "duration": 0.020357,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003204,
+          "duration": 0.003471,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002252,
+          "duration": 0.000897,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000567,
+          "duration": 0.000404,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004347,
+          "duration": 0.007968,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008069,
+          "duration": 0.009706,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008512,
+          "duration": 0.009454,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000287,
+          "duration": 0.000233,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.192347,
+          "duration": 0.797385,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003728,
+          "duration": 0.002594,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.252761,
+          "duration": 0.809676,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001373,
+          "duration": 0.000885,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001099,
+          "duration": 0.000159,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.167365,
+          "duration": 0.800893,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.274434,
+          "duration": 0.837024,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.079574,
+          "duration": 0.864368,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.16608,
+          "duration": 0.814465,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000278,
+          "duration": 0.000188,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000203,
+          "duration": 0.000128,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00326,
+          "duration": 0.003391,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00037,
+          "duration": 0.000309,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.035494,
+          "duration": 0.014674,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.47837,
+          "duration": 1.075346,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001296,
+          "duration": 0.00106,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000382,
+          "duration": 0.000268,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004823,
+          "duration": 0.000397,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.025546,
+          "duration": 0.692842,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.096497,
+          "duration": 0.832402,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015749,
+          "duration": 0.015986,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006828,
+          "duration": 0.012152,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.151677,
+          "duration": 0.970642,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.065265,
+          "duration": 0.68832,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.358822,
+          "duration": 0.986746,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000306,
+          "duration": 0.000175,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.47204,
+          "duration": 1.11845,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000276,
+          "duration": 0.000201,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00047,
+          "duration": 0.000309,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.809456,
+          "duration": 0.604164,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.04335,
+          "duration": 0.782704,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.389964,
+          "duration": 1.005865,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0146,
+          "duration": 0.006485,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008406,
+          "duration": 0.001837,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.555371,
+          "duration": 1.217622,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 20.780179,
+      "duration": 15.039789000000003,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 20.780179,
+        "duration": 15.039789000000003,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -10,7 +10,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
@@ -22,7 +22,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,25 +34,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.007 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.005 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.192 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.253 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.797 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.810 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.001 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.167 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.274 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.080 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.166 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.801 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.837 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.864 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.814 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.035 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.478 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.075 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.005 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.026 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.096 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.693 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.832 |  |  |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.152 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.065 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.359 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.971 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.987 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.472 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.118 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.809 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.043 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.390 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.015 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.008 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.555 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.604 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.783 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.006 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.218 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"d75aa8a5850a3e659307f08822f1a39152fc8aac","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"5a4805968fa13d6004d3e907575cc811c1ec371f","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -62,4 +62,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/add-token-to-labview/README.md](../../scripts/add-token-to-labview/README.md).
+## See also
+
+- [Workflow documentation](../workflows/add-token-to-labview.md)
+- [scripts/add-token-to-labview/README.md](../../scripts/add-token-to-labview/README.md)

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -70,4 +70,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/apply-vipc/README.md](../../scripts/apply-vipc/README.md).
+## See also
+
+- [Workflow documentation](../workflows/apply-vipc.md)
+- [scripts/apply-vipc/README.md](../../scripts/apply-vipc/README.md)

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -13,7 +13,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used for the build.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
 - **RelativePath** (`string`): Path relative to the action's working directory. Use "." when the working directory is desired.
-- **LabVIEW_Project** (`string`): Path to the LabVIEW project (.lvproj).
+- **LabVIEW_Project** (`string`): Path to the LabVIEW project (.lvproj)
 - **Build_Spec** (`string`): Name of the build specification to execute.
 - **Major** (`int`): Major version number.
 - **Minor** (`int`): Minor version number.
@@ -90,4 +90,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/build-lvlibp/README.md](../../scripts/build-lvlibp/README.md).
+## See also
+
+- [Workflow documentation](../workflows/build-lvlibp.md)
+- [scripts/build-lvlibp/README.md](../../scripts/build-lvlibp/README.md)

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -12,7 +12,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 - **MinimumSupportedLVVersion** (`string`): Minimum LabVIEW version supported by the package.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
-- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3")
 - **RelativePath** (`string`): Path relative to the action's working directory. Use "." when the working directory is desired.
 - **VIPBPath** (`string`): Relative path to the VIPB file to build.
 - **Major** (`int`): Major version component.
@@ -95,4 +95,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/build-vi-package/README.md](../../scripts/build-vi-package/README.md).
+## See also
+
+- [Workflow documentation](../workflows/build-vi-package.md)
+- [scripts/build-vi-package/README.md](../../scripts/build-vi-package/README.md)

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -16,7 +16,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 - **Patch** (`int`): Patch version component.
 - **Build** (`int`): Build number component.
 - **Commit** (`string`): Commit identifier embedded in the build.
-- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3")
 - **CompanyName** (`string`): Name of the company for metadata.
 - **AuthorName** (`string`): Author or organization name for metadata.
 
@@ -86,4 +86,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/build/README.md](../../scripts/build/README.md).
+## See also
+
+- [Workflow documentation](../workflows/build.md)
+- [scripts/build/README.md](../../scripts/build/README.md)

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -56,4 +56,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/close-labview/README.md](../../scripts/close-labview/README.md).
+## See also
+
+- [Workflow documentation](../workflows/close-labview.md)
+- [scripts/close-labview/README.md](../../scripts/close-labview/README.md)

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -14,7 +14,7 @@ None.
 
 ### Optional
 
-- **OutputPath** (`string`): Path to write the release notes file (default `Tooling/deployment/release_notes.md`).
+- **OutputPath** (`string`): Path to write the release notes file (default `Tooling/deployment/release_notes.md`)
 
 ## CLI example
 
@@ -52,4 +52,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/generate-release-notes/README.md](../../scripts/generate-release-notes/README.md).
+## See also
+
+- [Workflow documentation](../workflows/generate-release-notes.md)
+- [scripts/generate-release-notes/README.md](../../scripts/generate-release-notes/README.md)

--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -4,7 +4,7 @@ List of available GitHub Actions.
 
 - [add-token-to-labview](./add-token-to-labview.md): Add a custom library path token to the LabVIEW INI file so LabVIEW can locate project libraries.
 - [apply-vipc](./apply-vipc.md): Apply a VI Package Configuration (.vipc) file to a specific LabVIEW installation using g-cli.
-- [build-lvlibp](./build-lvlibp.md): Build a LabVIEW project’s build specification into a Packed Project Library (.lvlibp).
+- [build-lvlibp](./build-lvlibp.md): Build a LabVIEW project’s build specification into a Packed Project Library (.lvlibp)
 - [build-vi-package](./build-vi-package.md): Update VIPB display information and build a VI package using g-cli.
 - [build](./build.md): Automate building the LabVIEW Icon Editor project, including cleaning, building libraries, and packaging.
 - [close-labview](./close-labview.md): Gracefully close a running LabVIEW instance via g-cli.
@@ -19,3 +19,7 @@ List of available GitHub Actions.
 - [run-unit-tests](./run-unit-tests.md): Run LabVIEW unit tests via the LabVIEW Unit Test Framework CLI and report pass/fail/error using standard exit codes.
 - [set-development-mode](./set-development-mode.md): Configure the repository for development mode by removing packed libraries, adding tokens, preparing sources, and closing LabVIEW.
 - [setup-mkdocs](./setup-mkdocs.md): Install a pinned MkDocs with caching.
+
+## See also
+
+- [Workflow documentation](../workflows/index.md)

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -61,4 +61,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/missing-in-project/README.md](../../scripts/missing-in-project/README.md).
+## See also
+
+- [Workflow documentation](../workflows/missing-in-project.md)
+- [scripts/missing-in-project/README.md](../../scripts/missing-in-project/README.md)

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -14,7 +14,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 - **RelativePath** (`string`): Path relative to the action's working directory. Use "." when the working directory is desired.
 - **VIPBPath** (`string`): Relative path to the VIPB file.
 - **MinimumSupportedLVVersion** (`string`): Minimum LabVIEW version supported by the package.
-- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3")
 - **Major** (`int`): Major version component.
 - **Minor** (`int`): Minor version component.
 - **Patch** (`int`): Patch version component.
@@ -95,4 +95,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/modify-vipb-display-info/README.md](../../scripts/modify-vipb-display-info/README.md).
+## See also
+
+- [Workflow documentation](../workflows/modify-vipb-display-info.md)
+- [scripts/modify-vipb-display-info/README.md](../../scripts/modify-vipb-display-info/README.md)

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -13,7 +13,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
 - **RelativePath** (`string`): Path relative to the action's working directory. Use "." when the working directory is desired.
-- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension).
+- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension)
 - **Build_Spec** (`string`): Name of the build specification to prepare.
 
 ### Optional
@@ -70,4 +70,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/prepare-labview-source/README.md](../../scripts/prepare-labview-source/README.md).
+## See also
+
+- [Workflow documentation](../workflows/prepare-labview-source.md)
+- [scripts/prepare-labview-source/README.md](../../scripts/prepare-labview-source/README.md)

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -56,4 +56,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/rename-file/README.md](../../scripts/rename-file/README.md).
+## See also
+
+- [Workflow documentation](../workflows/rename-file.md)
+- [scripts/rename-file/README.md](../../scripts/rename-file/README.md)

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -13,7 +13,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
 - **RelativePath** (`string`): Path relative to the action's working directory. Use "." when the working directory is desired.
-- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension).
+- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension)
 - **Build_Spec** (`string`): Build specification name within the project.
 
 ### Optional
@@ -70,4 +70,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/restore-setup-lv-source/README.md](../../scripts/restore-setup-lv-source/README.md).
+## See also
+
+- [Workflow documentation](../workflows/restore-setup-lv-source.md)
+- [scripts/restore-setup-lv-source/README.md](../../scripts/restore-setup-lv-source/README.md)

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -54,4 +54,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/revert-development-mode/README.md](../../scripts/revert-development-mode/README.md).
+## See also
+
+- [Workflow documentation](../workflows/revert-development-mode.md)
+- [scripts/revert-development-mode/README.md](../../scripts/revert-development-mode/README.md)

--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -56,4 +56,7 @@ See [run-pester-tests/action.yml](../../run-pester-tests/action.yml) and [script
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/run-pester-tests/README.md](../../scripts/run-pester-tests/README.md).
+## See also
+
+- [Workflow documentation](../workflows/run-pester-tests.md)
+- [scripts/run-pester-tests/README.md](../../scripts/run-pester-tests/README.md)

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -66,4 +66,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/run-unit-tests/README.md](../../scripts/run-unit-tests/README.md).
+## See also
+
+- [Workflow documentation](../workflows/run-unit-tests.md)
+- [scripts/run-unit-tests/README.md](../../scripts/run-unit-tests/README.md)

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -54,4 +54,7 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-See also: [scripts/set-development-mode/README.md](../../scripts/set-development-mode/README.md).
+## See also
+
+- [Workflow documentation](../workflows/set-development-mode.md)
+- [scripts/set-development-mode/README.md](../../scripts/set-development-mode/README.md)

--- a/docs/actions/setup-mkdocs.md
+++ b/docs/actions/setup-mkdocs.md
@@ -27,3 +27,7 @@ This action has no inputs.
 See [setup-mkdocs/action.yml](../../setup-mkdocs/action.yml) for implementation details.
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+## See also
+
+- [Workflow documentation](../workflows/setup-mkdocs.md)

--- a/docs/workflows/add-token-to-labview.md
+++ b/docs/workflows/add-token-to-labview.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/add-token-to-labview.md)

--- a/docs/workflows/apply-vipc.md
+++ b/docs/workflows/apply-vipc.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName apply-vipc -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/apply-vipc.md)

--- a/docs/workflows/build-lvlibp.md
+++ b/docs/workflows/build-lvlibp.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/build-lvlibp.md)

--- a/docs/workflows/build-vi-package.md
+++ b/docs/workflows/build-vi-package.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build-vi-package -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/build-vi-package.md)

--- a/docs/workflows/build.md
+++ b/docs/workflows/build.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/build.md)

--- a/docs/workflows/close-labview.md
+++ b/docs/workflows/close-labview.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName close-labview -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/close-labview.md)

--- a/docs/workflows/generate-release-notes.md
+++ b/docs/workflows/generate-release-notes.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/generate-release-notes.md)

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -19,3 +19,7 @@ List of reusable GitHub Workflows.
 - [run-unit-tests workflow](./run-unit-tests.md): Dispatch the [run-unit-tests](../actions/run-unit-tests.md) action to a target repository through `Invoke-OSAction.ps1`.
 - [set-development-mode workflow](./set-development-mode.md): Dispatch the [set-development-mode](../actions/set-development-mode.md) action to a target repository through `Invoke-OSAction.ps1`.
 - [setup-mkdocs workflow](./setup-mkdocs.md): Dispatch the [setup-mkdocs](../actions/setup-mkdocs.md) action to a target repository through `Invoke-OSAction.ps1`.
+
+## See also
+
+- [Action documentation](../actions/index.md)

--- a/docs/workflows/missing-in-project.md
+++ b/docs/workflows/missing-in-project.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName missing-in-project -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/missing-in-project.md)

--- a/docs/workflows/modify-vipb-display-info.md
+++ b/docs/workflows/modify-vipb-display-info.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/modify-vipb-display-info.md)

--- a/docs/workflows/prepare-labview-source.md
+++ b/docs/workflows/prepare-labview-source.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/prepare-labview-source.md)

--- a/docs/workflows/rename-file.md
+++ b/docs/workflows/rename-file.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName rename-file -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/rename-file.md)

--- a/docs/workflows/restore-setup-lv-source.md
+++ b/docs/workflows/restore-setup-lv-source.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/restore-setup-lv-source.md)

--- a/docs/workflows/revert-development-mode.md
+++ b/docs/workflows/revert-development-mode.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/revert-development-mode.md)

--- a/docs/workflows/run-pester-tests.md
+++ b/docs/workflows/run-pester-tests.md
@@ -49,3 +49,7 @@ jobs:
 
 After the workflow completes, the target repository will contain a `requirement-coverage.json` file summarizing requirement pass/fail status from the test run.
 ```
+
+## See also
+
+- [Action documentation](../actions/run-pester-tests.md)

--- a/docs/workflows/run-unit-tests.md
+++ b/docs/workflows/run-unit-tests.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/run-unit-tests.md)

--- a/docs/workflows/set-development-mode.md
+++ b/docs/workflows/set-development-mode.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName set-development-mode -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/set-development-mode.md)

--- a/docs/workflows/setup-mkdocs.md
+++ b/docs/workflows/setup-mkdocs.md
@@ -47,3 +47,7 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName setup-mkdocs -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## See also
+
+- [Action documentation](../actions/setup-mkdocs.md)

--- a/error-summary.md
+++ b/error-summary.md
@@ -14,3 +14,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.274434" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.167365" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.358822" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.079574" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.166080" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003728" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.003260" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000278" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000203" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000370" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.035494" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.008406" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.014600" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.033537" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015749" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006828" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.008512" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008069" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.004347" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001296" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000382" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000306" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000287" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000470" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000276" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000567" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.555371" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.472040" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.389964" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.252761" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.096497" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.809456" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.065265" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.025546" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.008218" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005340" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.003829" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.006395" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001214" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.006857" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.004823" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001360" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001307" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.004908" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000682" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001434" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001373" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.001099" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.478370" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.151677" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.192347" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.043350" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003204" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002252" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.837024" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.800893" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.986746" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.864368" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.814465" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002594" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003391" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000188" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000128" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000309" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.014674" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001837" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006485" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.020357" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015986" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.012152" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009454" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009706" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.007968" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001060" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000268" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000175" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000233" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000309" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000201" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000404" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.217622" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.118450" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.005865" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.809676" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.832402" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.604164" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.688320" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.692842" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.008360" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002228" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.003601" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000836" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000952" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003543" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000397" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001980" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002017" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001587" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000565" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001518" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.000885" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000159" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.075346" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.970642" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.797385" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.782704" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.003471" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000897" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 11471.471396 -->
+	<!-- duration_ms 8201.646681 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- add reciprocal "See also" links between action docs and workflow docs
- include docs in MkDocs build

## Testing
- `npm run test:ci`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `mkdocs build`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a58a2fa1188329aa9edae7fbe90f58