### PR TITLE
docs: update action references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/summary.md)
 
-Open Source LabVIEW Actions provides typed GitHub Action wrappers around a unified PowerShell dispatcher for LabVIEW CI/CD tasks. Each adapter (for example `run-unit-tests`) is exposed as its own action and can be called from workflows with `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1`.
+Open Source LabVIEW Actions provides typed GitHub Action wrappers around a unified PowerShell dispatcher for LabVIEW CI/CD tasks. Each adapter (for example `run-unit-tests`) is exposed as its own action and can be called from workflows with `uses: LabVIEW-Community-CI-CD/open-source/<action>@v1`.
 
 For setup and action reference, see the [documentation](docs/index.md). The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md). For a mapping of high-level requirements to the tests that verify them, see [docs/requirements.md](docs/requirements.md).
 
@@ -19,7 +19,7 @@ See [Environment Setup](docs/environment-setup.md) for installation steps and co
 
 ```yaml
 - name: Run tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -41,7 +41,7 @@ Common optional inputs available on all wrappers:
 Run tests from a subfolder:
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -51,7 +51,7 @@ Run tests from a subfolder:
 Enable debug logging and perform a dry run:
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.52 | 100.00 |
-| linux | 54 | 0 | 0 | 15.52 | 100.00 |
+| overall | 54 | 0 | 0 | 14.38 | 100.00 |
+| linux | 54 | 0 | 0 | 14.38 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.52 | 100.00 |
-| linux | 54 | 0 | 0 | 15.52 | 100.00 |
+| overall | 54 | 0 | 0 | 14.38 | 100.00 |
+| linux | 54 | 0 | 0 | 14.38 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.003 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,19 +34,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,60 +58,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.008 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.947 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.945 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.849 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.845 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.022 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.826 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.840 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.897 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.929 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.767 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.781 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.110 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.027 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.904 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.719 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.802 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.878 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.990 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.646 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.764 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.773 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.665 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.842 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.155 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.039 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.623 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.966 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.321 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.576 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.718 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.952 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.206 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009997,
+          "duration": 0.008189,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001692,
+          "duration": 0.004103,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003535,
+          "duration": 0.003077,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001244,
+          "duration": 0.000976,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00127,
+          "duration": 0.000987,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003141,
+          "duration": 0.001343,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002577,
+          "duration": 0.000923,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001904,
+          "duration": 0.001072,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001062,
+          "duration": 0.000549,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000551,
+          "duration": 0.000388,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003635,
+          "duration": 0.001157,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008443,
+          "duration": 0.018631,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001585,
+          "duration": 0.001557,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000845,
+          "duration": 0.000783,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001526,
+          "duration": 0.000347,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00978,
+          "duration": 0.003909,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004871,
+          "duration": 0.006795,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004161,
+          "duration": 0.010474,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000186,
+          "duration": 0.000257,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.947326,
+          "duration": 0.944553,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001804,
+          "duration": 0.00182,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.849308,
+          "duration": 0.844586,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001408,
+          "duration": 0.001145,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000141,
+          "duration": 0.000179,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.887821,
+          "duration": 0.896994,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.022369,
+          "duration": 0.929187,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.825534,
+          "duration": 0.766951,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.840257,
+          "duration": 0.78089,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000266,
+          "duration": 0.000164,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000225,
+          "duration": 0.000191,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002582,
+          "duration": 0.001587,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000505,
+          "duration": 0.000377,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022229,
+          "duration": 0.026975,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.110062,
+          "duration": 0.903527,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001156,
+          "duration": 0.000924,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000309,
+          "duration": 0.000312,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000524,
+          "duration": 0.000388,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.718915,
+          "duration": 0.646429,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.801653,
+          "duration": 0.764138,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006979,
+          "duration": 0.017325,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003882,
+          "duration": 0.002012,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.878308,
+          "duration": 0.772679,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.705254,
+          "duration": 0.665392,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.990038,
+          "duration": 0.842021,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000251,
+          "duration": 0.000371,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.154779,
+          "duration": 1.039377,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000163,
+          "duration": 0.000188,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000252,
+          "duration": 0.000384,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.623496,
+          "duration": 0.575626,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.769248,
+          "duration": 0.717536,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.96614,
+          "duration": 0.952151,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00306,
+          "duration": 0.009482,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004072,
+          "duration": 0.005364,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.320624,
+          "duration": 1.206346,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.522945000000002,
+      "duration": 14.383088000000003,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.522945000000002,
+        "duration": 14.383088000000003,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.003 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,19 +34,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -58,60 +58,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.008 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.019 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.010 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.947 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.945 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.849 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.845 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.022 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.826 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.840 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.897 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.929 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.767 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.781 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.110 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.027 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.904 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.719 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.802 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.878 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.990 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.646 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.764 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.773 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.665 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.842 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.155 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.039 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.623 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.966 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.321 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.576 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.718 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.952 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.009 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.206 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"f3fa634ca1a8bf22c98dc2036262c488ed10c7cf","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"f34c573733ff0db28ecc5c492dd061c7ada8810b","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -1,13 +1,13 @@
 # Action Call Reference
 
-Each adapter in this repository is available as its own GitHub Action. Call them using `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1` with the required inputs shown below. Refer to the linked documentation for full parameter details.
+Each adapter in this repository is available as its own GitHub Action. Call them using `uses: LabVIEW-Community-CI-CD/open-source/<action>@v1` with the required inputs shown below. Refer to the linked documentation for full parameter details.
 
 ## add-token-to-labview
 
 See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/add-token-to-labview@v1
+- uses: LabVIEW-Community-CI-CD/open-source/add-token-to-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -19,7 +19,7 @@ See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 See [apply-vipc](actions/apply-vipc.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+- uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
   with:
     minimum_supported_lv_version: '2019'
     vip_lv_version: '2019'
@@ -32,7 +32,7 @@ See [apply-vipc](actions/apply-vipc.md) for all parameters.
 See [build](actions/build.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build@v1
   with:
     relative_path: '.'
     major: 1
@@ -50,7 +50,7 @@ See [build](actions/build.md) for all parameters.
 See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'
@@ -69,7 +69,7 @@ See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 See [build-vi-package](actions/build-vi-package.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build-vi-package@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build-vi-package@v1
   with:
     minimum_supported_lv_version: '2023'
     supported_bitness: '64'
@@ -89,7 +89,7 @@ See [build-vi-package](actions/build-vi-package.md) for all parameters.
 See [close-labview](actions/close-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/close-labview@v1
+- uses: LabVIEW-Community-CI-CD/open-source/close-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -100,7 +100,7 @@ See [close-labview](actions/close-labview.md) for all parameters.
 See [generate-release-notes](actions/generate-release-notes.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/generate-release-notes@v1
+- uses: LabVIEW-Community-CI-CD/open-source/generate-release-notes@v1
 ```
 
 ## missing-in-project
