### PR TITLE
Add dry-run script tests for icon editor pipeline

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 21.79 | 100.00 |
-| linux | 55 | 0 | 0 | 21.79 | 100.00 |
+| overall | 55 | 0 | 0 | 20.36 | 100.00 |
+| linux | 55 | 0 | 0 | 20.36 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 21.79 | 100.00 |
-| linux | 55 | 0 | 0 | 21.79 | 100.00 |
+| overall | 55 | 0 | 0 | 20.36 | 100.00 |
+| linux | 55 | 0 | 0 | 20.36 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.016 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.005 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.030 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.030 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
 | Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.216 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.269 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.379 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.224 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.256 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.053 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.387 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.065 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.083 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.187 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.111 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.357 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.609 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.956 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.044 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.505 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.601 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016347,
+          "duration": 0.009747,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.018668,
+          "duration": 0.007588,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002121,
+          "duration": 0.004783,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001321,
+          "duration": 0.002267,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001588,
+          "duration": 0.001161,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004302,
+          "duration": 0.002509,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003584,
+          "duration": 0.001412,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001928,
+          "duration": 0.001485,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005427,
+          "duration": 0.001755,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001444,
+          "duration": 0.001023,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004417,
+          "duration": 0.002682,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.030008,
+          "duration": 0.015502,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001818,
+          "duration": 0.003125,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00219,
+          "duration": 0.001728,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000483,
+          "duration": 0.001298,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016879,
+          "duration": 0.013926,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017359,
+          "duration": 0.008051,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.029738,
+          "duration": 0.018238,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000305,
+          "duration": 0.001865,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.247664,
+          "duration": 1.248288,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002526,
+          "duration": 0.007936,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.215788,
+          "duration": 1.174451,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003332,
+          "duration": 0.001569,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000333,
+          "duration": 0.000203,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.269401,
+          "duration": 1.123831,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.378855,
+          "duration": 1.446471,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.22388,
+          "duration": 1.097653,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.256447,
+          "duration": 1.230001,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000939,
+          "duration": 0.000573,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000466,
+          "duration": 0.000414,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004256,
+          "duration": 0.006045,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000757,
+          "duration": 0.000676,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.052596,
+          "duration": 0.022972,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.387249,
+          "duration": 1.310561,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003125,
+          "duration": 0.004251,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000716,
+          "duration": 0.002915,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000619,
+          "duration": 0.000897,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.064504,
+          "duration": 1.001176,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.082915,
+          "duration": 0.968813,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013809,
+          "duration": 0.020384,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015111,
+          "duration": 0.010414,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004864,
+          "duration": 0.003853,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.186993,
+          "duration": 1.117278,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.111474,
+          "duration": 0.985076,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.357437,
+          "duration": 1.193745,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000411,
+          "duration": 0.000844,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.608572,
+          "duration": 1.466826,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000333,
+          "duration": 0.000227,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000441,
+          "duration": 0.001145,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.956439,
+          "duration": 0.798065,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.04394,
+          "duration": 0.98769,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.505261,
+          "duration": 1.403466,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.023646,
+          "duration": 0.005096,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005266,
+          "duration": 0.004257,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.600819,
+          "duration": 1.615607,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 21.791110999999997,
+      "duration": 20.36381400000001,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 21.791110999999997,
+        "duration": 20.36381400000001,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.016 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.019 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.005 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.030 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.030 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
 | Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.216 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.003 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.269 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.379 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.224 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.256 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.053 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.387 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.065 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.083 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.187 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.111 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.357 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.609 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.956 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.044 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.505 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.024 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.601 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"12d598600a5563075bbc4fafc45a7d9fc6a8f4f9","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"b271bd747a41a33b2823b019f2dc112473499c5c","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -14,3 +14,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.378855" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.269401" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.357437" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.223880" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.256447" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.002526" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004256" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000939" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000466" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000757" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.052596" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.005266" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.023646" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.030008" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013809" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.004864" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.015111" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.029738" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.017359" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.016879" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003125" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000716" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000411" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000305" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000441" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000333" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000483" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.600819" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.608572" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.505261" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.215788" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.082915" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.956439" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.111474" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.064504" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.016347" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.018668" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.002121" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001321" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001588" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.004302" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000619" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003584" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001928" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.005427" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001444" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.004417" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.003332" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000333" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.387249" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.186993" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.247664" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.043940" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001818" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002190" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.446471" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.123831" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.193745" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.097653" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.230001" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.007936" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.006045" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000573" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000414" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000676" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.022972" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004257" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005096" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.015502" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020384" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003853" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.010414" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.018238" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008051" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.013926" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.004251" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.002915" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000844" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.001865" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001145" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000227" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001298" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.615607" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.466826" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.403466" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.174451" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.968813" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.798065" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.985076" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.001176" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009747" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007588" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.004783" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.002267" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001161" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002509" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000897" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001412" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001485" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001755" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001023" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002682" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001569" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000203" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.310561" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.117278" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.248288" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.987690" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.003125" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001728" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 12209.219259 -->
