### PR TITLE
docs: streamline README for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,33 +137,11 @@ XML test result output is intentionally disabled.
 
 ## Test and Release Mode
 
-Committing build artifacts together with a `release.json` file enables the
-release pipeline. The `release.json` file supplies the JSON payload describing
-the release:
-
-```json
-{"major":1,"minor":0,"patch":2,"title":"Release title"}
-```
-
-Ensure the build artifacts are present (for example under `artifacts/`) and
-checked in alongside `release.json`. The `ci.yml` workflow runs first and, on
-success, hands off to `release.yml` to publish the release. See
-[Test and Release Mode](AGENTS.md#test-and-release-mode) for more details.
+Committing build artifacts together with a `release.json` file enables the release pipeline. See [Test and Release Mode](docs/test-and-release-mode.md) for details.
 
 ## Requirement Traceability
 
-Each requirement is tracked as an issue or entry in a requirement mapping file
-such as [`requirements-core.json`](requirements-core.json) or
-[`requirements-icon-editor.json`](requirements-icon-editor.json). Every code change must reference the
-requirement it addresses, and each requirement must have at least one automated
-test. The CI pipeline checks these links and reports missing associations. For
-full mappings of requirements to tests, see
-[docs/requirements-core.md](docs/requirements-core.md) and
-[docs/requirements-icon-editor.md](docs/requirements-icon-editor.md).
-
-When generating summaries, provide the mapping files via the `REQ_MAPPING_FILE`
-environment variable. Multiple files can be supplied as a comma‑separated list,
-for example `REQ_MAPPING_FILE="requirements-core.json,requirements-icon-editor.json"`.
+Each commit must reference requirement IDs linked to automated tests. See [Test and Release Mode](docs/test-and-release-mode.md#requirement-traceability) for full guidance.
 
 ## Contributing
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 16.02 | 100.00 |
-| linux | 55 | 0 | 0 | 16.02 | 100.00 |
+| overall | 55 | 0 | 0 | 24.67 | 100.00 |
+| linux | 55 | 0 | 0 | 24.67 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 16.02 | 100.00 |
-| linux | 55 | 0 | 0 | 16.02 | 100.00 |
+| overall | 55 | 0 | 0 | 24.67 | 100.00 |
+| linux | 55 | 0 | 0 | 24.67 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,115 +4,115 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.013 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.014 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.959 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.882 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.011 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.507 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.935 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.137 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.889 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.274 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.539 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.407 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.510 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.018 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.519 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.009 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.703 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.779 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.022 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.004 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.855 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.731 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.968 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.006 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.180 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.600 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.824 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.330 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.183 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.247 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.456 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.222 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.307 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.739 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.004 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.107 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.312 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.715 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.831 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009282,
+          "duration": 0.012228,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00458,
+          "duration": 0.0186,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004619,
+          "duration": 0.012988,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000576,
+          "duration": 0.006272,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000716,
+          "duration": 0.001844,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001384,
+          "duration": 0.00443,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001023,
+          "duration": 0.002751,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001198,
+          "duration": 0.002563,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000738,
+          "duration": 0.001611,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000608,
+          "duration": 0.002134,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001104,
+          "duration": 0.00265,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014863,
+          "duration": 0.034209,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000984,
+          "duration": 0.001562,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000806,
+          "duration": 0.002081,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001069,
+          "duration": 0.00116,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017509,
+          "duration": 0.012277,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009671,
+          "duration": 0.014321,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004272,
+          "duration": 0.013261,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000406,
+          "duration": 0.000422,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.958568,
+          "duration": 1.538077,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001899,
+          "duration": 0.011134,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.881637,
+          "duration": 1.506724,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001436,
+          "duration": 0.001474,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00016,
+          "duration": 0.000199,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.934984,
+          "duration": 1.274064,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.136683,
+          "duration": 1.538821,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.889324,
+          "duration": 1.406783,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.905619,
+          "duration": 1.509932,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00031,
+          "duration": 0.000663,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000356,
+          "duration": 0.000534,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002494,
+          "duration": 0.004781,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001052,
+          "duration": 0.000971,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017866,
+          "duration": 0.022848,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.066807,
+          "duration": 1.519146,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001466,
+          "duration": 0.009065,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000598,
+          "duration": 0.001279,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00054,
+          "duration": 0.000902,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.703438,
+          "duration": 1.182818,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.779175,
+          "duration": 1.247212,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.021864,
+          "duration": 0.019707,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0039,
+          "duration": 0.009114,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00252,
+          "duration": 0.007393,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.854684,
+          "duration": 1.456046,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.731375,
+          "duration": 1.221719,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.967775,
+          "duration": 1.30688,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005624,
+          "duration": 0.000916,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.179678,
+          "duration": 1.738755,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000291,
+          "duration": 0.0045,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000549,
+          "duration": 0.001785,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.599622,
+          "duration": 1.107037,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.823795,
+          "duration": 1.311861,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.130103,
+          "duration": 1.714708,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005966,
+          "duration": 0.007808,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002234,
+          "duration": 0.005776,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.329776,
+          "duration": 1.830614,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 16.019576,
+      "duration": 24.669410000000003,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 16.019576,
+        "duration": 24.669410000000003,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,115 +4,115 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.009 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.013 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.001 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.001 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.015 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.018 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.010 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.014 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.959 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.882 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.011 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.507 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.935 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.137 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.889 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.906 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.002 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.274 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.539 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.407 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.510 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.018 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.067 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.519 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.009 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.703 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.779 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.022 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.004 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.003 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.855 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.731 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.968 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.006 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.180 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.600 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.824 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.130 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.330 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.183 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.247 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.456 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.222 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.307 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.739 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.004 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.107 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.312 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.715 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.831 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"27871350a1222b0755c17b2e48c61a074382fa07","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"94c3302c76b70d261bdf672d4fef2e552de90d76","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Open Source LabVIEW Actions unifies LabVIEW [CI/CD](glossary.md#ci-cd) scripts b
 - [User Guide](user-guide.md)
 - [Contributor Guide](contributor-guide.md)
 - [Maintainer Guide](maintainer-guide.md)
+- [Test and Release Mode](test-and-release-mode.md)
 - [Environment Setup](environment-setup.md)
 - [Action Call Reference](action-call-reference.md)
 - [Common Parameters](common-parameters.md)

--- a/docs/test-and-release-mode.md
+++ b/docs/test-and-release-mode.md
@@ -1,0 +1,21 @@
+# Test and Release Mode
+
+Committing build artifacts together with a `release.json` file enables the release pipeline. The `release.json` file supplies the JSON payload describing the release:
+
+```json
+{"major":1,"minor":0,"patch":2,"title":"Release title"}
+```
+
+Ensure the build artifacts are present (for example under `artifacts/`) and checked in alongside `release.json`. The `ci.yml` workflow runs first and, on success, hands off to `release.yml` to publish the release. See [AGENTS.md](../AGENTS.md#test-and-release-mode) for repository expectations.
+
+## Requirement Traceability
+
+Each requirement is tracked as an issue or entry in a requirement mapping file such as [`requirements-core.json`](../requirements-core.json) or [`requirements-icon-editor.json`](../requirements-icon-editor.json). Every code change must reference the requirement it addresses, and each requirement must have at least one automated test. The CI pipeline checks these links and reports missing associations. For full mappings of requirements to tests, see [docs/requirements-core.md](requirements-core.md) and [docs/requirements-icon-editor.md](requirements-icon-editor.md).
+
+When generating summaries, provide the mapping files via the `REQ_MAPPING_FILE` environment variable. Multiple files can be supplied as a comma-separated list, for example:
+
+```bash
+REQ_MAPPING_FILE="requirements-core.json,requirements-icon-editor.json"
+```
+
+`npm run test:ci` writes JUnit files to `test-results/`. [`scripts/generate-ci-summary.ts`](../scripts/generate-ci-summary.ts) parses these results to build requirement traceability files in OS-specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable. Commit `test-results/*` and `artifacts/linux/*` along with your source changes. The summary script searches `artifacts/` by default; set `TEST_RESULTS_GLOBS` if your reports are elsewhere.

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.136683" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.934984" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="0.967775" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.889324" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.905619" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.001899" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002494" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000310" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000356" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001052" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.017866" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002234" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005966" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.014863" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.021864" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.002520" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.003900" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.004272" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.009671" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.017509" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001466" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000598" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.005624" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000406" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000549" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000291" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001069" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.329776" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.179678" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.130103" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="0.881637" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.779175" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.599622" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.731375" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.703438" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009282" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004580" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004619" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000576" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000716" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001384" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000540" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001023" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001198" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000738" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000608" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001104" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001436" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000160" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.066807" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.854684" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.958568" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.823795" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.000984" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.000806" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.538821" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.274064" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.306880" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.406783" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.509932" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.011134" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004781" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000663" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000534" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000971" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.022848" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005776" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.007808" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.034209" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.019707" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.007393" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.009114" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.013261" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014321" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.012277" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.009065" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001279" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000916" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000422" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001785" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.004500" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001160" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.830614" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.738755" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.714708" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.506724" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.247212" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.107037" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.221719" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.182818" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012228" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.018600" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.012988" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.006272" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001844" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004430" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000902" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002751" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002563" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001611" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.002134" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002650" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001474" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000199" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.519146" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.456046" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.538077" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.311861" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001562" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002081" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 8752.148938 -->
+	<!-- duration_ms 13779.184065 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- condense advanced sections in README and link to maintainer documentation
- add Test and Release Mode guide detailing release workflow and traceability
- surface new guide from docs index

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run check:traceability`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh HEAD~1`


------
https://chatgpt.com/codex/tasks/task_e_68a5ece251588329bee3c13df7f555b0