@@ -108,7 +108,7 @@ See [generate-release-notes](actions/generate-release-notes.md) for all paramete
 See [missing-in-project](actions/missing-in-project.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/missing-in-project@v1
+- uses: LabVIEW-Community-CI-CD/open-source/missing-in-project@v1
   with:
     lv_version: '2020'
     supported_bitness: '64'
@@ -120,7 +120,7 @@ See [missing-in-project](actions/missing-in-project.md) for all parameters.
 See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/modify-vipb-display-info@v1
+- uses: LabVIEW-Community-CI-CD/open-source/modify-vipb-display-info@v1
   with:
     supported_bitness: '64'
     relative_path: '.'
@@ -140,7 +140,7 @@ See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all para
 See [prepare-labview-source](actions/prepare-labview-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/prepare-labview-source@v1
+- uses: LabVIEW-Community-CI-CD/open-source/prepare-labview-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -154,7 +154,7 @@ See [prepare-labview-source](actions/prepare-labview-source.md) for all paramete
 See [rename-file](actions/rename-file.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/rename-file@v1
+- uses: LabVIEW-Community-CI-CD/open-source/rename-file@v1
   with:
     current_filename: 'C:/path/lv_icon.lvlibp'
     new_filename: 'lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'
@@ -165,7 +165,7 @@ See [rename-file](actions/rename-file.md) for all parameters.
 See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/restore-setup-lv-source@v1
+- uses: LabVIEW-Community-CI-CD/open-source/restore-setup-lv-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -179,7 +179,7 @@ See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parame
 See [revert-development-mode](actions/revert-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+- uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
   with:
     relative_path: '.'
 ```
@@ -189,7 +189,7 @@ See [revert-development-mode](actions/revert-development-mode.md) for all parame
 See [run-pester-tests](actions/run-pester-tests.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-pester-tests@v1
   with:
     working_directory: '.'
 ```
@@ -199,7 +199,7 @@ See [run-pester-tests](actions/run-pester-tests.md) for all parameters.
 See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'
@@ -210,7 +210,7 @@ See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 See [set-development-mode](actions/set-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+- uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
   with:
     relative_path: '.'
 ```
@@ -220,5 +220,5 @@ See [set-development-mode](actions/set-development-mode.md) for all parameters.
 See [setup-mkdocs](actions/setup-mkdocs.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
+- uses: LabVIEW-Community-CI-CD/open-source/setup-mkdocs@v1
 ```

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -49,7 +49,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 
 ```yaml
 - name: Add library token
-  uses: LabVIEW-Community-CI-CD/open-source-actions/add-token-to-labview@v1
+  uses: LabVIEW-Community-CI-CD/open-source/add-token-to-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 
 ```yaml
 - name: Apply VIPC
-  uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+  uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
   with:
     minimum_supported_lv_version: '2019'
     vip_lv_version: '2019'

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -70,7 +70,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 
 ```yaml
 - name: Build Packed Library
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -74,7 +74,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 
 ```yaml
 - name: Build VI Package
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build-vi-package@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build-vi-package@v1
   with:
     minimum_supported_lv_version: '2023'
     supported_bitness: '64'

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -67,7 +67,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 
 ```yaml
 - name: Build project
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -45,7 +45,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 
 ```yaml
 - name: Close LabVIEW
-  uses: LabVIEW-Community-CI-CD/open-source-actions/close-labview@v1
+  uses: LabVIEW-Community-CI-CD/open-source/close-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -42,7 +42,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 
 ```yaml
 - name: Generate release notes
-  uses: LabVIEW-Community-CI-CD/open-source-actions/generate-release-notes@v1
+  uses: LabVIEW-Community-CI-CD/open-source/generate-release-notes@v1
   with:
     output_path: 'Tooling/deployment/release_notes.md'
 ```

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -48,7 +48,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 
 ```yaml
 - name: Check for Missing Project Items
-  uses: LabVIEW-Community-CI-CD/open-source-actions/missing-in-project@v1
+  uses: LabVIEW-Community-CI-CD/open-source/missing-in-project@v1
   with:
     lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -74,7 +74,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 
 ```yaml
 - name: Modify VIPB display info
-  uses: LabVIEW-Community-CI-CD/open-source-actions/modify-vipb-display-info@v1
+  uses: LabVIEW-Community-CI-CD/open-source/modify-vipb-display-info@v1
   with:
     supported_bitness: '64'
     working_directory: '.'

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 
 ```yaml
 - name: Prepare LabVIEW source
-  uses: LabVIEW-Community-CI-CD/open-source-actions/prepare-labview-source@v1
+  uses: LabVIEW-Community-CI-CD/open-source/prepare-labview-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -45,7 +45,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 
 ```yaml
 - name: Rename file
-  uses: LabVIEW-Community-CI-CD/open-source-actions/rename-file@v1
+  uses: LabVIEW-Community-CI-CD/open-source/rename-file@v1
   with:
     current_filename: 'C:/path/lv_icon.lvlibp'
     new_filename: 'lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 
 ```yaml
 - name: Restore LabVIEW setup
-  uses: LabVIEW-Community-CI-CD/open-source-actions/restore-setup-lv-source@v1
+  uses: LabVIEW-Community-CI-CD/open-source/restore-setup-lv-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -43,7 +43,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 
 ```yaml
 - name: Revert development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+  uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -40,7 +40,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{
 
 ```yaml
 - name: Run Pester tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-pester-tests@v1
   with:
     working_directory: '.'
 ```

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -54,7 +54,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./co
 
 ```yaml
 - name: Run LabVIEW Unit Tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -43,7 +43,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 
 ```yaml
 - name: Set development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+  uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/setup-mkdocs.md
+++ b/docs/actions/setup-mkdocs.md
@@ -18,7 +18,7 @@ This action has no inputs.
 
 ```yaml
 - name: Setup MkDocs
-  uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
+  uses: LabVIEW-Community-CI-CD/open-source/setup-mkdocs@v1
 ```
 
 ## Return Codes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Packed Library (32-bit)
-        uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+        uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
         with:
           minimum_supported_lv_version: '2019'
           supported_bitness: '32'
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: LabVIEW-Community-CI-CD/labview-icon-editor
           path: labview-icon-editor
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
         with:
           minimum_supported_lv_version: '2021'
           vip_lv_version: '2021'
@@ -78,13 +78,13 @@ jobs:
           working_directory: labview-icon-editor
           relative_path: '.'
           vipc_path: labview-icon-editor/.github/actions/apply-vipc/runner_dependencies.vipc
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
         with:
           minimum_supported_lv_version: '2021'
           supported_bitness: '64'
           working_directory: labview-icon-editor
           relative_path: '.'
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/build@v1
         with:
           working_directory: labview-icon-editor
           relative_path: '.'
@@ -96,7 +96,7 @@ jobs:
           labview_minor_revision: '3'
           company_name: 'Acme Corp'
           author_name: 'Jane Doe'
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
         with:
           working_directory: labview-icon-editor
           relative_path: '.'

--- a/error-summary.md
+++ b/error-summary.md
@@ -94,3 +94,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.022369" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.887821" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.990038" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.825534" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.840257" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.001804" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002582" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000266" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000225" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000505" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022229" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004072" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.003060" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.008443" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.006979" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.003882" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.004161" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004871" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.009780" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001156" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000309" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000251" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000186" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000252" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000163" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001526" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.320624" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.154779" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.966140" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.849308" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.801653" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.623496" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.705254" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.718915" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009997" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001692" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.003535" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001244" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001270" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003141" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000524" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002577" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001904" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001062" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000551" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.003635" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001408" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000141" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.110062" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.878308" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.947326" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.769248" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001585" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000845" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.929187" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.896994" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.842021" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.766951" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.780890" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.001820" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001587" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000164" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000191" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000377" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.026975" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005364" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.009482" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.018631" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.017325" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.002012" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.010474" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.006795" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.003909" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.000924" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000312" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000371" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000257" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000384" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000188" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000347" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.206346" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.039377" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.952151" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.844586" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.764138" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.575626" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.665392" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.646429" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.008189" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004103" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.003077" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000976" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000987" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001343" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000388" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000923" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001072" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000549" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000388" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001157" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001145" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000179" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.903527" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.772679" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.944553" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.717536" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001557" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000783" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8437.972077 -->
+	<!-- duration_ms 7973.694108 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- replace `LabVIEW-Community-CI-CD/open-source-actions/` with `LabVIEW-Community-CI-CD/open-source/` across README and docs
- regenerate CI evidence

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh f34c573733ff0db28ecc5c492dd061c7ada8810b`


------
https://chatgpt.com/codex/tasks/task_e_68a59bcf136c8329b1a46eef56eaeb88