### PR TITLE
Normalize action and workflow docs

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.04 | 100.00 |
-| linux | 54 | 0 | 0 | 15.04 | 100.00 |
+| overall | 54 | 0 | 0 | 19.61 | 100.00 |
+| linux | 54 | 0 | 0 | 19.61 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.04 | 100.00 |
-| linux | 54 | 0 | 0 | 15.04 | 100.00 |
+| overall | 54 | 0 | 0 | 19.61 | 100.00 |
+| linux | 54 | 0 | 0 | 19.61 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,31 +4,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -52,7 +52,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -70,48 +70,48 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.797 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.810 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.801 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.837 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.864 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.814 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.156 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.110 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.006 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.180 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.299 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.030 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.053 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
 | Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.075 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.693 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.832 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.971 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.987 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.328 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.004 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.932 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.957 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.071 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.961 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.257 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.118 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.604 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.783 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.006 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.218 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.435 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.011 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.786 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.936 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.318 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.645 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00836,
+          "duration": 0.009009,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002228,
+          "duration": 0.00344,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003601,
+          "duration": 0.005013,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000836,
+          "duration": 0.0015,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000952,
+          "duration": 0.001623,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003543,
+          "duration": 0.003533,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00198,
+          "duration": 0.001576,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002017,
+          "duration": 0.002309,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001587,
+          "duration": 0.001307,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000565,
+          "duration": 0.000573,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001518,
+          "duration": 0.001853,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020357,
+          "duration": 0.009675,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003471,
+          "duration": 0.00237,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000897,
+          "duration": 0.001439,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000404,
+          "duration": 0.00109,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007968,
+          "duration": 0.011505,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009706,
+          "duration": 0.004422,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009454,
+          "duration": 0.009561,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000233,
+          "duration": 0.000329,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.797385,
+          "duration": 1.156154,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002594,
+          "duration": 0.005243,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.809676,
+          "duration": 1.110031,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000885,
+          "duration": 0.001929,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000159,
+          "duration": 0.006144,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.800893,
+          "duration": 1.180063,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.837024,
+          "duration": 1.29899,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.864368,
+          "duration": 1.030078,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.814465,
+          "duration": 1.053016,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000188,
+          "duration": 0.000469,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000128,
+          "duration": 0.000331,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003391,
+          "duration": 0.002524,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000309,
+          "duration": 0.000468,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014674,
+          "duration": 0.014704,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.075346,
+          "duration": 1.327704,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00106,
+          "duration": 0.001568,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000268,
+          "duration": 0.003959,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000397,
+          "duration": 0.000536,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.692842,
+          "duration": 0.931806,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.832402,
+          "duration": 0.95705,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015986,
+          "duration": 0.014851,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012152,
+          "duration": 0.005243,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.970642,
+          "duration": 1.071358,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.68832,
+          "duration": 0.961151,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.986746,
+          "duration": 1.257111,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000175,
+          "duration": 0.000433,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.11845,
+          "duration": 1.435265,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000201,
+          "duration": 0.010709,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000309,
+          "duration": 0.000501,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.604164,
+          "duration": 0.785877,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.782704,
+          "duration": 0.936249,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.005865,
+          "duration": 1.318484,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006485,
+          "duration": 0.00413,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001837,
+          "duration": 0.004004,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.217622,
+          "duration": 1.645394,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.039789000000003,
+      "duration": 19.605653999999998,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.039789000000003,
+        "duration": 19.605653999999998,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,31 +4,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -52,7 +52,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -70,48 +70,48 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.020 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.797 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.810 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.801 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.837 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.864 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.814 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.156 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.110 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.006 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.180 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.299 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.030 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.053 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
 | Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.075 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.693 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.832 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.012 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.971 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.688 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.987 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.328 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.004 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.932 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.957 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.071 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.961 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.257 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.118 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.604 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.783 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.006 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.218 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.435 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.011 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.786 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.936 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.318 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.645 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"5a4805968fa13d6004d3e907575cc811c1ec371f","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"7f82f0b8a7dc406f568e5eb2e52a9c6502cb1c98","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -18,18 +18,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJson '{
