### PR TITLE
docs: add user, contributor, and maintainer guides

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 16.07 | 100.00 |
-| linux | 54 | 0 | 0 | 16.07 | 100.00 |
+| overall | 54 | 0 | 0 | 15.52 | 100.00 |
+| linux | 54 | 0 | 0 | 15.52 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 16.07 | 100.00 |
-| linux | 54 | 0 | 0 | 16.07 | 100.00 |
+| overall | 54 | 0 | 0 | 15.52 | 100.00 |
+| linux | 54 | 0 | 0 | 15.52 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,84 +34,84 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.006 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.008 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.868 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.947 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.924 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.849 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.915 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.025 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.941 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.855 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.022 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.826 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.840 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.002 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.110 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.729 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.842 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.934 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.722 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.988 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.719 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.802 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.878 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.990 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.224 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.155 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.875 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.085 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.271 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.623 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.966 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.321 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013722,
+          "duration": 0.009997,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015153,
+          "duration": 0.001692,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009201,
+          "duration": 0.003535,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00092,
+          "duration": 0.001244,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001426,
+          "duration": 0.00127,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008854,
+          "duration": 0.003141,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001873,
+          "duration": 0.002577,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001371,
+          "duration": 0.001904,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005664,
+          "duration": 0.001062,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002005,
+          "duration": 0.000551,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005457,
+          "duration": 0.003635,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.024678,
+          "duration": 0.008443,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001189,
+          "duration": 0.001585,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001113,
+          "duration": 0.000845,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000508,
+          "duration": 0.001526,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007505,
+          "duration": 0.00978,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007174,
+          "duration": 0.004871,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013161,
+          "duration": 0.004161,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000377,
+          "duration": 0.000186,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.868195,
+          "duration": 0.947326,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001911,
+          "duration": 0.001804,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.923732,
+          "duration": 0.849308,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001091,
+          "duration": 0.001408,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000142,
+          "duration": 0.000141,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.915346,
+          "duration": 0.887821,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.025091,
+          "duration": 1.022369,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.940833,
+          "duration": 0.825534,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.854835,
+          "duration": 0.840257,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000185,
+          "duration": 0.000266,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000209,
+          "duration": 0.000225,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001521,
+          "duration": 0.002582,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00158,
+          "duration": 0.000505,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017305,
+          "duration": 0.022229,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.066923,
+          "duration": 1.110062,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00111,
+          "duration": 0.001156,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0004,
+          "duration": 0.000309,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001384,
+          "duration": 0.000524,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.72872,
+          "duration": 0.718915,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.841787,
+          "duration": 0.801653,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020499,
+          "duration": 0.006979,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00681,
+          "duration": 0.003882,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.93371,
+          "duration": 0.878308,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.72232,
+          "duration": 0.705254,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.988132,
+          "duration": 0.990038,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000349,
+          "duration": 0.000251,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.224227,
+          "duration": 1.154779,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000341,
+          "duration": 0.000163,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000609,
+          "duration": 0.000252,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.617597,
+          "duration": 0.623496,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.875342,
+          "duration": 0.769248,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.085363,
+          "duration": 0.96614,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006335,
+          "duration": 0.00306,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002286,
+          "duration": 0.004072,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.271154,
+          "duration": 1.320624,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 16.068724999999997,
+      "duration": 15.522945000000002,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 16.068724999999997,
+        "duration": 15.522945000000002,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.015 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.009 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,84 +34,84 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.006 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.008 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.868 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.947 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.924 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.849 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.915 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.025 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.941 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.855 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.022 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.826 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.840 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.002 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.110 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.729 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.842 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.934 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.722 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.988 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.719 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.802 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.878 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.990 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.224 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.155 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.618 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.875 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.085 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.271 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.623 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.966 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.321 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"0f51c14b5e4521946e09aaf67e2e6b3ed5dc5f7e","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"f3fa634ca1a8bf22c98dc2036262c488ed10c7cf","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -1,0 +1,11 @@
+# Contributor Guide
+
+This guide assists those who modify actions or documentation.
+
+## Typical Tasks
+
+- Review the overall [Architecture](architecture.md).
+- Develop new adapters following the [Adapter Authoring Guide](adapter-authoring.md).
+- Prepare a development machine via [Environment Setup](environment-setup.md).
+- Run unit tests as described in the [Testing guide](testing-pester.md).
+- Update docs with the help of [Contributing Docs](contributing-docs.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@ Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerS
 
 - [Architecture](architecture.md)
 - [Quickstart](quickstart.md)
+- [User Guide](user-guide.md)
+- [Contributor Guide](contributor-guide.md)
+- [Maintainer Guide](maintainer-guide.md)
 - [Environment Setup](environment-setup.md)
 - [Action Call Reference](action-call-reference.md)
 - [Common Parameters](common-parameters.md)

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -1,0 +1,10 @@
+# Maintainer Guide
+
+Maintainers oversee releases and repository health.
+
+## Typical Tasks
+
+- Direct new users to the [Quickstart](quickstart.md) and ensure documentation stays current.
+- Review adapter contributions against the [Adapter Authoring Guide](adapter-authoring.md).
+- Run and review results from the [Testing guide](testing-pester.md) before merging.
+- Publish releases following the [Versioning Policy](versioning.md).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,11 @@
+# User Guide
+
+End users run the provided composite actions in their own workflows.
+
+## Typical Tasks
+
+- Get up to speed with the [Quickstart](quickstart.md).
+- Configure prerequisites using [Environment Setup](environment-setup.md).
+- Invoke actions by referencing the [Action Call Reference](action-call-reference.md) and shared [Common Parameters](common-parameters.md).
+- Validate changes with the [Testing guide](testing-pester.md).
+- Troubleshoot issues using the [Troubleshooting](troubleshooting.md) tips.

--- a/error-summary.md
+++ b/error-summary.md
@@ -78,3 +78,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.025091" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.915346" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.988132" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.940833" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.854835" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.001911" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001521" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000185" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000209" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001580" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.017305" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002286" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006335" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.024678" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020499" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006810" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.013161" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007174" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.007505" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001110" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000400" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000349" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000377" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000609" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000341" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000508" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.271154" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.224227" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.085363" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.923732" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.841787" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.617597" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.722320" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.728720" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.013722" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.015153" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.009201" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000920" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001426" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.008854" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001384" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001873" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001371" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.005664" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.002005" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.005457" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001091" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000142" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.066923" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.933710" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.868195" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.875342" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001189" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001113" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.022369" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.887821" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.990038" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.825534" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.840257" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.001804" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002582" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000266" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000225" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000505" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.022229" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004072" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.003060" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.008443" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.006979" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003882" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.004161" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004871" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.009780" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001156" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000309" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000251" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000186" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000252" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000163" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001526" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.320624" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.154779" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.966140" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.849308" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.801653" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.623496" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.705254" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.718915" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009997" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001692" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.003535" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001244" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001270" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003141" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000524" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002577" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001904" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001062" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000551" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.003635" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001408" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000141" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.110062" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.878308" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.947326" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.769248" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001585" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000845" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8820.452312 -->
+	<!-- duration_ms 8437.972077 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- add user, contributor, and maintainer guides outlining common tasks
- reference new guides from the documentation index

## Testing
- `node --version`
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh HEAD~1`


------
https://chatgpt.com/codex/tasks/task_e_68a595473c14832987af0c28bdcc4f08