### PR TITLE
docs: refresh README intro and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/summary.md)
 
-Open Source LabVIEW Actions provides typed GitHub Action wrappers around a unified PowerShell dispatcher for LabVIEW CI/CD tasks. Each adapter (for example `run-unit-tests`) is exposed as its own action and can be called from workflows with `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1`.
-
-For setup and action reference, see the [documentation](docs/index.md). The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md). For a mapping of high-level requirements to the tests that verify them, see [docs/requirements.md](docs/requirements.md).
+Open Source LabVIEW Actions is a collection of GitHub Actions and PowerShell scripts that streamline LabVIEW CI/CD workflows. Each task is exposed as its own action backed by a unified dispatcher. Refer to the [documentation](docs/index.md) for setup guidance, detailed examples, and the complete action reference.
 
 ## Prerequisites
 
@@ -19,7 +17,7 @@ See [Environment Setup](docs/environment-setup.md) for installation steps and co
 
 ```yaml
 - name: Run tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -41,7 +39,7 @@ Common optional inputs available on all wrappers:
 Run tests from a subfolder:
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -51,7 +49,7 @@ Run tests from a subfolder:
 Enable debug logging and perform a dry run:
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/actions/OpenSourceActions.psd1
+++ b/actions/OpenSourceActions.psd1
@@ -5,7 +5,7 @@
   Author                = 'LabVIEW Community CI/CD'
   CompanyName           = 'LabVIEW Community'
   Copyright             = '(c) 2025 LabVIEW Community'
-  Description           = 'Unified dispatcher adapters for open-source-actions'
+  Description           = 'Unified dispatcher adapters for open-source'
   PowerShellVersion     = '7.0'
   CompatiblePSEditions  = @('Core')
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.26 | 100.00 |
-| linux | 54 | 0 | 0 | 15.26 | 100.00 |
+| overall | 54 | 0 | 0 | 14.22 | 100.00 |
+| linux | 54 | 0 | 0 | 14.22 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 15.26 | 100.00 |
-| linux | 54 | 0 | 0 | 15.26 | 100.00 |
+| overall | 54 | 0 | 0 | 14.22 | 100.00 |
+| linux | 54 | 0 | 0 | 14.22 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.908 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.849 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.983 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.809 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.005 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.848 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.984 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.862 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.918 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.940 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.758 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.892 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.966 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.906 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.725 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.765 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.937 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.693 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.864 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.707 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.694 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.021 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.741 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.668 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.794 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.045 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.980 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.598 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.815 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.044 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.010 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.178 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.564 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.705 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.981 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.140 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013051,
+          "duration": 0.010782,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001978,
+          "duration": 0.007818,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00586,
+          "duration": 0.00183,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000776,
+          "duration": 0.002576,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000961,
+          "duration": 0.002124,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001978,
+          "duration": 0.002788,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000946,
+          "duration": 0.001336,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001212,
+          "duration": 0.003507,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000722,
+          "duration": 0.001345,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000572,
+          "duration": 0.000906,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002497,
+          "duration": 0.003383,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010711,
+          "duration": 0.01024,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00125,
+          "duration": 0.001046,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001716,
+          "duration": 0.003195,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00112,
+          "duration": 0.000643,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008236,
+          "duration": 0.009168,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006925,
+          "duration": 0.010491,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011147,
+          "duration": 0.01121,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000448,
+          "duration": 0.000417,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.908202,
+          "duration": 0.849063,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002885,
+          "duration": 0.003322,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.982879,
+          "duration": 0.80886,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001052,
+          "duration": 0.005157,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00021,
+          "duration": 0.000205,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.848038,
+          "duration": 0.917837,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.983792,
+          "duration": 0.939881,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.862378,
+          "duration": 0.758437,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.906077,
+          "duration": 0.892094,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000223,
+          "duration": 0.000361,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001317,
+          "duration": 0.000173,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001526,
+          "duration": 0.001456,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000399,
+          "duration": 0.000332,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022864,
+          "duration": 0.022132,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.966261,
+          "duration": 0.906265,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00176,
+          "duration": 0.0022,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000327,
+          "duration": 0.001198,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000439,
+          "duration": 0.000521,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.725273,
+          "duration": 0.706569,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.764593,
+          "duration": 0.693747,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006138,
+          "duration": 0.016216,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010612,
+          "duration": 0.021273,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.937453,
+          "duration": 0.740869,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.693193,
+          "duration": 0.668444,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.863637,
+          "duration": 0.794429,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000528,
+          "duration": 0.001213,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.04472,
+          "duration": 0.980198,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000471,
+          "duration": 0.000379,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00056,
+          "duration": 0.000624,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.597682,
+          "duration": 0.563797,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.815296,
+          "duration": 0.704977,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.044295,
+          "duration": 0.980787,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009968,
+          "duration": 0.01181,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002501,
+          "duration": 0.003551,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.177582,
+          "duration": 1.140125,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.257237,
+      "duration": 14.223307000000002,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.257237,
+        "duration": 14.223307000000002,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,54 +64,54 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.011 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.908 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.849 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.983 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.809 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.005 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.848 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.984 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.862 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.918 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.940 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.758 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.892 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.966 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.906 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.725 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.765 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.006 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.011 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.937 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.693 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.864 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.707 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.694 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.021 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.741 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.668 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.794 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.045 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.980 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.598 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.815 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.044 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.010 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.178 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.564 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.705 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.981 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.140 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"3aeaac34201042124d849a474c567cabf217d8f7","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"18acf10f67c1d2e12a76f2b87e62cea85d1e5162","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -1,13 +1,13 @@
 # Action Call Reference
 
-Each adapter in this repository is available as its own GitHub Action. Call them using `uses: LabVIEW-Community-CI-CD/open-source-actions/<action>@v1` with the required inputs shown below. Refer to the linked documentation for full parameter details.
+Each adapter in this repository is available as its own GitHub Action. Call them using `uses: LabVIEW-Community-CI-CD/open-source/<action>@v1` with the required inputs shown below. Refer to the linked documentation for full parameter details.
 
 ## add-token-to-labview
 
 See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/add-token-to-labview@v1
+- uses: LabVIEW-Community-CI-CD/open-source/add-token-to-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -19,7 +19,7 @@ See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 See [apply-vipc](actions/apply-vipc.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+- uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
   with:
     minimum_supported_lv_version: '2019'
     vip_lv_version: '2019'
@@ -32,7 +32,7 @@ See [apply-vipc](actions/apply-vipc.md) for all parameters.
 See [build](actions/build.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build@v1
   with:
     relative_path: '.'
     major: 1
@@ -50,7 +50,7 @@ See [build](actions/build.md) for all parameters.
 See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'
@@ -69,7 +69,7 @@ See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 See [build-vi-package](actions/build-vi-package.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/build-vi-package@v1
+- uses: LabVIEW-Community-CI-CD/open-source/build-vi-package@v1
   with:
     minimum_supported_lv_version: '2023'
     supported_bitness: '64'
@@ -89,7 +89,7 @@ See [build-vi-package](actions/build-vi-package.md) for all parameters.
 See [close-labview](actions/close-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/close-labview@v1
+- uses: LabVIEW-Community-CI-CD/open-source/close-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -100,7 +100,7 @@ See [close-labview](actions/close-labview.md) for all parameters.
 See [generate-release-notes](actions/generate-release-notes.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/generate-release-notes@v1
+- uses: LabVIEW-Community-CI-CD/open-source/generate-release-notes@v1
 ```
 
 ## missing-in-project