-  "MinimumSupportedLVVersion": "2021",
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": "."
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -43,7 +32,20 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": "."
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Add library token

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -20,20 +20,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
-  "MinimumSupportedLVVersion": "2019",
-  "VIP_LVVersion": "2019",
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "VIPCPath": "MyProject.vipc"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -49,7 +36,22 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
+  "MinimumSupportedLVVersion": "2019",
+  "VIP_LVVersion": "2019",
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "VIPCPath": "MyProject.vipc"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Apply VIPC

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -25,25 +25,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
-  "MinimumSupportedLVVersion": "2020",
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "LabVIEW_Project": "Source/MyProject.lvproj",
-  "Build_Spec": "PackedLib Build",
-  "Major": 1,
-  "Minor": 0,
-  "Patch": 0,
-  "Build": 123,
-  "Commit": "abcdef"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -64,7 +46,27 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
+  "MinimumSupportedLVVersion": "2020",
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "LabVIEW_Project": "Source/MyProject.lvproj",
+  "Build_Spec": "PackedLib Build",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 123,
+  "Commit": "abcdef"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Build Packed Library

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -26,26 +26,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 - **ReleaseNotesFile** (`string`): Path to a release notes file included in the package.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
-  "MinimumSupportedLVVersion": "2023",
-  "SupportedBitness": "64",
-  "LabVIEWMinorRevision": "3",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
-  "Major": 1,
-  "Minor": 0,
-  "Patch": 0,
-  "Build": 2,
-  "Commit": "abcdef",
-  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -68,7 +49,28 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
+  "MinimumSupportedLVVersion": "2023",
+  "SupportedBitness": "64",
+  "LabVIEWMinorRevision": "3",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 2,
+  "Commit": "abcdef",
+  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Build VI Package

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -24,24 +24,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "Major": 1,
-  "Minor": 0,
-  "Patch": 0,
-  "Build": 1,
-  "Commit": "abcdef",
-  "LabVIEWMinorRevision": "3",
-  "CompanyName": "Acme Corp",
-  "AuthorName": "Jane Doe"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -61,7 +44,26 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 1,
+  "Commit": "abcdef",
+  "LabVIEWMinorRevision": "3",
+  "CompanyName": "Acme Corp",
+  "AuthorName": "Jane Doe"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Build project

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -17,16 +17,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
-  "minimum_supported_lv_version": "2021",
-  "supported_bitness": "64"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -39,7 +30,18 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
+  "minimum_supported_lv_version": "2021",
+  "supported_bitness": "64"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Close LabVIEW

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -16,15 +16,7 @@ None.
 
 - **OutputPath** (`string`): Path to write the release notes file (default `Tooling/deployment/release_notes.md`)
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJson '{
-  "OutputPath": "Tooling/deployment/release_notes.md"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -36,7 +28,17 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJson '{
+  "OutputPath": "Tooling/deployment/release_notes.md"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Generate release notes

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -18,17 +18,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson '{
-  "LVVersion": "2020",
-  "SupportedBitness": "64",
-  "ProjectFile": "MyProject.lvproj"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -42,7 +32,19 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson '{
+  "LVVersion": "2020",
+  "SupportedBitness": "64",
+  "ProjectFile": "MyProject.lvproj"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Check for Missing Project Items

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -26,26 +26,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 - **ReleaseNotesFile** (`string`): Path to a release notes file injected into the build.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -ArgsJson '{
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
-  "MinimumSupportedLVVersion": "2023",
-  "LabVIEWMinorRevision": "3",
-  "Major": 1,
-  "Minor": 0,
-  "Patch": 0,
-  "Build": 2,
-  "Commit": "abcdef",
-  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -68,7 +49,28 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -ArgsJson '{
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+  "MinimumSupportedLVVersion": "2023",
+  "LabVIEWMinorRevision": "3",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 2,
+  "Commit": "abcdef",
+  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Modify VIPB display info

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -20,20 +20,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJson '{
-  "MinimumSupportedLVVersion": "2021",
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "LabVIEW_Project": "lv_icon_editor",
-  "Build_Spec": "Editor Packed Library"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -49,7 +36,22 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "LabVIEW_Project": "lv_icon_editor",
+  "Build_Spec": "Editor Packed Library"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Prepare LabVIEW source

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -17,16 +17,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
-  "CurrentFilename": "C:/path/lv_icon.lvlibp",
-  "NewFilename": "lv_icon_x64_v1.0.0.1+gabcdef.lvlibp"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -39,7 +30,18 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
+  "CurrentFilename": "C:/path/lv_icon.lvlibp",
+  "NewFilename": "lv_icon_x64_v1.0.0.1+gabcdef.lvlibp"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Rename file

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -20,20 +20,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -ArgsJson '{
-  "MinimumSupportedLVVersion": "2021",
-  "SupportedBitness": "64",
-  "WorkingDirectory": ".",
-  "RelativePath": ".",
-  "LabVIEW_Project": "lv_icon_editor",
-  "Build_Spec": "Editor Packed Library"
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -49,7 +36,22 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "LabVIEW_Project": "lv_icon_editor",
+  "Build_Spec": "Editor Packed Library"
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Restore LabVIEW setup

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -16,16 +16,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -ArgsJson '{
-  "WorkingDirectory": ".",
-  "RelativePath": "."
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -37,7 +28,18 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -ArgsJson '{
+  "WorkingDirectory": ".",
+  "RelativePath": "."
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Revert development mode

