### PR TITLE
docs: link README to hosted documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Traceability](https://img.shields.io/endpoint?url=https://LabVIEW-Community-CI-CD.github.io/badge-summary.json)](https://LabVIEW-Community-CI-CD.github.io/summary.md)
 
-Open Source LabVIEW Actions is a collection of GitHub Actions and PowerShell scripts that streamline LabVIEW CI/CD workflows. Each task is exposed as its own action backed by a unified dispatcher. Refer to the [documentation](docs/index.md) for setup guidance, detailed examples, and the complete action reference.
+[![Docs](https://img.shields.io/badge/docs-view%20here-blue)](https://labview-community-ci-cd.github.io/open-source/)
+
+Open Source LabVIEW Actions is a collection of GitHub Actions and PowerShell scripts that streamline LabVIEW CI/CD workflows. Each task is exposed as its own action backed by a unified dispatcher. Refer to the [documentation](https://labview-community-ci-cd.github.io/open-source/) for setup guidance, detailed examples, and the complete action reference.
 
 ## Prerequisites
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 16.66 | 100.00 |
-| linux | 55 | 0 | 0 | 16.66 | 100.00 |
+| overall | 55 | 0 | 0 | 22.44 | 100.00 |
+| linux | 55 | 0 | 0 | 22.44 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 16.66 | 100.00 |
-| linux | 55 | 0 | 0 | 16.66 | 100.00 |
+| overall | 55 | 0 | 0 | 22.44 | 100.00 |
+| linux | 55 | 0 | 0 | 22.44 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.018 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.012 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.003 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.038 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.030 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.917 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.910 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.035 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.004 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.399 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.303 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.923 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.082 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.976 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.916 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.219 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.632 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.119 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.273 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.029 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.134 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.062 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.455 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.712 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.770 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.005 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.983 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.745 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.077 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.285 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.653 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.843 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.233 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.311 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.009 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.039 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.117 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.023 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.286 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.031 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.452 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.678 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.888 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.077 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.530 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.019 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.647 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007507,
+          "duration": 0.018232,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002159,
+          "duration": 0.012443,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004762,
+          "duration": 0.007759,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001681,
+          "duration": 0.006275,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001526,
+          "duration": 0.003959,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003773,
+          "duration": 0.008594,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001334,
+          "duration": 0.00355,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001528,
+          "duration": 0.004183,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001898,
+          "duration": 0.003263,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000704,
+          "duration": 0.0014,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001774,
+          "duration": 0.004131,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.037528,
+          "duration": 0.034886,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001065,
+          "duration": 0.004248,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000781,
+          "duration": 0.002675,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000365,
+          "duration": 0.000782,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00852,
+          "duration": 0.006175,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.029975,
+          "duration": 0.011761,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008487,
+          "duration": 0.009257,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000549,
+          "duration": 0.000488,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.917194,
+          "duration": 1.39926,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00326,
+          "duration": 0.006878,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.910495,
+          "duration": 1.303086,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002394,
+          "duration": 0.001809,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000448,
+          "duration": 0.000202,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.922894,
+          "duration": 1.219058,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.081842,
+          "duration": 1.631692,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.975645,
+          "duration": 1.118563,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.916176,
+          "duration": 1.27309,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000353,
+          "duration": 0.000329,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000371,
+          "duration": 0.000234,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00229,
+          "duration": 0.002604,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000549,
+          "duration": 0.000457,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.029024,
+          "duration": 0.062353,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.134189,
+          "duration": 1.454831,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001249,
+          "duration": 0.001123,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000464,
+          "duration": 0.00941,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000548,
+          "duration": 0.002084,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.711571,
+          "duration": 1.039231,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.769542,
+          "duration": 1.11696,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012309,
+          "duration": 0.022853,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00504,
+          "duration": 0.009428,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005713,
+          "duration": 0.005303,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.983358,
+          "duration": 1.286403,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.745269,
+          "duration": 1.031372,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.077399,
+          "duration": 1.452481,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000425,
+          "duration": 0.000792,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.285421,
+          "duration": 1.677595,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000197,
+          "duration": 0.00051,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000395,
+          "duration": 0.00068,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.652804,
+          "duration": 0.888403,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.842866,
+          "duration": 1.076891,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.232829,
+          "duration": 1.530078,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006329,
+          "duration": 0.019459,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003353,
+          "duration": 0.007077,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.310619,
+          "duration": 1.647017,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 16.66074,
+      "duration": 22.443657,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 16.66074,
+        "duration": 22.443657,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.008 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.018 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.012 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.004 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.004 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.003 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.038 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.030 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.917 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.910 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.035 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.004 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.006 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.009 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.399 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.007 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.303 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.923 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.082 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.976 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.916 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.219 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.632 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.119 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.273 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.029 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.134 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.062 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.455 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.712 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.770 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.005 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.006 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.983 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.745 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.077 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.285 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.653 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.843 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.233 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.311 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.009 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.039 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.117 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.023 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.286 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.031 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.452 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.678 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.888 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.077 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.530 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.019 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.007 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.647 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"3be675e4af05cb8a85f976923b0856cf6a940535","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"aeebd66a8c906dd3512b2dcc75d6791ef55584e8","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.081842" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.922894" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.077399" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.975645" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.916176" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003260" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002290" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000353" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000371" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000549" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.029024" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003353" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006329" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.037528" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.012309" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.005713" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.005040" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.008487" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.029975" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.008520" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001249" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000464" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000425" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000549" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000395" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000197" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000365" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.310619" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.285421" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.232829" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.910495" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.769542" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.652804" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.745269" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.711571" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.007507" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002159" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004762" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001681" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001526" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003773" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000548" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001334" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001528" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001898" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000704" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001774" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.002394" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000448" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.134189" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.983358" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.917194" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.842866" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001065" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000781" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.631692" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.219058" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.452481" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.118563" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.273090" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.006878" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002604" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000329" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000234" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000457" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.062353" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.007077" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.019459" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.034886" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.022853" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.005303" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.009428" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.009257" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.011761" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.006175" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001123" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.009410" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000792" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000488" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000680" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000510" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000782" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.647017" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.677595" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.530078" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.303086" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.116960" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.888403" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.031372" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.039231" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.018232" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.012443" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.007759" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.006275" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.003959" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.008594" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.002084" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003550" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.004183" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.003263" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001400" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.004131" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001809" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000202" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.454831" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.286403" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.399260" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.076891" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.004248" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002675" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 9073.163559 -->
+	<!-- duration_ms 12453.418876 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- add docs badge linking to hosted documentation site
- use absolute URL to documentation in README intro

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh aeebd66a8c906dd3512b2dcc75d6791ef55584e8`
- `npm run check:traceability`

------
https://chatgpt.com/codex/tasks/task_e_68a5e39c9f408329986ae48d6ac875a9