### PR TITLE
Add dry-run checks across workflows

### DIFF
--- a/.github/workflows/add-token-to-labview-self-hosted.json
+++ b/.github/workflows/add-token-to-labview-self-hosted.json
@@ -16,7 +16,8 @@
           "with": {
             "minimum_supported_lv_version": "2021",
             "supported_bitness": "64",
-            "relative_path": "scripts/add-token-to-labview"
+            "relative_path": "scripts/add-token-to-labview",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/add-token-to-labview-self-hosted.yml
+++ b/.github/workflows/add-token-to-labview-self-hosted.yml
@@ -14,6 +14,7 @@ jobs:
           minimum_supported_lv_version: '2021'
           supported_bitness: '64'
           relative_path: 'scripts/add-token-to-labview'
+          dry_run: true
       - name: Upload token artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/build-lvlibp-self-hosted.json
+++ b/.github/workflows/build-lvlibp-self-hosted.json
@@ -23,7 +23,8 @@
             "minor": "0",
             "patch": "0",
             "build": "1",
-            "commit": "abcdef"
+            "commit": "abcdef",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/build-lvlibp-self-hosted.yml
+++ b/.github/workflows/build-lvlibp-self-hosted.yml
@@ -21,6 +21,7 @@ jobs:
           patch: '0'
           build: '1'
           commit: 'abcdef'
+          dry_run: true
       - name: Upload lvlibp artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/build-self-hosted.json
+++ b/.github/workflows/build-self-hosted.json
@@ -27,7 +27,8 @@
             "commit": "${{ github.sha }}",
             "labview_minor_revision": "3",
             "company_name": "Acme Corp",
-            "author_name": "Jane Doe"
+            "author_name": "Jane Doe",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -24,6 +24,7 @@ jobs:
           labview_minor_revision: '3'
           company_name: 'Acme Corp'
           author_name: 'Jane Doe'
+          dry_run: true
       - name: Record artifact metadata
         id: record
         run: |

--- a/.github/workflows/build-vi-package-self-hosted.json
+++ b/.github/workflows/build-vi-package-self-hosted.json
@@ -24,7 +24,8 @@
             "patch": "0",
             "build": "1",
             "commit": "abcdef",
-            "display_information_json": "{\"Name\":\"Test\"}"
+            "display_information_json": "{\"Name\":\"Test\"}",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/build-vi-package-self-hosted.yml
+++ b/.github/workflows/build-vi-package-self-hosted.yml
@@ -22,6 +22,7 @@ jobs:
           build: '1'
           commit: 'abcdef'
           display_information_json: '{"Name":"Test"}'
+          dry_run: true
       - name: Upload VI package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/missing-in-project-self-hosted.json
+++ b/.github/workflows/missing-in-project-self-hosted.json
@@ -17,7 +17,8 @@
             "lv_version": "2021",
             "supported_bitness": "64",
             "project_file": "scripts/missing-in-project/Missing in Project.lvproj",
-            "relative_path": "scripts/missing-in-project"
+            "relative_path": "scripts/missing-in-project",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/missing-in-project-self-hosted.yml
+++ b/.github/workflows/missing-in-project-self-hosted.yml
@@ -15,6 +15,7 @@ jobs:
           supported_bitness: '64'
           project_file: 'scripts/missing-in-project/Missing in Project.lvproj'
           relative_path: 'scripts/missing-in-project'
+          dry_run: true
       - name: Upload missing findings
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/modify-vipb-display-info-self-hosted.json
+++ b/.github/workflows/modify-vipb-display-info-self-hosted.json
@@ -24,7 +24,8 @@
             "patch": "0",
             "build": "1",
             "commit": "abcdef",
-            "display_information_json": "{\"Name\":\"Test\"}"
+            "display_information_json": "{\"Name\":\"Test\"}",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/modify-vipb-display-info-self-hosted.yml
+++ b/.github/workflows/modify-vipb-display-info-self-hosted.yml
@@ -22,6 +22,7 @@ jobs:
           build: '1'
           commit: 'abcdef'
           display_information_json: '{"Name":"Test"}'
+          dry_run: true
       - name: Upload vipb artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/prepare-labview-source-self-hosted.json
+++ b/.github/workflows/prepare-labview-source-self-hosted.json
@@ -18,7 +18,8 @@
             "supported_bitness": "64",
             "relative_path": "scripts/prepare-labview-source",
             "labview_project": "scripts/prepare-labview-source/lv_icon.lvproj",
-            "build_spec": "PackageSource"
+            "build_spec": "PackageSource",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/prepare-labview-source-self-hosted.yml
+++ b/.github/workflows/prepare-labview-source-self-hosted.yml
@@ -16,6 +16,7 @@ jobs:
           relative_path: 'scripts/prepare-labview-source'
           labview_project: 'scripts/prepare-labview-source/lv_icon.lvproj'
           build_spec: 'PackageSource'
+          dry_run: true
       - name: Upload prepared source
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/rename-file-self-hosted.json
+++ b/.github/workflows/rename-file-self-hosted.json
@@ -15,7 +15,8 @@
           "uses": "./rename-file/action.yml",
           "with": {
             "current_filename": "scripts/rename-file/README.md",
-            "new_filename": "scripts/rename-file/README-renamed.md"
+            "new_filename": "scripts/rename-file/README-renamed.md",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/rename-file-self-hosted.yml
+++ b/.github/workflows/rename-file-self-hosted.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           current_filename: 'scripts/rename-file/README.md'
           new_filename: 'scripts/rename-file/README-renamed.md'
+          dry_run: true
       - name: Upload renamed file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/restore-setup-lv-source-self-hosted.json
+++ b/.github/workflows/restore-setup-lv-source-self-hosted.json
@@ -18,7 +18,8 @@
             "supported_bitness": "64",
             "relative_path": "scripts/restore-setup-lv-source",
             "labview_project": "scripts/restore-setup-lv-source/lv_icon.lvproj",
-            "build_spec": "PackageSource"
+            "build_spec": "PackageSource",
+            "dry_run": true
           },
           "env": {
             "GCLI_SUPPRESS_PROMPTS": "1"

--- a/.github/workflows/restore-setup-lv-source-self-hosted.yml
+++ b/.github/workflows/restore-setup-lv-source-self-hosted.yml
@@ -16,6 +16,7 @@ jobs:
           relative_path: 'scripts/restore-setup-lv-source'
           labview_project: 'scripts/restore-setup-lv-source/lv_icon.lvproj'
           build_spec: 'PackageSource'
+          dry_run: true
         env:
           GCLI_SUPPRESS_PROMPTS: '1'
       - name: Upload restore logs

--- a/.github/workflows/revert-development-mode-self-hosted.json
+++ b/.github/workflows/revert-development-mode-self-hosted.json
@@ -14,7 +14,8 @@
           "name": "Run revert-development-mode action",
           "uses": "./revert-development-mode/action.yml",
           "with": {
-            "relative_path": "./"
+            "relative_path": "./",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/revert-development-mode-self-hosted.yml
+++ b/.github/workflows/revert-development-mode-self-hosted.yml
@@ -12,6 +12,7 @@ jobs:
         uses: ./revert-development-mode/action.yml
         with:
           relative_path: './'
+          dry_run: true
       - name: Upload config artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/run-unit-tests-self-hosted.json
+++ b/.github/workflows/run-unit-tests-self-hosted.json
@@ -18,7 +18,8 @@
             "supported_bitness": "64",
             "project_path": "scripts/run-unit-tests/lv_icon.lvproj",
             "test_config": "scripts/run-unit-tests/unittest-config.cfg",
-            "working_directory": "scripts/run-unit-tests"
+            "working_directory": "scripts/run-unit-tests",
+            "dry_run": true
           }
         },
         {

--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -16,6 +16,7 @@ jobs:
           project_path: 'scripts/run-unit-tests/lv_icon.lvproj'
           test_config: 'scripts/run-unit-tests/unittest-config.cfg'
           working_directory: 'scripts/run-unit-tests'
+          dry_run: true
       - name: Upload test results to GitHub
         uses: EnricoMi/publish-unit-test-result-action@0f06977fde99088e583f6fa8ec622da326e818c3
         if: ${{ (success() || failure()) && !cancelled() }}

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 21.96 | 100.00 |
-| linux | 55 | 0 | 0 | 21.96 | 100.00 |
+| overall | 55 | 0 | 0 | 22.78 | 100.00 |
+| linux | 55 | 0 | 0 | 22.78 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 21.96 | 100.00 |
-| linux | 55 | 0 | 0 | 21.96 | 100.00 |
+| overall | 55 | 0 | 0 | 22.78 | 100.00 |
+| linux | 55 | 0 | 0 | 22.78 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.006 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,73 +46,73 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.003 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.003 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.027 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.272 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.346 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.019 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.020 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.199 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.027 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.253 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.305 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.449 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.189 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.396 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.574 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.192 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.197 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.414 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.006 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.098 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.106 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.076 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.273 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.565 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.028 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.648 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.146 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.048 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.022 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.186 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.061 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.448 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.569 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.854 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.191 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.518 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.720 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.899 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.069 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.536 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.010 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.094 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010764,
+          "duration": 0.013541,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003858,
+          "duration": 0.002886,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011877,
+          "duration": 0.005766,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001756,
+          "duration": 0.001234,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001657,
+          "duration": 0.004214,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004196,
+          "duration": 0.005685,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00325,
+          "duration": 0.002736,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00224,
+          "duration": 0.00279,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001043,
+          "duration": 0.002719,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002975,
+          "duration": 0.001331,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005607,
+          "duration": 0.005423,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016526,
+          "duration": 0.027319,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001686,
+          "duration": 0.001878,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001406,
+          "duration": 0.001694,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001681,
+          "duration": 0.000821,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013403,
+          "duration": 0.019338,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007139,
+          "duration": 0.02033,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007145,
+          "duration": 0.016105,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000668,
+          "duration": 0.000385,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.27237,
+          "duration": 1.19908,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006081,
+          "duration": 0.027395,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.346291,
+          "duration": 1.252523,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002542,
+          "duration": 0.001827,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000353,
+          "duration": 0.0003,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.305306,
+          "duration": 1.396289,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.448885,
+          "duration": 1.574349,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.236626,
+          "duration": 1.192178,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.188541,
+          "duration": 1.197262,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000589,
+          "duration": 0.000626,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000388,
+          "duration": 0.00027,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005924,
+          "duration": 0.003607,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000758,
+          "duration": 0.000729,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.038229,
+          "duration": 0.028256,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.413805,
+          "duration": 1.648481,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005568,
+          "duration": 0.002816,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001143,
+          "duration": 0.000487,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001047,
+          "duration": 0.00156,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.098068,
+          "duration": 1.146035,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.144142,
+          "duration": 1.048487,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010644,
+          "duration": 0.014866,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007164,
+          "duration": 0.022356,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003569,
+          "duration": 0.006181,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.105985,
+          "duration": 1.185596,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.075894,
+          "duration": 1.060549,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.272639,
+          "duration": 1.447682,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00089,
+          "duration": 0.000494,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.565025,
+          "duration": 1.568761,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001454,
+          "duration": 0.000804,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001747,
+          "duration": 0.001905,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.853994,
+          "duration": 0.899044,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.190622,
+          "duration": 1.069498,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.517895,
+          "duration": 1.536083,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011681,
+          "duration": 0.009688,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006857,
+          "duration": 0.003228,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.71991,
+          "duration": 2.094376,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 21.961503,
+      "duration": 22.779863,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 21.961503,
+        "duration": 22.779863,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,37 +4,37 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.014 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.006 |  |  |
 
 #### REQ-029 (100% passed)
 
@@ -46,73 +46,73 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.003 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.003 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.005 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.027 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.007 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.007 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.272 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.006 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.346 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.019 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.020 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.016 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.199 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.027 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.253 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.305 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.449 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.189 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.396 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.574 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.192 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.197 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.038 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.414 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.006 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.098 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.144 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.011 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.106 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.076 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.273 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.565 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.028 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.648 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.146 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.048 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.022 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.186 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.061 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.448 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.569 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.854 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.191 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.518 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.720 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.899 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.069 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.536 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.010 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.094 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"54d3bae779f412134a28f10cda343630acf22657","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"ff8ef91db7592c10eb2c3761bc82316334ad68e5","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -142,3 +142,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.448885" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.305306" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.272639" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.236626" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.188541" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.006081" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.005924" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000589" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000388" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000758" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.038229" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006857" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.011681" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.016526" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.010644" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.003569" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.007164" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.007145" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007139" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.013403" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.005568" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001143" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000890" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000668" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001747" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.001454" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001681" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.719910" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.565025" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.517895" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.346291" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.144142" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.853994" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.075894" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.098068" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010764" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.003858" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.011877" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001756" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001657" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004196" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001047" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003250" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002240" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001043" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.002975" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.005607" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.002542" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000353" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.413805" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.105985" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.272370" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.190622" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001686" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001406" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.574349" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.396289" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.447682" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.192178" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.197262" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.027395" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003607" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000626" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000270" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000729" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.028256" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003228" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.009688" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.027319" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.014866" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.006181" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.022356" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.016105" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.020330" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.019338" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002816" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000487" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000494" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000385" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001905" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000804" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000821" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="2.094376" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.568761" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.536083" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.252523" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.048487" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.899044" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.060549" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.146035" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.013541" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002886" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.005766" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001234" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.004214" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.005685" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001560" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002736" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002790" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.002719" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001331" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.005423" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001827" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000300" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.648481" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.185596" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.199080" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.069498" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001878" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001694" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 12333.441973 -->
+	<!-- duration_ms 12794.058943 -->
 </testsuites>

--- a/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
@@ -26,6 +26,7 @@ Describe 'AddTokenToLabview.Workflow' {
         $addStep.with.minimum_supported_lv_version | Should -Be '2021'
         $addStep.with.supported_bitness | Should -Be '64'
         $addStep.with.relative_path | Should -Be 'scripts/add-token-to-labview'
+        $addStep.with.dry_run | Should -Be $true
 
         $uploadStep = $job.steps | Where-Object {
             $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*'

--- a/tests/pester/Build.Workflow.Tests.ps1
+++ b/tests/pester/Build.Workflow.Tests.ps1
@@ -32,6 +32,7 @@ Describe 'Build.Workflow' {
         $buildStep.with.labview_minor_revision | Should -Be '3'
         $buildStep.with.company_name | Should -Be 'Acme Corp'
         $buildStep.with.author_name | Should -Be 'Jane Doe'
+        $buildStep.with.dry_run | Should -Be $true
 
         $artifactMeta = $job.steps | Where-Object { $_.name -eq 'Record artifact metadata' } | Select-Object -First 1
         $manifestStep = $job.steps | Where-Object { $_.name -eq 'Upload artifact manifest' } | Select-Object -First 1

--- a/tests/pester/BuildLvlibp.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.Workflow.Tests.ps1
@@ -28,6 +28,7 @@ Describe 'BuildLvlibp.Workflow' {
         $buildStep.with.relative_path | Should -Be 'scripts/build-lvlibp'
         $buildStep.with.labview_project | Should -Be 'scripts/build-lvlibp/lv_icon.lvproj'
         $buildStep.with.build_spec | Should -Be 'PackedLib Build'
+        $buildStep.with.dry_run | Should -Be $true
 
         $artifactStep | Should -Not -BeNullOrEmpty
         $artifactStep.with.path | Should -Be 'scripts/build-lvlibp/lv_icon_x64_v1.0.0.1+gabcdef.lvlibp'

--- a/tests/pester/BuildViPackage.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.Workflow.Tests.ps1
@@ -34,6 +34,7 @@ Describe 'BuildViPackage.Workflow' {
         $buildStep.with.patch | Should -Be '0'
         $buildStep.with.build | Should -Be '1'
         $buildStep.with.commit | Should -Be 'abcdef'
+        $buildStep.with.dry_run | Should -Be $true
 
         $artifactStep | Should -Not -BeNullOrEmpty
         $artifactStep.with.path | Should -Be 'scripts/build-vi-package/lv_icon_v1.0.0.1+gabcdef.vip'

--- a/tests/pester/CloseLabview.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.Workflow.Tests.ps1
@@ -38,6 +38,7 @@ Describe 'CloseLabview.Workflow' {
 
                 foreach ($step in $closeSteps) {
                     $step.with.working_directory | Should -Be '${{ github.workspace }}/scripts/close-labview'
+                    $step.with.dry_run | Should -Be $true
                 }
 
                 $logUploadSteps = $job.steps | Where-Object {

--- a/tests/pester/GenerateReleaseNotes.Workflow.Tests.ps1
+++ b/tests/pester/GenerateReleaseNotes.Workflow.Tests.ps1
@@ -1,0 +1,26 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'GenerateReleaseNotes.Workflow' {
+    $meta = @{
+        requirement = 'REQ-013'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/GenerateReleaseNotes.Workflow.Tests.ps1'
+    }
+
+    It 'runs generate-release-notes action [REQ-013]' -Tag 'REQ-013' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/generate-release-notes-self-hosted.json'
+        if (-not (Test-Path $workflowPath)) {
+            Set-ItResult -Skipped -Because 'Workflow file not found'
+            return
+        }
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
+        $job = $wf.jobs.'generate-release-notes'
+        $step = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './generate-release-notes/action.yml' } | Select-Object -First 1
+        $step | Should -Not -BeNullOrEmpty
+        $step.with.dry_run | Should -Be $true
+    }
+}
+

--- a/tests/pester/MissingInProject.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.Workflow.Tests.ps1
@@ -27,6 +27,7 @@ Describe 'MissingInProject.Workflow' {
         $missingStep.with.supported_bitness | Should -Be '64'
         $missingStep.with.project_file | Should -Be 'scripts/missing-in-project/Missing in Project.lvproj'
         $missingStep.with.relative_path | Should -Be 'scripts/missing-in-project'
+        $missingStep.with.dry_run | Should -Be $true
 
         $artifactStep.with.path | Should -Be 'scripts/missing-in-project/missing_files.txt'
     }

--- a/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
@@ -33,6 +33,7 @@ Describe 'ModifyVipbDisplayInfo.Workflow' {
         $modStep.with.patch | Should -Be '0'
         $modStep.with.build | Should -Be '1'
         $modStep.with.commit | Should -Be 'abcdef'
+        $modStep.with.dry_run | Should -Be $true
         $modStep.with.display_information_json | Should -Be '{"Name":"Test"}'
 
         $artifactStep.with.path | Should -Be 'scripts/modify-vipb-display-info/lv_icon.vipb'

--- a/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
@@ -26,6 +26,7 @@ Describe 'PrepareLabviewSource.Workflow' {
         $prepareStep.with.relative_path | Should -Be 'scripts/prepare-labview-source'
         $prepareStep.with.labview_project | Should -Be 'scripts/prepare-labview-source/lv_icon.lvproj'
         $prepareStep.with.build_spec | Should -Be 'PackageSource'
+        $prepareStep.with.dry_run | Should -Be $true
 
         $artifactStep.with.path | Should -Be 'scripts/prepare-labview-source/prepared-source.zip'
     }

--- a/tests/pester/RenameFile.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.Workflow.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'RenameFile.Workflow' {
 
         $renameStep.with.current_filename | Should -Be 'scripts/rename-file/README.md'
         $renameStep.with.new_filename | Should -Be 'scripts/rename-file/README-renamed.md'
+        $renameStep.with.dry_run | Should -Be $true
         $uploadStep.with.path | Should -Be 'scripts/rename-file/README-renamed.md'
     }
 }

--- a/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'RestoreSetupLvSource.Workflow' {
 
         $restoreStep.with.relative_path | Should -Be 'scripts/restore-setup-lv-source'
         $restoreStep.env | Should -Not -BeNullOrEmpty
+        $restoreStep.with.dry_run | Should -Be $true
 
         $artifactStep.with.path | Should -Be 'scripts/restore-setup-lv-source/restore.log'
     }

--- a/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'RevertDevelopmentMode.Workflow' {
                     $job.'runs-on' | Should -Be 'ubuntu-latest'
                     $revertStep.uses | Should -Be './revert-development-mode/action.yml'
                     $revertStep.with.relative_path | Should -Not -BeNullOrEmpty
+                    $revertStep.with.dry_run | Should -Be $true
                     $uploadStep = $job.steps | Where-Object {
                         $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
                             $_.with.name -match 'config' -or $_.with.path -match 'config'

--- a/tests/pester/RunUnitTests.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.Workflow.Tests.ps1
@@ -29,6 +29,7 @@ Describe 'RunUnitTests.Workflow' {
         $testStep.with.project_path | Should -Be 'scripts/run-unit-tests/lv_icon.lvproj'
         $testStep.with.test_config | Should -Be 'scripts/run-unit-tests/unittest-config.cfg'
         $testStep.with.working_directory | Should -Be 'scripts/run-unit-tests'
+        $testStep.with.dry_run | Should -Be $true
 
         $artifactStep | Should -Not -BeNullOrEmpty
         $artifactStep.with.name | Should -Be 'unit-test-results'


### PR DESCRIPTION
## Summary
- test every workflow in dry-run mode
- record unimplemented generate-release-notes workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh ff8ef91db7592c10eb2c3761bc82316334ad68e5`


------
https://chatgpt.com/codex/tasks/task_e_68a5c72ebdc48329afaf4ec7a23017a3