@@ -108,7 +108,7 @@ See [generate-release-notes](actions/generate-release-notes.md) for all paramete
 See [missing-in-project](actions/missing-in-project.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/missing-in-project@v1
+- uses: LabVIEW-Community-CI-CD/open-source/missing-in-project@v1
   with:
     lv_version: '2020'
     supported_bitness: '64'
@@ -120,7 +120,7 @@ See [missing-in-project](actions/missing-in-project.md) for all parameters.
 See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/modify-vipb-display-info@v1
+- uses: LabVIEW-Community-CI-CD/open-source/modify-vipb-display-info@v1
   with:
     supported_bitness: '64'
     relative_path: '.'
@@ -140,7 +140,7 @@ See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all para
 See [prepare-labview-source](actions/prepare-labview-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/prepare-labview-source@v1
+- uses: LabVIEW-Community-CI-CD/open-source/prepare-labview-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -154,7 +154,7 @@ See [prepare-labview-source](actions/prepare-labview-source.md) for all paramete
 See [rename-file](actions/rename-file.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/rename-file@v1
+- uses: LabVIEW-Community-CI-CD/open-source/rename-file@v1
   with:
     current_filename: 'C:/path/lv_icon.lvlibp'
     new_filename: 'lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'
@@ -165,7 +165,7 @@ See [rename-file](actions/rename-file.md) for all parameters.
 See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/restore-setup-lv-source@v1
+- uses: LabVIEW-Community-CI-CD/open-source/restore-setup-lv-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'
@@ -179,7 +179,7 @@ See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parame
 See [revert-development-mode](actions/revert-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+- uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
   with:
     relative_path: '.'
 ```
@@ -189,7 +189,7 @@ See [revert-development-mode](actions/revert-development-mode.md) for all parame
 See [run-pester-tests](actions/run-pester-tests.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-pester-tests@v1
   with:
     working_directory: '.'
 ```
@@ -199,7 +199,7 @@ See [run-pester-tests](actions/run-pester-tests.md) for all parameters.
 See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+- uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'
@@ -210,7 +210,7 @@ See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 See [set-development-mode](actions/set-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+- uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
   with:
     relative_path: '.'
 ```
@@ -220,5 +220,5 @@ See [set-development-mode](actions/set-development-mode.md) for all parameters.
 See [setup-mkdocs](actions/setup-mkdocs.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
+- uses: LabVIEW-Community-CI-CD/open-source/setup-mkdocs@v1
 ```

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -49,7 +49,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 
 ```yaml
 - name: Add library token
-  uses: LabVIEW-Community-CI-CD/open-source-actions/add-token-to-labview@v1
+  uses: LabVIEW-Community-CI-CD/open-source/add-token-to-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 
 ```yaml
 - name: Apply VIPC
-  uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+  uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
   with:
     minimum_supported_lv_version: '2019'
     vip_lv_version: '2019'

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -70,7 +70,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 
 ```yaml
 - name: Build Packed Library
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -74,7 +74,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 
 ```yaml
 - name: Build VI Package
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build-vi-package@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build-vi-package@v1
   with:
     minimum_supported_lv_version: '2023'
     supported_bitness: '64'

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -67,7 +67,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 
 ```yaml
 - name: Build project
-  uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+  uses: LabVIEW-Community-CI-CD/open-source/build@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -45,7 +45,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 
 ```yaml
 - name: Close LabVIEW
-  uses: LabVIEW-Community-CI-CD/open-source-actions/close-labview@v1
+  uses: LabVIEW-Community-CI-CD/open-source/close-labview@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -42,7 +42,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 
 ```yaml
 - name: Generate release notes
-  uses: LabVIEW-Community-CI-CD/open-source-actions/generate-release-notes@v1
+  uses: LabVIEW-Community-CI-CD/open-source/generate-release-notes@v1
   with:
     output_path: 'Tooling/deployment/release_notes.md'
 ```

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -48,7 +48,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 
 ```yaml
 - name: Check for Missing Project Items
-  uses: LabVIEW-Community-CI-CD/open-source-actions/missing-in-project@v1
+  uses: LabVIEW-Community-CI-CD/open-source/missing-in-project@v1
   with:
     lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -74,7 +74,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 
 ```yaml
 - name: Modify VIPB display info
-  uses: LabVIEW-Community-CI-CD/open-source-actions/modify-vipb-display-info@v1
+  uses: LabVIEW-Community-CI-CD/open-source/modify-vipb-display-info@v1
   with:
     supported_bitness: '64'
     working_directory: '.'

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 
 ```yaml
 - name: Prepare LabVIEW source
-  uses: LabVIEW-Community-CI-CD/open-source-actions/prepare-labview-source@v1
+  uses: LabVIEW-Community-CI-CD/open-source/prepare-labview-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -45,7 +45,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 
 ```yaml
 - name: Rename file
-  uses: LabVIEW-Community-CI-CD/open-source-actions/rename-file@v1
+  uses: LabVIEW-Community-CI-CD/open-source/rename-file@v1
   with:
     current_filename: 'C:/path/lv_icon.lvlibp'
     new_filename: 'lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -55,7 +55,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 
 ```yaml
 - name: Restore LabVIEW setup
-  uses: LabVIEW-Community-CI-CD/open-source-actions/restore-setup-lv-source@v1
+  uses: LabVIEW-Community-CI-CD/open-source/restore-setup-lv-source@v1
   with:
     minimum_supported_lv_version: '2021'
     supported_bitness: '64'

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -43,7 +43,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 
 ```yaml
 - name: Revert development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+  uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -40,7 +40,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{
 
 ```yaml
 - name: Run Pester tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-pester-tests@v1
   with:
     working_directory: '.'
 ```

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -54,7 +54,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./co
 
 ```yaml
 - name: Run LabVIEW Unit Tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+  uses: LabVIEW-Community-CI-CD/open-source/run-unit-tests@v1
   with:
     minimum_supported_lv_version: '2020'
     supported_bitness: '64'

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -43,7 +43,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 
 ```yaml
 - name: Set development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+  uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
   with:
     working_directory: '.'
     relative_path: '.'

--- a/docs/actions/setup-mkdocs.md
+++ b/docs/actions/setup-mkdocs.md
@@ -18,7 +18,7 @@ This action has no inputs.
 
 ```yaml
 - name: Setup MkDocs
-  uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
+  uses: LabVIEW-Community-CI-CD/open-source/setup-mkdocs@v1
 ```
 
 ## Return Codes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Packed Library (32-bit)
-        uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+        uses: LabVIEW-Community-CI-CD/open-source/build-lvlibp@v1
         with:
           minimum_supported_lv_version: '2019'
           supported_bitness: '32'
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: LabVIEW-Community-CI-CD/labview-icon-editor
           path: labview-icon-editor
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/apply-vipc@v1
         with:
           minimum_supported_lv_version: '2021'
           vip_lv_version: '2021'
@@ -78,13 +78,13 @@ jobs:
           working_directory: labview-icon-editor
           relative_path: '.'
           vipc_path: labview-icon-editor/.github/actions/apply-vipc/runner_dependencies.vipc
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/set-development-mode@v1
         with:
           minimum_supported_lv_version: '2021'
           supported_bitness: '64'
           working_directory: labview-icon-editor
           relative_path: '.'
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/build@v1
         with:
           working_directory: labview-icon-editor
           relative_path: '.'
@@ -96,7 +96,7 @@ jobs:
           labview_minor_revision: '3'
           company_name: 'Acme Corp'
           author_name: 'Jane Doe'
-      - uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+      - uses: LabVIEW-Community-CI-CD/open-source/revert-development-mode@v1
         with:
           working_directory: labview-icon-editor
           relative_path: '.'

--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -4,7 +4,7 @@
 
 Most tests run without cloning the [`labview-icon-editor`](https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor) repository. The helper defaults to the repository root as the project directory.
 
-Tests that need the example project can either clone it under `open-source-actions/labview-icon-editor`:
+Tests that need the example project can either clone it under `open-source/labview-icon-editor`:
 
 ```bash
 git clone https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor.git labview-icon-editor

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -6,7 +6,7 @@
   "verbosity": "error",
   "directoryListing": true,
   "skip": [
-    "https://open-source-actions.github.io/open-source-actions/",
+    "https://labview-community-ci-cd.github.io/open-source/",
     "http://127.0.0.1:8000/",
     "https://LabVIEW-Community-CI-CD.github.io/summary.md",
     "https://labview-community-ci-cd.github.io/summary.md"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "open-source-actions",
+  "name": "open-source",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-source-actions",
+      "name": "open-source",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-source-actions",
+  "name": "open-source",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/test-results/linkinator.log
+++ b/test-results/linkinator.log
@@ -1,3 +1,0 @@
-npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
-🏊‍♂️ crawling README.md docs scripts
-🤖 Successfully scanned 18 links in 0.244 seconds.

--- a/test-results/lint-md.log
+++ b/test-results/lint-md.log
@@ -1,8 +1,8 @@
 
-> open-source-actions@1.0.0 lint:md
+> open-source@1.0.0 lint:md
 > markdownlint-cli2 README.md "docs/**/*.md" "scripts/**/*.md"
 
 markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
 Finding: README.md docs/**/*.md scripts/**/*.md
-Linting: 91 file(s)
+Linting: 92 file(s)
 Summary: 0 error(s)

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.983792" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.848038" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.863637" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.862378" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.906077" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002885" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001526" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000223" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.001317" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000399" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022864" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002501" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.009968" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.010711" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.006138" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.010612" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.011147" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.006925" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.008236" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001760" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000327" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000528" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000448" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000560" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000471" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001120" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.177582" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.044720" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.044295" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.982879" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.764593" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.597682" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.693193" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.725273" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.013051" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001978" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.005860" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000776" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000961" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001978" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000439" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.000946" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001212" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000722" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000572" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002497" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001052" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000210" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.966261" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.937453" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.908202" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.815296" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001250" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001716" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.939881" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.917837" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.794429" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.758437" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.892094" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.003322" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001456" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000361" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000173" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000332" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.022132" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003551" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.011810" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.010240" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.016216" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.021273" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.011210" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.010491" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.009168" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002200" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001198" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.001213" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000417" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000624" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000379" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000643" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.140125" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.980198" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="0.980787" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.808860" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.693747" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.563797" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.668444" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.706569" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010782" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007818" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.001830" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.002576" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002124" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002788" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000521" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001336" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.003507" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001345" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000906" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.003383" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.005157" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000205" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.906265" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.740869" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.849063" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.704977" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001046" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.003195" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8456.153984 -->
+	<!-- duration_ms 7869.469943 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- revamp README introduction and link readers to detailed docs
- replace open-source-actions mentions with current repository name and site URLs
- rename package and update configuration to match new repository structure

## Testing
- `npm run check:node`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $BASE_SHA`


------
https://chatgpt.com/codex/tasks/task_e_68a59f5ccbe88329b07f62ba95514c95