--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -16,15 +16,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{
-  "WorkingDirectory": "."
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -34,7 +26,17 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{
+  "WorkingDirectory": "."
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Run Pester tests

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -17,7 +17,22 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
+### GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | LabVIEW version for the test run. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Base directory for the action; relative paths are resolved from here. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
+## Examples
+
+### CLI
 
 ```powershell
 $json = @'
@@ -35,20 +50,7 @@ Alternatively, load arguments from a JSON file:
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json
 ```
 
-## GitHub Action inputs
-
-GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
-
-| Input | CLI parameter | Description |
-| --- | --- | --- |
-| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | LabVIEW version for the test run. |
-| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
-| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
-| `working_directory` | `WorkingDirectory` | Base directory for the action; relative paths are resolved from here. |
-| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
-| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
-
-## GitHub Action example
+### GitHub Action
 
 ```yaml
 - name: Run LabVIEW Unit Tests

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -16,16 +16,7 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 None.
 
-## CLI example
-
-```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJson '{
-  "WorkingDirectory": ".",
-  "RelativePath": "."
-}'
-```
-
-## GitHub Action inputs
+### GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
 
@@ -37,7 +28,18 @@ GitHub Action inputs are provided in `snake_case`, while CLI parameters use `Pas
 | `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
 | `dry_run` | `DryRun` | If true, simulate the action without side effects. |
 
-## GitHub Action example
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJson '{
+  "WorkingDirectory": ".",
+  "RelativePath": "."
+}'
+```
+
+### GitHub Action
 
 ```yaml
 - name: Set development mode

--- a/docs/actions/setup-mkdocs.md
+++ b/docs/actions/setup-mkdocs.md
@@ -8,11 +8,13 @@ Install a pinned MkDocs with caching.
 
 None.
 
-## GitHub Action inputs
+### GitHub Action inputs
 
 This action has no inputs.
 
-## GitHub Action example
+## Examples
+
+### GitHub Action
 
 ```yaml
 - name: Setup MkDocs

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -8,6 +8,10 @@ Action documentation lives under [docs/actions](actions/README.md). Keep these f
 
 - Run `npm run verify:docs` to check that documented inputs match each action's action.yml.
 
+### Template
+
+Use [docs/template-action.md](template-action.md) as the starting point for new or updated action and workflow docs. Each document should include **Purpose**, **Parameters**, **Examples**, and **Return Codes** sections, with GitHub Action inputs mapped to CLI parameters and example code blocks for both CLI and GitHub usage.
+
 ## Markdown linting
 
 - Run `npm run lint:md` to lint Markdown formatting.

--- a/docs/template-action.md
+++ b/docs/template-action.md
@@ -1,0 +1,51 @@
+# Action Documentation Template
+
+This template standardizes action and workflow documentation.
+
+## Purpose
+
+Explain what the action or workflow does.
+
+## Parameters
+
+Describe required and optional parameters.
+
+### Required
+
+- **ParameterName** (`type`): Description of required parameter.
+
+### Optional
+
+- **ParameterName** (`type`): Description of optional parameter.
+
+### GitHub Action inputs
+
+Map GitHub Action inputs to CLI parameters when applicable.
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `input_name` | `ParameterName` | Explanation. |
+
+## Examples
+
+### CLI
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
+  "ParameterName": "value"
+}'
+```
+
+### GitHub Action
+
+```yaml
+- name: Run action
+  uses: owner/repo/<action-name>@v1
+  with:
+    input_name: value
+```
+
+## Return Codes
+
+- `0` – success
+- non‑zero – failure

--- a/docs/workflows/add-token-to-labview.md
+++ b/docs/workflows/add-token-to-labview.md
@@ -4,20 +4,22 @@
 
 Dispatch the [add-token-to-labview](../actions/add-token-to-labview.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: add-token-to-labview
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/apply-vipc.md
+++ b/docs/workflows/apply-vipc.md
@@ -4,20 +4,22 @@
 
 Dispatch the [apply-vipc](../actions/apply-vipc.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: apply-vipc
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName apply-vipc -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/build-lvlibp.md
+++ b/docs/workflows/build-lvlibp.md
@@ -4,20 +4,22 @@
 
 Dispatch the [build-lvlibp](../actions/build-lvlibp.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: build-lvlibp
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/build-vi-package.md
+++ b/docs/workflows/build-vi-package.md
@@ -4,20 +4,22 @@
 
 Dispatch the [build-vi-package](../actions/build-vi-package.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: build-vi-package
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build-vi-package -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/build.md
+++ b/docs/workflows/build.md
@@ -4,20 +4,22 @@
 
 Dispatch the [build](../actions/build.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: build
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName build -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/close-labview.md
+++ b/docs/workflows/close-labview.md
@@ -4,20 +4,22 @@
 
 Dispatch the [close-labview](../actions/close-labview.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: close-labview
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName close-labview -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/generate-release-notes.md
+++ b/docs/workflows/generate-release-notes.md
@@ -4,20 +4,22 @@
 
 Dispatch the [generate-release-notes](../actions/generate-release-notes.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: generate-release-notes
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/missing-in-project.md
+++ b/docs/workflows/missing-in-project.md
@@ -4,20 +4,22 @@
 
 Dispatch the [missing-in-project](../actions/missing-in-project.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: missing-in-project
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName missing-in-project -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/modify-vipb-display-info.md
+++ b/docs/workflows/modify-vipb-display-info.md
@@ -4,20 +4,22 @@
 
 Dispatch the [modify-vipb-display-info](../actions/modify-vipb-display-info.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: modify-vipb-display-info
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/prepare-labview-source.md
+++ b/docs/workflows/prepare-labview-source.md
@@ -4,20 +4,22 @@
 
 Dispatch the [prepare-labview-source](../actions/prepare-labview-source.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: prepare-labview-source
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/rename-file.md
+++ b/docs/workflows/rename-file.md
@@ -4,20 +4,22 @@
 
 Dispatch the [rename-file](../actions/rename-file.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: rename-file
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName rename-file -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/restore-setup-lv-source.md
+++ b/docs/workflows/restore-setup-lv-source.md
@@ -4,20 +4,22 @@
 
 Dispatch the [restore-setup-lv-source](../actions/restore-setup-lv-source.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: restore-setup-lv-source
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/revert-development-mode.md
+++ b/docs/workflows/revert-development-mode.md
@@ -4,20 +4,22 @@
 
 Dispatch the [revert-development-mode](../actions/revert-development-mode.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: revert-development-mode
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/run-pester-tests.md
+++ b/docs/workflows/run-pester-tests.md
@@ -4,20 +4,22 @@
 
 Dispatch the [run-pester-tests](../actions/run-pester-tests.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: run-pester-tests
@@ -49,6 +51,10 @@ jobs:
 
 After the workflow completes, the target repository will contain a `requirement-coverage.json` file summarizing requirement pass/fail status from the test run.
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/run-unit-tests.md
+++ b/docs/workflows/run-unit-tests.md
@@ -4,20 +4,22 @@
 
 Dispatch the [run-unit-tests](../actions/run-unit-tests.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: run-unit-tests
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/set-development-mode.md
+++ b/docs/workflows/set-development-mode.md
@@ -4,20 +4,22 @@
 
 Dispatch the [set-development-mode](../actions/set-development-mode.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: set-development-mode
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName set-development-mode -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/docs/workflows/setup-mkdocs.md
+++ b/docs/workflows/setup-mkdocs.md
@@ -4,20 +4,22 @@
 
 Dispatch the [setup-mkdocs](../actions/setup-mkdocs.md) action to a target repository through `Invoke-OSAction.ps1`.
 
-## Inputs
+## Parameters
 
-| Input | Description |
+### Inputs
+
+| Parameter | Description |
 | --- | --- |
 | `repository` | Repository in `owner/repo` format to operate on. |
 | `ref` | Branch or tag to check out. Defaults to `main`. |
 
-## Required secrets
+### Secrets
 
 | Secret | Description |
 | --- | --- |
 | `REPO_TOKEN` | Personal access token with permission to read the target repository. |
 
-## Example
+## Examples
 
 ```yaml
 name: setup-mkdocs
