### PR TITLE
feat: merge multiple requirement files for CI summary (REQ-024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ full mappings of requirements to tests, see
 [docs/requirements-core.md](docs/requirements-core.md) and
 [docs/requirements-icon-editor.md](docs/requirements-icon-editor.md).
 
+When generating summaries, provide the mapping files via the `REQ_MAPPING_FILE`
+environment variable. Multiple files can be supplied as a comma‑separated list,
+for example `REQ_MAPPING_FILE="requirements-core.json,requirements-icon-editor.json"`.
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules.

--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -12,7 +12,7 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 43 | 43 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 44 | 44 | 0 | 0 | 100.00 |
 
 ### Requirement Testcases
 | Requirement ID | Test ID | Status |
@@ -57,6 +57,7 @@
 | Unmapped | handles-zipped-junit-artifacts | Passed |
 | Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed |
+| Unmapped | loadrequirements-merges-multiple-files | Passed |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed |
 | Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed |
 | Unmapped | partitions-requirement-groups-by-runner\_type | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 22.07 | 100.00 |
-| linux | 54 | 0 | 0 | 22.07 | 100.00 |
+| overall | 55 | 0 | 0 | 21.96 | 100.00 |
+| linux | 55 | 0 | 0 | 21.96 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 54 | 0 | 0 | 22.07 | 100.00 |
-| linux | 54 | 0 | 0 | 22.07 | 100.00 |
+| overall | 55 | 0 | 0 | 21.96 | 100.00 |
+| linux | 55 | 0 | 0 | 21.96 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
@@ -18,6 +18,6 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 43 | 43 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 44 | 44 | 0 | 0 | 100.00 |
 
 _For detailed per-test information, see [traceability.md](traceability.md)._

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,84 +34,85 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.007 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.003 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.017 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.227 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.201 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.272 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.346 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.118 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.540 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.197 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.261 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.305 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.449 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.189 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.031 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.560 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.414 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.006 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.006 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.067 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.076 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.033 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.229 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.064 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.369 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.098 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.106 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.076 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.273 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.729 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.877 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.156 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.530 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.565 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.854 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.191 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.518 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.638 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.720 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009855,
+          "duration": 0.010764,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002617,
+          "duration": 0.003858,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00664,
+          "duration": 0.011877,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001851,
+          "duration": 0.001756,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001747,
+          "duration": 0.001657,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01365,
+          "duration": 0.004196,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001186,
+          "duration": 0.00325,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001418,
+          "duration": 0.00224,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006741,
+          "duration": 0.001043,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000814,
+          "duration": 0.002975,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001701,
+          "duration": 0.005607,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.025011,
+          "duration": 0.016526,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001468,
+          "duration": 0.001686,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001794,
+          "duration": 0.001406,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00063,
+          "duration": 0.001681,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01391,
+          "duration": 0.013403,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013321,
+          "duration": 0.007139,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016525,
+          "duration": 0.007145,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000484,
+          "duration": 0.000668,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.227473,
+          "duration": 1.27237,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005066,
+          "duration": 0.006081,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.200739,
+          "duration": 1.346291,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001443,
+          "duration": 0.002542,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000212,
+          "duration": 0.000353,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.117615,
+          "duration": 1.305306,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.540292,
+          "duration": 1.448885,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.197339,
+          "duration": 1.236626,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.260592,
+          "duration": 1.188541,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000713,
+          "duration": 0.000589,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000253,
+          "duration": 0.000388,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00355,
+          "duration": 0.005924,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001228,
+          "duration": 0.000758,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.030652,
+          "duration": 0.038229,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.559972,
+          "duration": 1.413805,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001768,
+          "duration": 0.005568,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000647,
+          "duration": 0.001143,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005565,
+          "duration": 0.001047,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.066819,
+          "duration": 1.098068,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.076102,
+          "duration": 1.144142,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,16 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.032533,
+          "duration": 0.010644,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "loadrequirements-merges-multiple-files",
+          "name": "loadRequirements merges multiple files",
+          "className": "test",
+          "status": "Passed",
+          "duration": 0.007164,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006355,
+          "duration": 0.003569,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.229498,
+          "duration": 1.105985,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.064204,
+          "duration": 1.075894,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.369322,
+          "duration": 1.272639,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000698,
+          "duration": 0.00089,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.729039,
+          "duration": 1.565025,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000431,
+          "duration": 0.001454,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000572,
+          "duration": 0.001747,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.877148,
+          "duration": 0.853994,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.156229,
+          "duration": 1.190622,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.530342,
+          "duration": 1.517895,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004866,
+          "duration": 0.011681,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006569,
+          "duration": 0.006857,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.63829,
+          "duration": 1.71991,
           "requirements": [],
           "os": "linux"
         }
