### PR TITLE
docs: add script docs and navigation

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 35.93 | 100.00 |
-| linux | 54 | 0 | 0 | 35.93 | 100.00 |
+| overall | 54 | 0 | 0 | 16.07 | 100.00 |
+| linux | 54 | 0 | 0 | 16.07 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 35.93 | 100.00 |
-| linux | 54 | 0 | 0 | 35.93 | 100.00 |
+| overall | 54 | 0 | 0 | 16.07 | 100.00 |
+| linux | 54 | 0 | 0 | 16.07 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.028 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.020 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.006 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.045 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.037 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.021 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.974 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.700 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.868 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.924 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.872 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 2.048 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 2.523 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.938 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.915 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.025 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.941 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.855 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.063 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 2.731 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.002 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.620 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.743 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.032 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 2.133 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.594 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 2.053 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 3.075 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.729 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.842 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.934 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.722 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.988 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.224 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.324 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.600 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.684 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.944 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.875 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.085 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.271 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.028243,
+          "duration": 0.013722,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008283,
+          "duration": 0.015153,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020006,
+          "duration": 0.009201,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003619,
+          "duration": 0.00092,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004624,
+          "duration": 0.001426,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013659,
+          "duration": 0.008854,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003851,
+          "duration": 0.001873,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004271,
+          "duration": 0.001371,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004171,
+          "duration": 0.005664,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001948,
+          "duration": 0.002005,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004355,
+          "duration": 0.005457,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.045091,
+          "duration": 0.024678,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00307,
+          "duration": 0.001189,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004361,
+          "duration": 0.001113,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000754,
+          "duration": 0.000508,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.036579,
+          "duration": 0.007505,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.021206,
+          "duration": 0.007174,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017892,
+          "duration": 0.013161,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000516,
+          "duration": 0.000377,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.973628,
+          "duration": 0.868195,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007065,
+          "duration": 0.001911,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.69985,
+          "duration": 0.923732,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002012,
+          "duration": 0.001091,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000339,
+          "duration": 0.000142,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.872328,
+          "duration": 0.915346,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 2.047539,
+          "duration": 1.025091,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 2.523409,
+          "duration": 0.940833,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.938118,
+          "duration": 0.854835,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000426,
+          "duration": 0.000185,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000291,
+          "duration": 0.000209,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004378,
+          "duration": 0.001521,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000957,
+          "duration": 0.00158,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.062571,
+          "duration": 0.017305,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 2.730984,
+          "duration": 1.066923,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003979,
+          "duration": 0.00111,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001502,
+          "duration": 0.0004,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001752,
+          "duration": 0.001384,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.620135,
+          "duration": 0.72872,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.743187,
+          "duration": 0.841787,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.031836,
+          "duration": 0.020499,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011323,
+          "duration": 0.00681,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 2.132872,
+          "duration": 0.93371,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.593974,
+          "duration": 0.72232,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 2.052942,
+          "duration": 0.988132,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000874,
+          "duration": 0.000349,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 3.074895,
+          "duration": 1.224227,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00071,
+          "duration": 0.000341,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001121,
+          "duration": 0.000609,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.324256,
+          "duration": 0.617597,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.600109,
+          "duration": 0.875342,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 2.683507,
+          "duration": 1.085363,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007133,
+          "duration": 0.006335,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007338,
+          "duration": 0.002286,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 2.943919,
+          "duration": 1.271154,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 35.927758,
+      "duration": 16.068724999999997,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 35.927758,
+        "duration": 16.068724999999997,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.028 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.020 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.005 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.004 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.006 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.045 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.037 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.021 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.974 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.700 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.868 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.924 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.872 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 2.048 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 2.523 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.938 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.915 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.025 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.941 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.855 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.063 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 2.731 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.002 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.620 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.743 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.032 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 2.133 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.594 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 2.053 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 3.075 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.729 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.842 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.934 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.722 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.988 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.224 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.324 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.600 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.684 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.944 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.875 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.085 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.271 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"884d81859a0a74f94c5ecf6e653d19c7b69a40d9","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"0f51c14b5e4521946e09aaf67e2e6b3ed5dc5f7e","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/scripts/add-token-to-labview.md
+++ b/docs/scripts/add-token-to-labview.md
@@ -1,0 +1,27 @@
+# Add LabVIEW INI Token ⚙️
+
+Invoke **`AddTokenToLabVIEW.ps1`** through a composite action to add a `Localhost.LibraryPaths` token to the LabVIEW INI file via **g-cli**.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version used by g-cli. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/add-token-to-labview
+  with:
+    minimum_supported_lv_version: 2024
+    supported_bitness: 64
+    relative_path: ${{ github.workspace }}
+```
+
+See also: [docs/actions/add-token-to-labview.md](../actions/add-token-to-labview.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/apply-vipc.md
+++ b/docs/scripts/apply-vipc.md
@@ -1,0 +1,83 @@
+# Apply VIPC Dependencies 📦
+
+Ensure a runner has all required LabVIEW packages installed before building or testing. This composite action calls **`ApplyVIPC.ps1`** to apply a `.vipc` container through **g-cli**. The action automatically detects the `runner_dependencies.vipc` file located in this directory.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Inputs](#inputs)
+3. [Quick-start](#quick-start)
+4. [How it works](#how-it-works)
+5. [Troubleshooting](#troubleshooting)
+6. [License](#license)
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **Windows runner** | LabVIEW and g-cli are Windows only. |
+| **LabVIEW** `>= 2021` | Must match both `minimum_supported_lv_version` and `vip_lv_version`. |
+| **g-cli** in `PATH` | Used to apply the `.vipc` container. Install from NI Package Manager or include the executable in the runner image. |
+| **PowerShell 7** | Composite steps use PowerShell Core (`pwsh`). |
+
+---
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW *major* version that the repo supports. |
+| `vip_lv_version` | **Yes** | `2021` | LabVIEW version used to apply the `.vipc` file. Usually the same as `minimum_supported_lv_version`. |
+| `supported_bitness` | **Yes** | `32` or `64` | LabVIEW bitness to target. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Root path of the repository on disk. |
+
+---
+
+## Quick-start
+
+```yaml
+# .github/workflows/ci-composite.yml (excerpt)
+steps:
+  - uses: actions/checkout@v4
+  - name: Install LabVIEW dependencies
+    uses: ./.github/actions/apply-vipc
+    with:
+      minimum_supported_lv_version: 2021
+      vip_lv_version: 2021
+      supported_bitness: 64
+      relative_path: ${{ github.workspace }}
+```
+
+The CI pipeline applies these dependencies across multiple LabVIEW versions—2021 (32-bit and 64-bit) and 2023 (64-bit)—as shown in
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).
+
+---
+
+## How it works
+
+1. **Checkout** – pulls the repository to ensure scripts and the `.vipc` file are present.
+2. **PowerShell wrapper** – executes `ApplyVIPC.ps1` with the provided inputs.
+3. **g-cli invocation** – `ApplyVIPC.ps1` launches **g-cli** to apply the `.vipc` container to the specified LabVIEW installation.
+4. **Failure propagation** – any error in path resolution, g-cli, or the script causes the step (and job) to fail.
+
+---
+
+## Troubleshooting
+
+| Symptom | Hint |
+|---------|------|
+| *g-cli executable not found* | Ensure g-cli is installed and on `PATH`. |
+| *`.vipc` file not found* | Ensure `runner_dependencies.vipc` exists in this action directory. |
+| *LabVIEW version mismatch* | Make sure the installed LabVIEW version matches both version inputs. |
+
+---
+
+See also: [docs/actions/apply-vipc.md](../actions/apply-vipc.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/build-lvlibp.md
+++ b/docs/scripts/build-lvlibp.md
@@ -1,0 +1,39 @@
+# Build Packed Library 📦
+
+Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version to use. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
+| `major` | **Yes** | `1` | Major version component. |
+| `minor` | **Yes** | `0` | Minor version component. |
+| `patch` | **Yes** | `0` | Patch version component. |
+| `build` | **Yes** | `1` | Build number component. |
+| `commit` | **Yes** | `abcdef` | Commit identifier. |
+
+## Quick-start
+
+The following example builds using LabVIEW 2021.
+
+```yaml
+- uses: ./.github/actions/build-lvlibp
+  with:
+    minimum_supported_lv_version: 2021
+    supported_bitness: 64
+    relative_path: ${{ github.workspace }}
+    major: 1
+    minor: 0
+    patch: 0
+    build: 1
+    commit: ${{ github.sha }}
+```
+
+See also: [docs/actions/build-lvlibp.md](../actions/build-lvlibp.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/build-vi-package.md
+++ b/docs/scripts/build-vi-package.md
@@ -1,0 +1,42 @@
+# Build VI Package 📦
+
+Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the VI Package via g-cli.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `supported_bitness` | **Yes** | `64` | Target LabVIEW bitness. |
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
+| `labview_minor_revision` | No (defaults to `3`) | `3` | LabVIEW minor revision. |
+| `major` | **Yes** | `1` | Major version component. |
+| `minor` | **Yes** | `0` | Minor version component. |
+| `patch` | **Yes** | `0` | Patch version component. |
+| `build` | **Yes** | `1` | Build number component. |
+| `commit` | **Yes** | `abcdef` | Commit identifier. |
+| `release_notes_file` | **Yes** | `Tooling/deployment/release_notes.md` | Release notes file. |
+| `display_information_json` | **Yes** | `'{}'` | JSON for VIPB display information. |
+
+> **Note:** The action automatically uses the first `.vipb` file located in this directory.
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/build-vi-package
+  with:
+    supported_bitness: 64
+    minimum_supported_lv_version: 2024
+    major: 1
+    minor: 0
+    patch: 0
+    build: 1
+    commit: ${{ github.sha }}
+    release_notes_file: Tooling/deployment/release_notes.md
+    display_information_json: '{}'
+```
+
+See also: [docs/actions/build-vi-package.md](../actions/build-vi-package.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/build.md
+++ b/docs/scripts/build.md
@@ -1,0 +1,45 @@
+# Full Build 🛠️
+
+Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
+Each build records provenance by renaming output artifacts to include the
+build number and commit SHA and by writing an `artifact-manifest.json` file that
+maps the generated artifacts back to the source commit.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
+| `major` | **Yes** | `1` | Major version number. |
+| `minor` | **Yes** | `0` | Minor version number. |
+| `patch` | **Yes** | `0` | Patch version number. |
+| `build` | **Yes** | `1` | Build number. |
+| `commit` | **Yes** | `abcdef` | Commit identifier embedded in metadata. |
+| `labview_minor_revision` | No (defaults to `3`) | `3` | LabVIEW minor revision. |
+| `company_name` | **Yes** | `Acme Corp` | Company for display info. |
+| `author_name` | **Yes** | `Jane Doe` | Author for display info. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/build
+  with:
+    relative_path: ${{ github.workspace }}
+    major: 1
+    minor: 0
+    patch: 0
+    build: ${{ github.run_number }}
+    commit: ${{ github.sha }}
+    company_name: Example Co
+    author_name: CI
+```
+
+See also: [docs/actions/build.md](../actions/build.md)
+
+## Error handling
+
+On failure the script outputs `An unexpected error occurred during script execution: <details>` and returns a non-zero exit code.
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/close-labview.md
+++ b/docs/scripts/close-labview.md
@@ -1,0 +1,25 @@
+# Close LabVIEW 💤
+
+Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version to close. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/close-labview
+  with:
+    minimum_supported_lv_version: 2024
+    supported_bitness: 64
+```
+
+See also: [docs/actions/close-labview.md](../actions/close-labview.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/generate-release-notes.md
+++ b/docs/scripts/generate-release-notes.md
@@ -1,0 +1,19 @@
+# Generate Release Notes
+
+This composite action creates a Markdown file summarizing commits since the last tag.
+By default, it writes to `Tooling/deployment/release_notes.md`, which you can use when drafting changelogs or GitHub releases.
+
+## Inputs
+
+- `output_path` (optional): Path for the generated release notes file relative to the repository root. Defaults to `Tooling/deployment/release_notes.md`.
+
+## Example Usage
+
+```yaml
+- name: Generate release notes
+  uses: ./.github/actions/generate-release-notes
+  with:
+    output_path: Tooling/deployment/release_notes.md
+```
+
+See also: [docs/actions/generate-release-notes.md](../actions/generate-release-notes.md).

--- a/docs/scripts/missing-in-project.md
+++ b/docs/scripts/missing-in-project.md
@@ -1,0 +1,159 @@
+# Missing‑In‑Project 💼🔍
+
+Validate that **every file on disk that should live in a LabVIEW project _actually_ appears in the `.lvproj`.**  
+The check is executed as the _first_ step in your CI pipeline so the run fails fast and you never ship a package or run a unit test with a broken project file.
+
+Internally the action launches the **`MissingInProjectCLI.vi`** utility (checked into the same directory) through **g‑cli**.  
+Results are returned as standard GitHub Action outputs so downstream jobs can decide what to do next (for example, post a comment with the missing paths).
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)  
+2. [Inputs](#inputs)  
+3. [Outputs](#outputs)  
+4. [Quick-start](#quick-start)
+5. [Example: Fail-fast workflow](#example-fail-fast-workflow)
+6. [How it works](#how-it-works)  
+7. [Exit codes & failure modes](#exit-codes--failure-modes)  
+8. [Troubleshooting](#troubleshooting)  
+9. [Developing & testing locally](#developing--testing-locally)  
+10. [License](#license)
+
+---
+
+## Prerequisites
+
+| Requirement            | Notes |
+|------------------------|-------|
+| **Ubuntu runner**     | LabVIEW and g‑cli are available on Ubuntu. |
+| **LabVIEW** `>= 2020`  | Must match the _numeric_ version you pass in **`lv-ver`**. |
+| **g‑cli** in `PATH`    | The action calls `g-cli --lv-ver …`. Install from NI Package Manager or copy the executable into the runner image. |
+| **PowerShell 7**       | Composite steps use PowerShell Core (`pwsh`). |
+
+---
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `lv-ver` | **Yes** | `2021` | LabVIEW _major_ version number that should be used to run `MissingInProjectCLI.vi` |
+| `supported-bitness` | **Yes** | `32` or `64` | Bitness of the LabVIEW runtime to launch |
+| `project-file` | No | `source/MyPlugin.lvproj` | Path (absolute or relative to repository root) of the project to inspect. Defaults to **`lv_icon.lvproj`** |
+
+---
+
+## Outputs
+
+| Name | Type | Meaning |
+|------|------|---------|
+| `passed` | `true \| false` | `true` when _no_ missing files were detected and the VI ran without error |
+| `missing-files` | `string` | Comma‑separated list of _relative_ paths that are absent from the project (empty on success) |
+
+---
+
+## Quick-start
+
+```yaml
+# .github/workflows/ci-composite.yml – missing-in-project-check (excerpt)
+jobs:
+  missing-in-project-check:
+    needs: [changes, apply-deps]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify no files are missing from the project
+        id: mip
+        uses: ./.github/actions/missing-in-project
+        with:
+          lv-ver: 2021
+          supported-bitness: 64
+
+      - name: Print report
+        if: ${{ steps.mip.outputs.passed == 'false' }}
+        run: echo "Missing: ${{ steps.mip.outputs['missing-files'] }}"
+```
+
+---
+
+## Example: Fail-fast workflow
+
+If you want **any** missing file to abort the pipeline immediately, place the step in an _independent_ job at the top of your DAG and let every other job depend on it:
+
+```yaml
+jobs:
+  missing-in-project-check:
+    needs: [changes, apply-deps]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        supported_bitness: [32, 64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/missing-in-project
+        with:
+          lv-ver: 2021
+          supported-bitness: ${{ matrix.supported_bitness }}
+
+  build-package:
+    needs: missing-in-project-check
+    …
+```
+
+---
+
+## How it works
+
+1. **Path Resolution**  
+   A small PowerShell snippet expands `project-file` to an absolute path and throws if the file doesn’t exist.
+2. **Invoke‑MissingInProjectCLI.ps1 wrapper**  
+   - Launches `MissingInProjectCLI.vi` through **g‑cli**  
+   - Captures the VI’s exit status and writes any missing paths to `missing_files.txt`
+   - Translates the outcome into GitHub Action outputs (`passed`, `missing-files`) and an **exit code** (0, 1, 2).
+3. **Composite step result**  
+   GitHub Actions marks the step (and job) as **failed** if the exit code is non‑zero, causing a fail‑fast pipeline.
+
+---
+
+## Exit codes & failure modes
+
+| Exit | Scenario | Typical fix |
+|------|----------|-------------|
+| **0** | No missing files; VI ran successfully | Nothing to do |
+| **1** | g‑cli or the VI crashed (parsing failed) | Ensure g‑cli is in `PATH`, LabVIEW version matches `lv-ver`, VI dependencies are present |
+| **2** | The VI completed and found at least one missing file | Add the file(s) to the project or delete them from disk |
+
+---
+
+## Troubleshooting
+
+| Symptom | Hint |
+|---------|------|
+| _“g‑cli executable not found”_ | Verify g‑cli is installed and on `PATH` |
+| _“Project file not found”_ | Double‑check the value of `project-file`; relative paths are resolved against `GITHUB_WORKSPACE` |
+| _Step times out_ | Large projects can be slow to load; consider bumping the job’s default timeout. |
+
+---
+
+## Developing & testing locally
+
+```powershell
+pwsh -File .github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1 `
+      -LVVersion 2021 `
+      -SupportedBitness 64 `
+      -ProjectFile 'C:\path\to\MyProj.lvproj'
+
+echo "Exit code: $LASTEXITCODE"
+type .github/actions/missing-in-project/missing_files.txt
+```
+
+---
+
+See also: [docs/actions/missing-in-project.md](../actions/missing-in-project.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/modify-vipb-display-info.md
+++ b/docs/scripts/modify-vipb-display-info.md
@@ -1,0 +1,44 @@
+# Modify VIPB Display Info 📝
+
+Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file before packaging.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `supported_bitness` | **Yes** | `64` | Target LabVIEW bitness. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
+| `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
+| `labview_minor_revision` | No (defaults to `3`) | `3` | LabVIEW minor revision. |
+| `major` | **Yes** | `1` | Major version component. |
+| `minor` | **Yes** | `0` | Minor version component. |
+| `patch` | **Yes** | `0` | Patch version component. |
+| `build` | **Yes** | `1` | Build number component. |
+| `commit` | **Yes** | `abcdef` | Commit identifier. |
+| `release_notes_file` | **Yes** | `Tooling/deployment/release_notes.md` | Release notes file. |
+| `display_information_json` | **Yes** | `'{}'` | JSON for display information. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/modify-vipb-display-info
+  with:
+    supported_bitness: 64
+    relative_path: ${{ github.workspace }}
+    vipb_path: Tooling/deployment/NI Icon editor.vipb
+    minimum_supported_lv_version: 2024
+    major: 1
+    minor: 0
+    patch: 0
+    build: 1
+    commit: ${{ github.sha }}
+    release_notes_file: Tooling/deployment/release_notes.md
+    display_information_json: '{}'
+```
+
+See also: [docs/actions/modify-vipb-display-info.md](../actions/modify-vipb-display-info.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/prepare-labview-source.md
+++ b/docs/scripts/prepare-labview-source.md
@@ -1,0 +1,31 @@
+# Prepare LabVIEW Source 📁
+
+Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources before builds.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
+| `labview_project` | **Yes** | `lv_icon_editor` | Project name (no extension). |
+| `build_spec` | **Yes** | `Editor Packed Library` | Build specification name. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/prepare-labview-source
+  with:
+    minimum_supported_lv_version: 2024
+    supported_bitness: 64
+    relative_path: ${{ github.workspace }}
+    labview_project: lv_icon_editor
+    build_spec: "Editor Packed Library"
+```
+
+See also: [docs/actions/prepare-labview-source.md](../actions/prepare-labview-source.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/rename-file.md
+++ b/docs/scripts/rename-file.md
@@ -1,0 +1,25 @@
+# Rename File ✏️
+
+Use **`Rename-file.ps1`** to rename a file within the repository.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `current_filename` | **Yes** | `resource/plugins/lv_icon.lvlibp` | Existing file path. |
+| `new_filename` | **Yes** | `lv_icon_x64_v1.0.0.1+gabcdef.lvlibp` | New file name or path. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/rename-file
+  with:
+    current_filename: resource/plugins/lv_icon.lvlibp
+    new_filename: lv_icon_x64_v1.0.0.1+gabcdef.lvlibp
+```
+
+See also: [docs/actions/rename-file.md](../actions/rename-file.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/restore-setup-lv-source.md
+++ b/docs/scripts/restore-setup-lv-source.md
@@ -1,0 +1,31 @@
+# Restore LabVIEW Setup ↩️
+
+Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remove INI tokens.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
+| `labview_project` | **Yes** | `lv_icon_editor` | Project name (no extension). |
+| `build_spec` | **Yes** | `Editor Packed Library` | Build specification name. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/restore-setup-lv-source
+  with:
+    minimum_supported_lv_version: 2024
+    supported_bitness: 64
+    relative_path: ${{ github.workspace }}
+    labview_project: lv_icon_editor
+    build_spec: "Editor Packed Library"
+```
+
+See also: [docs/actions/restore-setup-lv-source.md](../actions/restore-setup-lv-source.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/revert-development-mode.md
+++ b/docs/scripts/revert-development-mode.md
@@ -1,0 +1,27 @@
+# Revert Development Mode 🔄
+
+Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after development work.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/revert-development-mode
+  with:
+    relative_path: ${{ github.workspace }}
+```
+
+See also: [docs/actions/revert-development-mode.md](../actions/revert-development-mode.md)
+
+## Error handling
+
+Failures emit `An unexpected error occurred during script execution: <details>` and the script exits with a non-zero status.
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/run-pester-tests.md
+++ b/docs/scripts/run-pester-tests.md
@@ -1,0 +1,28 @@
+# Run Pester Tests ✅
+
+Invoke **`RunPesterTests.ps1`** to execute PowerShell Pester tests under `tests/pester`.
+For full documentation, see [run-pester-tests action](../actions/run-pester-tests.md).
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `working_directory` | **Yes** | `.` | Path to the repository containing tests under `tests/pester`. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/run-pester-tests
+  with:
+    working_directory: '.'
+```
+
+## Outputs
+
+Upon completion a `requirement-coverage.json` file is written to the specified `working_directory`. It reports the pass/fail status of each requirement ID inferred from test tags.
+
+See also: [docs/actions/run-pester-tests.md](../actions/run-pester-tests.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/run-unit-tests.md
+++ b/docs/scripts/run-unit-tests.md
@@ -1,0 +1,26 @@
+# Run Unit Tests ✅
+
+Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result table.
+The script copies `UnitTestReport.xml` to `artifacts/unit-tests/UnitTestReport.xml` for later use.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
+| `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/run-unit-tests
+  with:
+    minimum_supported_lv_version: 2024
+    supported_bitness: 64
+```
+
+See also: [docs/actions/run-unit-tests.md](../actions/run-unit-tests.md)
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/docs/scripts/set-development-mode.md
+++ b/docs/scripts/set-development-mode.md
@@ -1,0 +1,27 @@
+# Set Development Mode 🔧
+
+Execute **`Set_Development_Mode.ps1`** to prepare the repository for active development.
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/set-development-mode
+  with:
+    relative_path: ${{ github.workspace }}
+```
+
+See also: [docs/actions/set-development-mode.md](../actions/set-development-mode.md)
+
+## Error handling
+
+Failures produce the message `An unexpected error occurred during script execution: <details>` and the script exits with a non-zero status.
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).

--- a/error-summary.md
+++ b/error-summary.md
@@ -62,3 +62,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,23 @@ nav:
           - Run Unit Tests: actions/run-unit-tests.md
           - Set Development Mode: actions/set-development-mode.md
           - Setup MkDocs: actions/setup-mkdocs.md
+      - Scripts:
+          - Add Token to LabVIEW: scripts/add-token-to-labview.md
+          - Apply VIPC: scripts/apply-vipc.md
+          - Build: scripts/build.md
+          - Build LVLibp: scripts/build-lvlibp.md
+          - Build VI Package: scripts/build-vi-package.md
+          - Close LabVIEW: scripts/close-labview.md
+          - Generate Release Notes: scripts/generate-release-notes.md
+          - Missing in Project: scripts/missing-in-project.md
+          - Modify VIPB Display Info: scripts/modify-vipb-display-info.md
+          - Prepare LabVIEW Source: scripts/prepare-labview-source.md
+          - Rename File: scripts/rename-file.md
+          - Restore Setup LV Source: scripts/restore-setup-lv-source.md
+          - Revert Development Mode: scripts/revert-development-mode.md
+          - Run Pester Tests: scripts/run-pester-tests.md
+          - Run Unit Tests: scripts/run-unit-tests.md
+          - Set Development Mode: scripts/set-development-mode.md
       - Workflows:
           - Overview: workflows/index.md
           - Add Token to LabVIEW: workflows/add-token-to-labview.md

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="2.047539" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.872328" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="2.052942" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="2.523409" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.938118" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.007065" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004378" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000426" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000291" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000957" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.062571" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.007338" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.007133" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.045091" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.031836" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.011323" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.017892" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.021206" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.036579" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003979" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001502" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000874" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000516" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001121" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000710" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000754" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="2.943919" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="3.074895" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="2.683507" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.699850" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.743187" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.324256" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.593974" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.620135" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.028243" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.008283" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.020006" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.003619" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.004624" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.013659" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001752" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003851" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004271" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.004171" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001948" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.004355" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.002012" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000339" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="2.730984" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="2.132872" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.973628" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.600109" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003070" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.004361" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.025091" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.915346" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.988132" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.940833" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.854835" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.001911" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001521" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000185" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000209" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.001580" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.017305" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002286" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006335" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.024678" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020499" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.006810" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.013161" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007174" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.007505" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001110" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000400" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000349" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000377" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000609" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000341" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000508" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.271154" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.224227" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.085363" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.923732" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.841787" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.617597" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.722320" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.728720" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.013722" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.015153" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.009201" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000920" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001426" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.008854" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001384" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001873" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001371" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.005664" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.002005" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.005457" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001091" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000142" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.066923" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.933710" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.868195" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.875342" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001189" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001113" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 19563.977489 -->
+	<!-- duration_ms 8820.452312 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- document all scripts under new `docs/scripts` directory
- add "Scripts" section to MkDocs navigation

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_68a5934a58448329935a6ea512bbcff0