### PR TITLE
Replace AGENTS reference with maintainer guide

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 24.67 | 100.00 |
-| linux | 55 | 0 | 0 | 24.67 | 100.00 |
+| overall | 55 | 0 | 0 | 14.58 | 100.00 |
+| linux | 55 | 0 | 0 | 14.58 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 24.67 | 100.00 |
-| linux | 55 | 0 | 0 | 24.67 | 100.00 |
+| overall | 55 | 0 | 0 | 14.58 | 100.00 |
+| linux | 55 | 0 | 0 | 14.58 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,115 +4,115 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.013 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.013 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.011 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.507 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.847 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.854 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.274 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.539 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.407 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.510 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.908 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.916 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.752 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.776 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
 | Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.519 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.009 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.183 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.247 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.456 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.222 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.307 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.739 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.004 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.107 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.312 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.715 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.831 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.938 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.689 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.733 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.003 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.817 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.684 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.986 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.058 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.584 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.740 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.047 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.132 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012228,
+          "duration": 0.005994,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0186,
+          "duration": 0.00146,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012988,
+          "duration": 0.00388,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006272,
+          "duration": 0.000911,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001844,
+          "duration": 0.001462,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00443,
+          "duration": 0.002032,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002751,
+          "duration": 0.001493,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002563,
+          "duration": 0.002441,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001611,
+          "duration": 0.000563,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002134,
+          "duration": 0.000479,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00265,
+          "duration": 0.000911,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.034209,
+          "duration": 0.013105,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001562,
+          "duration": 0.000961,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002081,
+          "duration": 0.004396,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00116,
+          "duration": 0.000377,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012277,
+          "duration": 0.004185,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014321,
+          "duration": 0.007685,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013261,
+          "duration": 0.00382,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000422,
+          "duration": 0.000347,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.538077,
+          "duration": 0.846563,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011134,
+          "duration": 0.002636,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.506724,
+          "duration": 0.854332,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001474,
+          "duration": 0.000954,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000199,
+          "duration": 0.000187,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.274064,
+          "duration": 0.908449,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.538821,
+          "duration": 0.916351,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.406783,
+          "duration": 0.751786,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.509932,
+          "duration": 0.775746,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000663,
+          "duration": 0.000242,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000534,
+          "duration": 0.000242,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004781,
+          "duration": 0.004719,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000971,
+          "duration": 0.000416,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022848,
+          "duration": 0.023447,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.519146,
+          "duration": 0.937563,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009065,
+          "duration": 0.001195,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001279,
+          "duration": 0.00043,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000902,
+          "duration": 0.00047,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.182818,
+          "duration": 0.689189,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.247212,
+          "duration": 0.733459,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.019707,
+          "duration": 0.009295,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009114,
+          "duration": 0.002732,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007393,
+          "duration": 0.002235,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.456046,
+          "duration": 0.817233,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.221719,
+          "duration": 0.684466,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.30688,
+          "duration": 0.986207,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000916,
+          "duration": 0.000399,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.738755,
+          "duration": 1.058217,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0045,
+          "duration": 0.000255,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001785,
+          "duration": 0.000395,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.107037,
+          "duration": 0.583873,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.311861,
+          "duration": 0.739888,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.714708,
+          "duration": 1.046543,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007808,
+          "duration": 0.00529,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005776,
+          "duration": 0.005166,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.830614,
+          "duration": 1.131796,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 24.669410000000003,
+      "duration": 14.578867999999998,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 24.669410000000003,
+        "duration": 14.578867999999998,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,115 +4,115 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.001 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.013 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.006 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.002 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.003 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-032 | preserves-unknown-attributes | Passed | 0.002 |  |  |
+| REQ-032 | preserves-unknown-attributes | Passed | 0.000 |  |  |
 
 #### REQ-033 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.034 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.012 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.013 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.013 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.004 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.004 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.004 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.011 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.507 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.847 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.854 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.274 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.539 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.407 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.510 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.908 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.916 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.752 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.776 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
 | Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.519 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.009 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.183 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.247 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.456 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.222 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.307 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.739 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.004 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.107 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.312 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.715 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.008 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.831 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.938 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.689 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.733 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.009 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.003 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.002 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.817 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.684 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.986 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.058 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.584 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.740 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.047 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.132 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"94c3302c76b70d261bdf672d4fef2e552de90d76","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"18220f46ead4a0420ffe388787d77e8d17681622","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/docs/test-and-release-mode.md
+++ b/docs/test-and-release-mode.md
@@ -6,7 +6,7 @@ Committing build artifacts together with a `release.json` file enables the relea
 {"major":1,"minor":0,"patch":2,"title":"Release title"}
 ```
 
-Ensure the build artifacts are present (for example under `artifacts/`) and checked in alongside `release.json`. The `ci.yml` workflow runs first and, on success, hands off to `release.yml` to publish the release. See [AGENTS.md](../AGENTS.md#test-and-release-mode) for repository expectations.
+Ensure the build artifacts are present (for example under `artifacts/`) and checked in alongside `release.json`. The `ci.yml` workflow runs first and, on success, hands off to `release.yml` to publish the release. See the [Maintainer Guide](maintainer-guide.md) for repository expectations.
 
 ## Requirement Traceability
 

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.538821" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.274064" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.306880" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.406783" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.509932" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.011134" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004781" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000663" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000534" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000971" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022848" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005776" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.007808" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.034209" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.019707" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.007393" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.009114" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.013261" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014321" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.012277" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.009065" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001279" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000916" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000422" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001785" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.004500" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001160" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.830614" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.738755" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.714708" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.506724" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.247212" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.107037" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.221719" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.182818" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012228" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.018600" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.012988" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.006272" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001844" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004430" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000902" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002751" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002563" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001611" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.002134" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002650" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001474" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000199" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.519146" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.456046" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.538077" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.311861" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001562" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002081" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.916351" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.908449" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.986207" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.751786" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.775746" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002636" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004719" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000242" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000242" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000416" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.023447" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005166" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005290" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.013105" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.009295" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.002235" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.002732" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.003820" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.007685" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.004185" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001195" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000430" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000399" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000347" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000395" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000255" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000377" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.131796" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.058217" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.046543" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.854332" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.733459" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.583873" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.684466" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.689189" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.005994" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.001460" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.003880" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000911" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001462" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002032" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000470" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001493" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002441" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000563" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000479" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.000911" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.000954" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000187" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.937563" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.817233" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.846563" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.739888" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.000961" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.004396" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 13779.184065 -->
+	<!-- duration_ms 8079.383834 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- replace outdated AGENTS.md link in Test and Release Mode docs with Maintainer Guide link

## Testing
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_OS=Linux TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh 18220f46ead4a0420ffe388787d77e8d17681622`


------
https://chatgpt.com/codex/tasks/task_e_68a5efddebac8329af76b99623c32fe4