@@ -47,6 +49,10 @@ jobs:
         shell: pwsh
         run: ./actions/Invoke-OSAction.ps1 -ActionName setup-mkdocs -WorkingDirectory "${{ github.workspace }}/target"
 ```
+
+## Return Codes
+
+- N/A
 
 ## See also
 

--- a/error-summary.md
+++ b/error-summary.md
@@ -30,3 +30,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.837024" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.800893" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.986746" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.864368" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.814465" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002594" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.003391" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000188" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000128" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000309" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.014674" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.001837" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006485" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.020357" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.015986" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.012152" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.009454" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009706" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.007968" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001060" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000268" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000175" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000233" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000309" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000201" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000404" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.217622" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.118450" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.005865" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.809676" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.832402" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.604164" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.688320" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.692842" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.008360" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002228" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.003601" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000836" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000952" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003543" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000397" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001980" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002017" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001587" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000565" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001518" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.000885" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000159" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.075346" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.970642" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.797385" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.782704" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003471" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000897" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.298990" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.180063" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.257111" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.030078" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.053016" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.005243" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002524" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000469" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000331" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000468" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.014704" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004004" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.004130" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.009675" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.014851" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.005243" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009561" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004422" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.011505" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001568" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.003959" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000433" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000329" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000501" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.010709" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001090" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.645394" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.435265" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.318484" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.110031" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.957050" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.785877" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.961151" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.931806" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009009" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003440" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.005013" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001500" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001623" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003533" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000536" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001576" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002309" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001307" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000573" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001853" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001929" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.006144" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.327704" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.071358" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.156154" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.936249" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.002370" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001439" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8201.646681 -->
+	<!-- duration_ms 10759.39766 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- add reusable template for action and workflow documentation
- normalize headings and tables across existing action and workflow docs
- outline template usage in documentation style guide

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint -verbose`
- `scripts/check-commit-requirements.sh 7f82f0b8a7dc406f568e5eb2e52a9c6502cb1c98`
- `npm run check:traceability`

------
https://chatgpt.com/codex/tasks/task_e_68a58c439ca48329a5e85ad5b8ae284a