### PR TITLE
docs: update traceability badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source LabVIEW Actions
 
-[![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/open-source-actions/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/open-source-actions/summary.md)
+[![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/summary.md)
 
 Open Source LabVIEW Actions provides typed GitHub Action wrappers around a unified PowerShell dispatcher for LabVIEW CI/CD tasks. Each adapter (for example `run-unit-tests`) is exposed as its own action and can be called from workflows with `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1`.
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -8,7 +8,7 @@
   "skip": [
     "https://open-source-actions.github.io/open-source-actions/",
     "http://127.0.0.1:8000/",
-    "https://LabVIEW-Community-CI-CD.github.io/open-source-actions/summary.md",
-    "https://labview-community-ci-cd.github.io/open-source-actions/summary.md"
+    "https://LabVIEW-Community-CI-CD.github.io/summary.md",
+    "https://labview-community-ci-cd.github.io/summary.md"
   ]
 }

--- a/test-results/linkinator.log
+++ b/test-results/linkinator.log
@@ -1,0 +1,3 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+🏊‍♂️ crawling README.md docs scripts
+🤖 Successfully scanned 18 links in 0.244 seconds.

--- a/test-results/lint-md.log
+++ b/test-results/lint-md.log
@@ -1,0 +1,8 @@
+
+> open-source-actions@1.0.0 lint:md
+> markdownlint-cli2 README.md "docs/**/*.md" "scripts/**/*.md"
+
+markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
+Finding: README.md docs/**/*.md scripts/**/*.md
+Linting: 91 file(s)
+Summary: 0 error(s)


### PR DESCRIPTION
## Summary
- update traceability badge and summary URLs in README
- skip new summary link in linkinator configuration
- capture lint and link check logs

## Testing
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`


------
https://chatgpt.com/codex/tasks/task_e_68a59a437fb083298caba208933b2ef4