### PR TITLE
Add dispatcher validation tests for REQ-001

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 14.22 | 100.00 |
-| linux | 54 | 0 | 0 | 14.22 | 100.00 |
+| overall | 54 | 0 | 0 | 14.94 | 100.00 |
+| linux | 54 | 0 | 0 | 14.94 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 14.22 | 100.00 |
-| linux | 54 | 0 | 0 | 14.22 | 100.00 |
+| overall | 54 | 0 | 0 | 14.94 | 100.00 |
+| linux | 54 | 0 | 0 | 14.94 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,31 +4,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,7 +64,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
@@ -72,46 +72,46 @@
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.849 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.809 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.005 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.952 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.908 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.918 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.940 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.758 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.892 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.111 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.818 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.761 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.906 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.942 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.707 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.694 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.021 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.741 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.668 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.794 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.980 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.690 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.707 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.902 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.693 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.885 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.984 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.564 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.705 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.981 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.140 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.579 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.715 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.094 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.188 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010782,
+          "duration": 0.007012,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007818,
+          "duration": 0.007455,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00183,
+          "duration": 0.000803,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002576,
+          "duration": 0.000774,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002124,
+          "duration": 0.00087,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002788,
+          "duration": 0.002523,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001336,
+          "duration": 0.001134,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003507,
+          "duration": 0.005269,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001345,
+          "duration": 0.000622,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000906,
+          "duration": 0.00064,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003383,
+          "duration": 0.001194,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01024,
+          "duration": 0.010228,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001046,
+          "duration": 0.000941,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003195,
+          "duration": 0.000825,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000643,
+          "duration": 0.000556,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009168,
+          "duration": 0.003886,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010491,
+          "duration": 0.005883,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01121,
+          "duration": 0.009412,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000417,
+          "duration": 0.00024,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.849063,
+          "duration": 0.951911,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003322,
+          "duration": 0.003571,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.80886,
+          "duration": 0.90824,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005157,
+          "duration": 0.001119,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000205,
+          "duration": 0.00013,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.917837,
+          "duration": 0.888221,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 0.939881,
+          "duration": 1.111001,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.758437,
+          "duration": 0.81848,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.892094,
+          "duration": 0.760977,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000361,
+          "duration": 0.000368,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000173,
+          "duration": 0.000247,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001456,
+          "duration": 0.003031,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000332,
+          "duration": 0.000359,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022132,
+          "duration": 0.023327,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 0.906265,
+          "duration": 0.942434,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0022,
+          "duration": 0.001363,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001198,
+          "duration": 0.000597,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000521,
+          "duration": 0.001379,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.706569,
+          "duration": 0.689831,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.693747,
+          "duration": 0.706591,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016216,
+          "duration": 0.009387,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.021273,
+          "duration": 0.005584,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.740869,
+          "duration": 0.902315,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.668444,
+          "duration": 0.692507,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.794429,
+          "duration": 0.88487,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001213,
+          "duration": 0.000357,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 0.980198,
+          "duration": 0.984279,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000379,
+          "duration": 0.000341,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000624,
+          "duration": 0.00149,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.563797,
+          "duration": 0.578896,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.704977,
+          "duration": 0.714744,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.980787,
+          "duration": 1.093773,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01181,
+          "duration": 0.003064,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003551,
+          "duration": 0.002173,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.140125,
+          "duration": 1.188025,
           "requirements": [],
           "os": "linux"
         }
@@ -585,7 +585,7 @@
       "passed": 54,
       "failed": 0,
       "skipped": 0,
-      "duration": 14.223307000000002,
+      "duration": 14.935249,
       "rate": 100
     },
     "byOs": {
@@ -593,7 +593,7 @@
         "passed": 54,
         "failed": 0,
         "skipped": 0,
-        "duration": 14.223307000000002,
+        "duration": 14.935249,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,31 +4,31 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.007 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.003 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.005 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,7 +64,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
@@ -72,46 +72,46 @@
 | --- | --- | --- | --- | --- | --- |
 | Unmapped | associates-classname-with-requirement | Passed | 0.010 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.849 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.809 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.005 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.952 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.004 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.908 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.918 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.940 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.758 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.892 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.888 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.111 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.818 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.761 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.906 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.942 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.707 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.694 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.021 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.741 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.668 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.794 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.980 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.690 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.707 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.902 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.693 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.885 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.984 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.564 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.705 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 0.981 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.140 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.579 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.715 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.094 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.188 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"18acf10f67c1d2e12a76f2b87e62cea85d1e5162","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"b0b84b174b2700771b02d3d4becd1e34d5b5fdb6","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -110,3 +110,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:91:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="0.939881" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.917837" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.794429" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.758437" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.892094" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003322" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001456" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000361" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000173" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000332" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022132" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003551" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.011810" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.010240" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.016216" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.021273" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.011210" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.010491" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.009168" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002200" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001198" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.001213" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000417" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000624" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000379" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000643" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.140125" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="0.980198" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="0.980787" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.808860" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.693747" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.563797" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.668444" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.706569" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010782" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007818" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.001830" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.002576" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002124" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002788" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000521" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001336" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.003507" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001345" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000906" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.003383" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.005157" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000205" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="0.906265" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.740869" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.849063" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.704977" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001046" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.003195" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.111001" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.888221" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.884870" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.818480" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.760977" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.003571" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003031" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000368" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000247" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000359" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.023327" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002173" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.003064" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.010228" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.009387" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.005584" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009412" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.005883" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.003886" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001363" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000597" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000357" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000240" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001490" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000341" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000556" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.188025" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.984279" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.093773" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.908240" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.706591" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.578896" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.692507" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.689831" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.007012" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007455" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.000803" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000774" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000870" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002523" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001379" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001134" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.005269" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000622" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000640" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001194" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001119" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000130" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.942434" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.902315" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.951911" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.714744" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000941" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000825" classname="test"/>
 	<!-- tests 54 -->
 	<!-- suites 0 -->
 	<!-- pass 54 -->
@@ -61,5 +61,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 7869.469943 -->
+	<!-- duration_ms 8184.959836 -->
 </testsuites>

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -68,6 +68,23 @@ Describe 'Unified Dispatcher — discovery and validation' {
     pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json -WorkingDirectory $projectRoot *>$null
     $LASTEXITCODE | Should -Be 1
   }
+
+  It 'fails to describe an unknown action [REQ-001]' -Tag 'REQ-001' {
+    $params = Get-LabVIEWIconEditorArgsJson
+    $json = $params.ArgsJson
+    $projectRoot = $params.WorkingDirectory
+    pwsh -NoProfile -File $global:dispatcher -Describe no-such-action -ArgsJson $json -WorkingDirectory $projectRoot *>&1 | Out-String | Out-Null
+    $LASTEXITCODE | Should -Be 1
+  }
+
+  It 'fails when required arguments are missing [REQ-001]' -Tag 'REQ-001' {
+    $params = Get-LabVIEWIconEditorArgsJson
+    $projectRoot = $params.WorkingDirectory
+    $json = @{ SupportedBitness = '64' } | ConvertTo-Json -Compress
+    $out = pwsh -NoProfile -File $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+    $LASTEXITCODE | Should -Be 1
+    $out | Should -Match "Missing an argument for parameter 'MinimumSupportedLVVersion'"
+  }
 }
 
 Describe 'ArgsJson path handling' {


### PR DESCRIPTION
## Summary
- expand dispatcher test suite to cover describing unknown actions
- ensure dispatcher fails when required arguments are missing

## Testing
- `npm run check:node`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_68a5bdc46ba08329a5ef1a5efd49afd7