### PR TITLE
docs: list actions and workflows in reference nav

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 19.61 | 100.00 |
-| linux | 54 | 0 | 0 | 19.61 | 100.00 |
+| overall | 54 | 0 | 0 | 35.93 | 100.00 |
+| linux | 54 | 0 | 0 | 35.93 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 19.61 | 100.00 |
-| linux | 54 | 0 | 0 | 19.61 | 100.00 |
+| overall | 54 | 0 | 0 | 35.93 | 100.00 |
+| linux | 54 | 0 | 0 | 35.93 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,114 +4,114 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.028 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.020 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.045 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.156 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.110 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.037 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.021 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.974 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.700 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.006 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.180 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.299 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.030 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.053 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.872 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 2.048 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 2.523 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.938 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.328 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.004 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.932 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.957 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.071 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.961 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.257 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.435 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.011 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.063 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 2.731 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.002 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.620 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.743 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.032 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 2.133 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.594 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 2.053 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 3.075 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.786 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.936 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.318 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.645 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.324 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.600 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.684 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.944 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009009,
+          "duration": 0.028243,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00344,
+          "duration": 0.008283,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005013,
+          "duration": 0.020006,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0015,
+          "duration": 0.003619,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001623,
+          "duration": 0.004624,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003533,
+          "duration": 0.013659,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001576,
+          "duration": 0.003851,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002309,
+          "duration": 0.004271,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001307,
+          "duration": 0.004171,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000573,
+          "duration": 0.001948,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001853,
+          "duration": 0.004355,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009675,
+          "duration": 0.045091,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00237,
+          "duration": 0.00307,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001439,
+          "duration": 0.004361,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00109,
+          "duration": 0.000754,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011505,
+          "duration": 0.036579,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004422,
+          "duration": 0.021206,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009561,
+          "duration": 0.017892,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000329,
+          "duration": 0.000516,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.156154,
+          "duration": 1.973628,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005243,
+          "duration": 0.007065,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.110031,
+          "duration": 1.69985,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001929,
+          "duration": 0.002012,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006144,
+          "duration": 0.000339,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.180063,
+          "duration": 1.872328,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.29899,
+          "duration": 2.047539,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.030078,
+          "duration": 2.523409,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.053016,
+          "duration": 1.938118,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000469,
+          "duration": 0.000426,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000331,
+          "duration": 0.000291,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002524,
+          "duration": 0.004378,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000468,
+          "duration": 0.000957,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014704,
+          "duration": 0.062571,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.327704,
+          "duration": 2.730984,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001568,
+          "duration": 0.003979,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003959,
+          "duration": 0.001502,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000536,
+          "duration": 0.001752,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.931806,
+          "duration": 1.620135,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.95705,
+          "duration": 1.743187,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014851,
+          "duration": 0.031836,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005243,
+          "duration": 0.011323,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.071358,
+          "duration": 2.132872,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.961151,
+          "duration": 1.593974,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.257111,
+          "duration": 2.052942,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000433,
+          "duration": 0.000874,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.435265,
+          "duration": 3.074895,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010709,
+          "duration": 0.00071,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000501,
+          "duration": 0.001121,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.785877,
+          "duration": 1.324256,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.936249,
+          "duration": 1.600109,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.318484,
+          "duration": 2.683507,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00413,
+          "duration": 0.007133,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004004,
+          "duration": 0.007338,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.645394,
+          "duration": 2.943919,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 19.605653999999998,
+      "duration": 35.927758,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 19.605653999999998,
+        "duration": 35.927758,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,114 +4,114 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.028 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.020 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.045 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.004 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.156 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.110 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.037 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.021 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.974 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.700 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.006 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.180 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.299 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.030 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.053 |  |  |
+| Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.872 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 2.048 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 2.523 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.938 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.015 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.328 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.004 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.932 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.957 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.071 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.961 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.257 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.435 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.011 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.063 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 2.731 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.002 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.620 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.743 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.032 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 2.133 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.594 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 2.053 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 3.075 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.786 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.936 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.318 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.645 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.324 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.600 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.684 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.944 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"7f82f0b8a7dc406f568e5eb2e52a9c6502cb1c98","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"884d81859a0a74f94c5ecf6e653d19c7b69a40d9","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -46,3 +46,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,8 +46,45 @@ nav:
   - Reference:
       - Action Calls: action-call-reference.md
       - Common Parameters: common-parameters.md
