### PR TITLE
docs: clarify adapter terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-view%20here-blue)](https://labview-community-ci-cd.github.io/open-source/)
 
-Open Source LabVIEW Actions is a collection of GitHub Actions and PowerShell scripts that streamline LabVIEW CI/CD workflows. Each task is exposed as its own action backed by a unified dispatcher. Refer to the [documentation](https://labview-community-ci-cd.github.io/open-source/) for setup guidance, detailed examples, and the complete action reference.
+Open Source LabVIEW Actions is a collection of GitHub Actions and PowerShell scripts that streamline LabVIEW CI/CD workflows. Each task is implemented by a PowerShell adapter script with a GitHub Action wrapper, all coordinated by a unified dispatcher. Refer to the [documentation](https://labview-community-ci-cd.github.io/open-source/) for setup guidance, detailed examples, and the complete action reference.
 
 ## Prerequisites
 
@@ -25,7 +25,7 @@ See [Environment Setup](docs/environment-setup.md) for installation steps and co
     supported_bitness: '64'
 ```
 
-Each adapter has its own wrapper. Replace `run-unit-tests` with any action name listed in the [action reference](docs/index.md#action-reference). The wrappers translate the typed inputs above into the dispatcher.
+Each adapter script ships with a corresponding wrapper action. Replace `run-unit-tests` with any action name listed in the [action reference](docs/index.md#action-reference). The wrapper translates the typed inputs above into the dispatcher.
 
 Common optional inputs available on all wrappers:
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 15.71 | 100.00 |
-| linux | 55 | 0 | 0 | 15.71 | 100.00 |
+| overall | 55 | 0 | 0 | 16.02 | 100.00 |
+| linux | 55 | 0 | 0 | 16.02 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 15.71 | 100.00 |
-| linux | 55 | 0 | 0 | 15.71 | 100.00 |
+| overall | 55 | 0 | 0 | 16.02 | 100.00 |
+| linux | 55 | 0 | 0 | 16.02 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,13 +4,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.015 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
@@ -34,19 +34,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.018 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.803 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.939 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.959 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.882 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.845 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.052 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.887 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.879 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.935 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.137 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.889 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.064 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.018 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.732 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.732 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.933 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.996 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.289 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.703 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.779 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.022 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.004 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.855 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.731 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.968 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.006 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.180 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.599 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.125 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.600 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.824 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.220 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.330 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01539,
+          "duration": 0.009282,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002636,
+          "duration": 0.00458,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004638,
+          "duration": 0.004619,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000815,
+          "duration": 0.000576,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000906,
+          "duration": 0.000716,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003223,
+          "duration": 0.001384,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002337,
+          "duration": 0.001023,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001772,
+          "duration": 0.001198,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001131,
+          "duration": 0.000738,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000976,
+          "duration": 0.000608,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004025,
+          "duration": 0.001104,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01799,
+          "duration": 0.014863,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000959,
+          "duration": 0.000984,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000912,
+          "duration": 0.000806,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000941,
+          "duration": 0.001069,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0081,
+          "duration": 0.017509,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004945,
+          "duration": 0.009671,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004448,
+          "duration": 0.004272,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000333,
+          "duration": 0.000406,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.802567,
+          "duration": 0.958568,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002511,
+          "duration": 0.001899,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.938837,
+          "duration": 0.881637,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001017,
+          "duration": 0.001436,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00018,
+          "duration": 0.00016,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.844561,
+          "duration": 0.934984,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.052397,
+          "duration": 1.136683,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.886989,
+          "duration": 0.889324,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.879157,
+          "duration": 0.905619,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000279,
+          "duration": 0.00031,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000223,
+          "duration": 0.000356,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001831,
+          "duration": 0.002494,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001009,
+          "duration": 0.001052,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.025858,
+          "duration": 0.017866,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.064358,
+          "duration": 1.066807,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001505,
+          "duration": 0.001466,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000525,
+          "duration": 0.000598,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000616,
+          "duration": 0.00054,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.731778,
+          "duration": 0.703438,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.731919,
+          "duration": 0.779175,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011942,
+          "duration": 0.021864,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006592,
+          "duration": 0.0039,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006732,
+          "duration": 0.00252,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.93291,
+          "duration": 0.854684,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.704687,
+          "duration": 0.731375,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.996084,
+          "duration": 0.967775,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000361,
+          "duration": 0.005624,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.289223,
+          "duration": 1.179678,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00039,
+          "duration": 0.000291,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000495,
+          "duration": 0.000549,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.599097,
+          "duration": 0.599622,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.769196,
+          "duration": 0.823795,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.12546,
+          "duration": 1.130103,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003808,
+          "duration": 0.005966,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002266,
+          "duration": 0.002234,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.220265,
+          "duration": 1.329776,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 15.714101999999997,
+      "duration": 16.019576,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 15.714101999999997,
+        "duration": 16.019576,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,13 +4,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.015 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
@@ -34,19 +34,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.018 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.005 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
 | Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.803 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.939 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.959 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.882 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.845 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.052 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.887 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.879 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.935 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.137 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.889 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.064 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.018 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.732 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.732 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.933 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.705 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.996 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.289 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.703 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.779 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.022 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.004 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.855 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.731 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.968 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.006 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.180 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.599 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.769 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.125 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.004 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.600 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.824 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.220 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.330 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"fa51e56d6e0dd1e65785ffda1bf416c270ee51de","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"27871350a1222b0755c17b2e48c61a074382fa07","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart
 
-1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Ubuntu runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution. Install **Node.js 24+** and run `npm install` to pull in the TypeScript dependencies used by helper scripts. Decide whether to execute on a standard GitHub-hosted runner or an integration runner with preinstalled tooling; see [runner-types](runner-types.md) for details.
-2. **Invoke via Composite Action (GitHub):** Use the adapter-specific action in your workflow. For example, to **build a LabVIEW Packed Library**:
+1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Ubuntu runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution. Install **Node.js 24+** and run `npm install` to pull in the TypeScript dependencies used by helper scripts. Decide whether to execute on a standard GitHub-hosted runner or an integration runner (a self-hosted machine with preinstalled tooling such as LabVIEW and g-cli); see [runner-types](runner-types.md) for details.
+2. **Invoke via Composite Action (GitHub):** Use the adapter-specific action in your workflow. Each task is implemented by a PowerShell adapter script and surfaced via a GitHub Action wrapper. For example, to **build a LabVIEW Packed Library**:
 
 ```yaml
 jobs:
@@ -25,7 +25,7 @@ jobs:
           commit: abcdef
 ```
 
-In this step, the wrapper action invokes the dispatcher to run the **build-lvlibp** task. The typed inputs provide the required parameters to build a 32-bit LV library. The dispatcher locates the appropriate script and executes it, failing the step if a problem occurs.
+In this step, the wrapper action (a composite GitHub Action) invokes the dispatcher to run the **build-lvlibp** adapter script. The typed inputs provide the required parameters to build a 32-bit LV library. The dispatcher locates the appropriate script and executes it, failing the step if a problem occurs.
 3. **Invoke via PowerShell (CLI):** You can also call the dispatcher script directly. For example, the above build can be run in a PowerShell session or script:
 
 ```powershell

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.052397" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.844561" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.996084" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.886989" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.879157" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002511" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.001831" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000279" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000223" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001009" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.025858" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002266" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.003808" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.017990" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.011942" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.006732" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.006592" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.004448" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.004945" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.008100" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001505" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000525" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000361" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000333" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000495" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000390" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000941" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.220265" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.289223" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.125460" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.938837" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.731919" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.599097" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.704687" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.731778" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.015390" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002636" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004638" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000815" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000906" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003223" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000616" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002337" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001772" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001131" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000976" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.004025" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001017" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000180" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.064358" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.932910" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.802567" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.769196" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000959" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000912" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.136683" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.934984" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.967775" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.889324" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.905619" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.001899" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.002494" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000310" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000356" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.001052" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.017866" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002234" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005966" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.014863" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.021864" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.002520" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.003900" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.004272" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009671" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.017509" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001466" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000598" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.005624" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000406" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000549" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000291" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001069" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.329776" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.179678" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.130103" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.881637" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.779175" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.599622" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.731375" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.703438" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009282" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004580" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.004619" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000576" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000716" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001384" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000540" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001023" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001198" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000738" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000608" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001104" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001436" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000160" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.066807" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.854684" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.958568" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.823795" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000984" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000806" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8657.244172 -->
+	<!-- duration_ms 8752.148938 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- clarify adapter/wrapper relationship in README
- define integration runners and wrapper roles in Quickstart

## Testing
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh $BASE_SHA`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea2a125c8329886a0bc5478287e4