+	<!-- duration_ms 11254.672041 -->
 </testsuites>

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
@@ -1,0 +1,24 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Script' {
+    $meta = @{
+        requirement = 'REQIE-001'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1'
+    }
+
+    It 'invokes AddTokenToLabVIEW with expected arguments [REQIE-001]' -Tag 'REQIE-001' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $scriptPath = Join-Path $repoRoot 'scripts' 'add-token-to-labview' 'AddTokenToLabVIEW.ps1'
+        $captured = $null
+        Mock g-cli { $script:captured = $args }
+        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot *> $null
+        Assert-MockCalled g-cli -Exactly 1 -Scope It
+        $captured | Should -Contain '--lv-ver'
+        $captured | Should -Contain '2021'
+        $captured | Should -Contain '--arch'
+        $captured | Should -Contain '64'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
@@ -1,0 +1,23 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'BuildProfile1.IconEditor.ApplyVipc.Script' {
+    $meta = @{
+        requirement = 'REQIE-002'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1'
+    }
+
+    It 'constructs g-cli commands without executing [REQIE-002]' -Tag 'REQIE-002' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $scriptPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'ApplyVIPC.ps1'
+        $vipcPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'runner_dependencies.vipc'
+        $captured = $null
+        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
+        & $scriptPath -MinimumSupportedLVVersion '2021' -VIP_LVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -VIPCPath $vipcPath *> $null
+        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
+        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64'
+        $captured | Should -Match [regex]::Escape($vipcPath)
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
@@ -1,0 +1,24 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'BuildProfile1.IconEditor.BuildViPackage.Script' {
+    $meta = @{
+        requirement = 'REQIE-008'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1'
+    }
+
+    It 'constructs g-cli vipb command without executing [REQIE-008]' -Tag 'REQIE-008' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $scriptPath = Join-Path $repoRoot 'scripts' 'build-vi-package' 'build_vip.ps1'
+        $releaseNotes = Join-Path $repoRoot 'scripts' 'build-vi-package' 'release-notes.md'
+        $json = '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
+        $captured = $null
+        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
+        Mock New-Item { }
+        & $scriptPath -SupportedBitness '64' -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit 'abcdef0' -ReleaseNotesFile $releaseNotes -DisplayInformationJSON $json *> $null
+        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
+        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 vipb'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
@@ -1,0 +1,21 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'BuildProfile1.IconEditor.CloseLabview.Script' {
+    $meta = @{
+        requirement = 'REQIE-010'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1'
+    }
+
+    It 'constructs g-cli QuitLabVIEW command without executing [REQIE-010]' -Tag 'REQIE-010' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $scriptPath = Join-Path $repoRoot 'scripts' 'close-labview' 'Close_LabVIEW.ps1'
+        $captured = $null
+        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
+        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' *> $null
+        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
+        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 QuitLabVIEW'
+    }
+}


### PR DESCRIPTION
## Summary
- add dry-run script tests for AddTokenToLabVIEW, ApplyVIPC, Build VI Package, and Close LabVIEW scripts

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh b271bd747a41a33b2823b019f2dc112473499c5c`


------
https://chatgpt.com/codex/tasks/task_e_68a609079b908329b44eb7cff95b92fe