@@ -582,18 +591,18 @@
   ],
   "totals": {
     "overall": {
-      "passed": 54,
+      "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 22.065499,
+      "duration": 21.961503,
       "rate": 100
     },
     "byOs": {
       "linux": {
-        "passed": 54,
+        "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 22.065499,
+        "duration": 21.961503,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.007 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,84 +34,85 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.014 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.007 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.003 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.025 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.017 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.227 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.201 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.272 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.346 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.118 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.540 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.197 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.261 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.305 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.449 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.189 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.031 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.560 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.414 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.006 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.006 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.067 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.076 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.033 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.229 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.064 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.369 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.098 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.106 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.076 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.273 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.729 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.877 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.156 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.530 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.565 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.854 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.191 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.518 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.638 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.720 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"b0b84b174b2700771b02d3d4becd1e34d5b5fdb6","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"54d3bae779f412134a28f10cda343630acf22657","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,3 +6,10 @@ This project tracks multiple requirement sets:
 - [Icon editor requirements](requirements-icon-editor.md) – mapped in [`requirements-icon-editor.json`](../requirements-icon-editor.json)
 
 Each page lists the requirements and associated tests for that set.
+When generating CI summaries, specify one or more mapping files with the
+`REQ_MAPPING_FILE` environment variable. Separate multiple files with commas,
+for example:
+
+```bash
+REQ_MAPPING_FILE="requirements-core.json,requirements-icon-editor.json" npm run generate:summary
+```

--- a/error-summary.md
+++ b/error-summary.md
@@ -126,3 +126,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:76:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,7 @@
 # scripts
 
 TypeScript and PowerShell helper scripts invoked by the GitHub Action wrappers.
+
+`generate-ci-summary.ts` reads requirement mappings from the `REQ_MAPPING_FILE`
+environment variable. Provide one or more JSON files separated by commas to
+combine multiple requirement sets.

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -111,6 +111,21 @@ test('loadRequirements warns and skips invalid entries', async () => {
   assert.deepEqual(Object.keys(meta), ['REQ-1']);
 });
 
+test('loadRequirements merges multiple files', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'multi-'));
+  const req1 = { requirements: [{ id: 'REQ-A', tests: ['a'] }] };
+  const req2 = { requirements: [{ id: 'REQ-B', tests: ['b'] }] };
+  const p1 = path.join(dir, 'r1.json');
+  const p2 = path.join(dir, 'r2.json');
+  await fs.writeFile(p1, JSON.stringify(req1));
+  await fs.writeFile(p2, JSON.stringify(req2));
+  const { map, meta } = await loadRequirements([p1, p2]);
+  await fs.rm(dir, { recursive: true, force: true });
+  assert.deepEqual(map.a.requirements, ['REQ-A']);
+  assert.deepEqual(map.b.requirements, ['REQ-B']);
+  assert.deepEqual(Object.keys(meta).sort(), ['REQ-A', 'REQ-B']);
+});
+
 test('collectTestCases uses machine-name property for owner', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-'));
   const xmlProp = `<testsuite><testcase name="foo" time="0"><properties><property name="machine-name" value="ci-bot"/></properties></testcase></testsuite>`;

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -23,7 +23,10 @@ import { collectTestCases } from './summary/tests.ts';
 import { loadRequirements, mapToRequirements, redact } from './summary/requirements.ts';
 
 async function main() {
-  const mappingFile = process.env.REQ_MAPPING_FILE || 'requirements.json';
+  const mappingFiles = (process.env.REQ_MAPPING_FILE || 'requirements.json')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
   const dispatcherRegistryFile = process.env.DISPATCHER_REGISTRY || 'dispatchers.json';
   const evidenceDir = process.env.EVIDENCE_DIR || 'test-screenshots';
   const osType = (process.env.RUNNER_OS ?? 'linux').toLowerCase();
@@ -82,7 +85,7 @@ async function main() {
   } finally {
     if (extractedDir) await fs.rm(extractedDir, { recursive: true, force: true });
   }
-  const { map, meta } = await loadRequirements(mappingFile);
+  const { map, meta } = await loadRequirements(mappingFiles);
   const groups = mapToRequirements(tests, map, meta);
   const allUnmapped = groups.every(g => g.id === 'Unmapped');
   if (allUnmapped) {

--- a/scripts/summary/requirements.ts
+++ b/scripts/summary/requirements.ts
@@ -50,52 +50,53 @@ function isRequirementEntry(value: unknown): value is RequirementEntry {
   return true;
 }
 
-export async function loadRequirements(mappingFile: string) {
-  try {
-    const raw = await fs.readFile(mappingFile, 'utf8');
-    const parsed: RequirementsFile = JSON.parse(raw);
+export async function loadRequirements(mappingFile: string | string[]) {
+  const files = Array.isArray(mappingFile) ? mappingFile : [mappingFile];
+  const map: Record<string, { requirements: string[]; owner?: string }> = {};
+  const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
+  for (const file of files) {
+    try {
+      const raw = await fs.readFile(file, 'utf8');
+      const parsed: RequirementsFile = JSON.parse(raw);
 
-    const defaults: Record<string, RunnerDefaults> = {};
-    const rawDefs = (parsed.runners || parsed.defaults) ?? {};
-    if (rawDefs && typeof rawDefs === 'object') {
-      for (const [name, val] of Object.entries(rawDefs)) {
-        if (isRunnerDefaults(val)) {
-          defaults[name] = val;
-        } else {
-          console.warn(`Invalid runner defaults for ${name}`);
+      const defaults: Record<string, RunnerDefaults> = {};
+      const rawDefs = (parsed.runners || parsed.defaults) ?? {};
+      if (rawDefs && typeof rawDefs === 'object') {
+        for (const [name, val] of Object.entries(rawDefs)) {
+          if (isRunnerDefaults(val)) {
+            defaults[name] = val;
+          } else {
+            console.warn(`Invalid runner defaults for ${name}`);
+          }
         }
       }
-    }
 
-    const map: Record<string, { requirements: string[]; owner?: string }> = {};
-    const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
-
-    if (Array.isArray(parsed.requirements)) {
-      for (const r of parsed.requirements) {
-        if (!isRequirementEntry(r)) {
-          console.warn(`Invalid requirement entry: ${JSON.stringify(r)}`);
-          continue;
-        }
-        const def = (r.runner && defaults[r.runner]) || {};
-        const owner = r.owner ?? def.owner;
-        const runner_label = r.runner_label ?? def.runner_label;
-        const runner_type = r.runner_type ?? def.runner_type;
-        const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
-        meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
-        for (const t of r.tests) {
-          const key = t.toLowerCase();
-          if (!map[key]) map[key] = { requirements: [], owner };
-          map[key].requirements.push(r.id);
+      if (Array.isArray(parsed.requirements)) {
+        for (const r of parsed.requirements) {
+          if (!isRequirementEntry(r)) {
+            console.warn(`Invalid requirement entry: ${JSON.stringify(r)}`);
+            continue;
+          }
+          const def = (r.runner && defaults[r.runner]) || {};
+          const owner = r.owner ?? def.owner;
+          const runner_label = r.runner_label ?? def.runner_label;
+          const runner_type = r.runner_type ?? def.runner_type;
+          const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
+          meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
+          for (const t of r.tests) {
+            const key = t.toLowerCase();
+            if (!map[key]) map[key] = { requirements: [], owner };
+            map[key].requirements.push(r.id);
+          }
         }
       }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Failed to load requirements mapping from ${file}: ${msg}`);
+      await writeErrorSummary(err);
     }
-    return { map, meta };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`Failed to load requirements mapping from ${mappingFile}: ${msg}`);
-    await writeErrorSummary(err);
-    return { map: {}, meta: {} };
   }
+  return { map, meta };
 }
 
 export function mapToRequirements(

--- a/test-results/lint-md.log
+++ b/test-results/lint-md.log
@@ -4,5 +4,5 @@
 
 markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
 Finding: README.md docs/**/*.md scripts/**/*.md
-Linting: 92 file(s)
+Linting: 94 file(s)
 Summary: 0 error(s)

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,65 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.540292" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.117615" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.369322" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.197339" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.260592" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.005066" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.003550" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000713" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000253" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001228" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.030652" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006569" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.004866" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.025011" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.032533" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006355" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.016525" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.013321" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.013910" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001768" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000647" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000698" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000484" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000572" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000431" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000630" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.638290" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.729039" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.530342" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.200739" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.076102" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.877148" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.064204" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.066819" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009855" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002617" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.006640" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001851" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001747" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.013650" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.005565" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001186" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001418" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.006741" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000814" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001701" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001443" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000212" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.559972" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.229498" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.227473" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.156229" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001468" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001794" classname="test"/>
-	<!-- tests 54 -->
+	<testcase name="fails when requirement lacks test coverage" time="1.448885" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.305306" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.272639" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.236626" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.188541" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.006081" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.005924" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000589" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000388" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000758" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.038229" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006857" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.011681" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.016526" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.010644" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003569" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.007164" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.007145" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007139" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.013403" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.005568" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001143" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000890" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000668" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001747" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.001454" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001681" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.719910" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.565025" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.517895" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.346291" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.144142" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.853994" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.075894" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.098068" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010764" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003858" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.011877" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001756" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001657" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004196" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001047" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003250" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002240" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001043" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.002975" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.005607" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002542" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000353" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.413805" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.105985" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.272370" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.190622" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001686" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001406" classname="test"/>
+	<!-- tests 55 -->
 	<!-- suites 0 -->
-	<!-- pass 54 -->
+	<!-- pass 55 -->
 	<!-- fail 0 -->
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 12211.065979 -->
+	<!-- duration_ms 12333.441973 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- allow REQ_MAPPING_FILE to accept comma-separated requirement mapping files
- merge requirement maps and metadata from multiple files
- document how to supply multiple mapping files

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `./scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a5c40d6a6c8329a7f8e37716811c10