-      - Actions: actions/index.md
-      - Workflows: workflows/index.md
+      - Actions:
+          - README: actions/README.md
+          - Overview: actions/index.md
+          - Add Token to LabVIEW: actions/add-token-to-labview.md
+          - Apply VIPC: actions/apply-vipc.md
+          - Build: actions/build.md
+          - Build LVLibp: actions/build-lvlibp.md
+          - Build VI Package: actions/build-vi-package.md
+          - Close LabVIEW: actions/close-labview.md
+          - Generate Release Notes: actions/generate-release-notes.md
+          - Missing in Project: actions/missing-in-project.md
+          - Modify VIPB Display Info: actions/modify-vipb-display-info.md
+          - Prepare LabVIEW Source: actions/prepare-labview-source.md
+          - Rename File: actions/rename-file.md
+          - Restore Setup LV Source: actions/restore-setup-lv-source.md
+          - Revert Development Mode: actions/revert-development-mode.md
+          - Run Pester Tests: actions/run-pester-tests.md
+          - Run Unit Tests: actions/run-unit-tests.md
+          - Set Development Mode: actions/set-development-mode.md
+          - Setup MkDocs: actions/setup-mkdocs.md
+      - Workflows:
+          - Overview: workflows/index.md
+          - Add Token to LabVIEW: workflows/add-token-to-labview.md
+          - Apply VIPC: workflows/apply-vipc.md
+          - Build: workflows/build.md
+          - Build LVLibp: workflows/build-lvlibp.md
+          - Build VI Package: workflows/build-vi-package.md
+          - Close LabVIEW: workflows/close-labview.md
+          - Generate Release Notes: workflows/generate-release-notes.md
+          - Missing in Project: workflows/missing-in-project.md
+          - Modify VIPB Display Info: workflows/modify-vipb-display-info.md
+          - Prepare LabVIEW Source: workflows/prepare-labview-source.md
+          - Rename File: workflows/rename-file.md
+          - Restore Setup LV Source: workflows/restore-setup-lv-source.md
+          - Revert Development Mode: workflows/revert-development-mode.md
+          - Run Pester Tests: workflows/run-pester-tests.md
+          - Run Unit Tests: workflows/run-unit-tests.md
+          - Set Development Mode: workflows/set-development-mode.md
+          - Setup MkDocs: workflows/setup-mkdocs.md
   - Developer Docs:
       - Adapter Authoring: adapter-authoring.md
       - Versioning: versioning.md

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.298990" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.180063" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.257111" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.030078" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.053016" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.005243" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002524" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000469" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000331" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000468" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.014704" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004004" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.004130" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.009675" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.014851" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.005243" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.009561" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004422" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.011505" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001568" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.003959" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000433" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000329" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000501" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.010709" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001090" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.645394" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.435265" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.318484" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.110031" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.957050" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.785877" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.961151" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.931806" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009009" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003440" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.005013" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001500" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001623" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003533" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000536" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001576" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002309" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001307" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000573" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001853" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001929" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.006144" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.327704" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.071358" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.156154" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.936249" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.002370" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001439" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="2.047539" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.872328" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="2.052942" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="2.523409" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.938118" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.007065" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004378" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000426" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000291" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000957" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.062571" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.007338" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.007133" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.045091" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.031836" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.011323" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.017892" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.021206" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.036579" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003979" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001502" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000874" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000516" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001121" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000710" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000754" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="2.943919" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="3.074895" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="2.683507" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.699850" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.743187" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.324256" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.593974" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.620135" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.028243" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.008283" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.020006" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.003619" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.004624" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.013659" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001752" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003851" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004271" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.004171" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001948" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.004355" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002012" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000339" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="2.730984" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="2.132872" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.973628" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.600109" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.003070" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.004361" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 10759.39766 -->
+	<!-- duration_ms 19563.977489 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- group reference docs by Actions and Workflows in mkdocs navigation so each page is directly accessible
- regenerate artifacts and test results

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_68a5909a715c8329ac9a4a4a85dcc016