### PR TITLE
Add dispatcher tests for icon editor actions

### DIFF
--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 20.36 | 100.00 |
-| linux | 55 | 0 | 0 | 20.36 | 100.00 |
+| overall | 55 | 0 | 0 | 28.93 | 100.00 |
+| linux | 55 | 0 | 0 | 28.93 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 20.36 | 100.00 |
-| linux | 55 | 0 | 0 | 20.36 | 100.00 |
+| overall | 55 | 0 | 0 | 28.93 | 100.00 |
+| linux | 55 | 0 | 0 | 28.93 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.019 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.016 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,25 +28,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.006 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.006 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.005 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.033 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.023 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.034 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.685 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.013 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.728 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.533 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.723 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.663 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.701 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.008 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.044 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.983 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.325 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.470 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.602 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.390 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.881 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.960 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.138 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.487 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.190 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.043 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.011 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.102 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009747,
+          "duration": 0.019295,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007588,
+          "duration": 0.016408,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004783,
+          "duration": 0.00181,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002267,
+          "duration": 0.002105,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001161,
+          "duration": 0.002133,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002509,
+          "duration": 0.005986,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001412,
+          "duration": 0.006017,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001485,
+          "duration": 0.002777,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001755,
+          "duration": 0.001737,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001023,
+          "duration": 0.001319,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002682,
+          "duration": 0.005746,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015502,
+          "duration": 0.0332,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003125,
+          "duration": 0.001937,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001728,
+          "duration": 0.004564,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +222,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001298,
+          "duration": 0.002625,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +231,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013926,
+          "duration": 0.032598,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +240,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008051,
+          "duration": 0.023427,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +249,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.018238,
+          "duration": 0.033673,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001865,
+          "duration": 0.000746,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.248288,
+          "duration": 1.685356,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007936,
+          "duration": 0.013294,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.174451,
+          "duration": 1.727691,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001569,
+          "duration": 0.002045,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000203,
+          "duration": 0.000369,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.123831,
+          "duration": 1.533182,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.446471,
+          "duration": 1.722613,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.097653,
+          "duration": 1.663083,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.230001,
+          "duration": 1.700791,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000573,
+          "duration": 0.00064,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000414,
+          "duration": 0.000241,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006045,
+          "duration": 0.008394,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000676,
+          "duration": 0.00096,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022972,
+          "duration": 0.04409,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.310561,
+          "duration": 1.98251,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004251,
+          "duration": 0.003282,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002915,
+          "duration": 0.001166,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000897,
+          "duration": 0.000978,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.001176,
+          "duration": 1.32545,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.968813,
+          "duration": 1.469592,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020384,
+          "duration": 0.017324,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010414,
+          "duration": 0.015151,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003853,
+          "duration": 0.006516,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.117278,
+          "duration": 1.602453,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.985076,
+          "duration": 1.390444,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.193745,
+          "duration": 1.881005,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000844,
+          "duration": 0.00073,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.466826,
+          "duration": 1.959895,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000227,
+          "duration": 0.000497,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001145,
+          "duration": 0.001228,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.798065,
+          "duration": 1.137804,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.98769,
+          "duration": 1.48705,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.403466,
+          "duration": 2.190031,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005096,
+          "duration": 0.042571,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004257,
+          "duration": 0.011387,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.615607,
+          "duration": 2.101558,
           "requirements": [],
           "os": "linux"
         }
@@ -594,7 +594,7 @@
       "passed": 55,
       "failed": 0,
       "skipped": 0,
-      "duration": 20.36381400000001,
+      "duration": 28.929473999999995,
       "rate": 100
     },
     "byOs": {
@@ -602,7 +602,7 @@
         "passed": 55,
         "failed": 0,
         "skipped": 0,
-        "duration": 20.36381400000001,
+        "duration": 28.929473999999995,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.019 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.016 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,25 +28,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.006 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.006 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,55 +64,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.006 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.033 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.005 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.033 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.023 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.034 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.685 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.013 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.728 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.533 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.723 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.663 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.701 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.008 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.044 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.983 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.325 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.470 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.015 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.007 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.602 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.390 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.881 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.960 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.138 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.487 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 2.190 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.043 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.011 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 2.102 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"b271bd747a41a33b2823b019f2dc112473499c5c","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"a4ddc5334d90f16cc8f3f0d60a7a84cd6e0bacba","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -30,3 +30,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/test-results/lint-md.log
+++ b/test-results/lint-md.log
@@ -4,5 +4,5 @@
 
 markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
 Finding: README.md docs/**/*.md scripts/**/*.md
-Linting: 94 file(s)
+Linting: 95 file(s)
 Summary: 0 error(s)

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.446471" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.123831" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.193745" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.097653" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.230001" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.007936" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.006045" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000573" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000414" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000676" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022972" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004257" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005096" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.015502" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020384" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.003853" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.010414" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.018238" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008051" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.013926" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.004251" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.002915" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000844" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.001865" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001145" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000227" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001298" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.615607" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.466826" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.403466" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.174451" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.968813" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.798065" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.985076" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.001176" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009747" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007588" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004783" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.002267" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001161" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002509" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000897" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001412" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001485" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001755" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001023" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002682" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001569" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000203" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.310561" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.117278" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.248288" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.987690" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003125" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001728" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.722613" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.533182" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.881005" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.663083" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.700791" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.013294" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.008394" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000640" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000241" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000960" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.044090" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.011387" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.042571" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.033200" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.017324" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.006516" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.015151" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.033673" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.023427" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.032598" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.003282" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.001166" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000730" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000746" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001228" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000497" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.002625" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="2.101558" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.959895" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="2.190031" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.727691" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.469592" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.137804" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.390444" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.325450" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.019295" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.016408" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.001810" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.002105" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.002133" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.005986" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000978" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.006017" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002777" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001737" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001319" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.005746" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002045" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000369" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.982510" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.602453" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.685356" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.487050" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001937" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.004564" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 11254.672041 -->
+	<!-- duration_ms 15809.392181 -->
 </testsuites>

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
@@ -1,0 +1,26 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-001'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1'
+    }
+
+    It 'invokes add-token-to-labview via dispatcher [REQIE-001]' -Tag 'REQIE-001' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $json = $params.ArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'AddTokenToLabVIEW.ps1'
+        $out | Should -Match '"MinimumSupportedLVVersion":"2021"'
+        $out | Should -Match '"SupportedBitness":"64"'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
@@ -1,0 +1,30 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.ApplyVipc.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-002'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1'
+    }
+
+    It 'invokes apply-vipc via dispatcher [REQIE-002]' -Tag 'REQIE-002' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $base = $params.ArgsJson | ConvertFrom-Json
+        $vipcPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'runner_dependencies.vipc'
+        $base | Add-Member VIP_LVVersion '2021'
+        $base | Add-Member VIPCPath $vipcPath
+        $json = $base | ConvertTo-Json -Compress
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName apply-vipc -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'ApplyVIPC.ps1'
+        $out | Should -Match [regex]::Escape('runner_dependencies.vipc')
+        $out | Should -Match '"VIP_LVVersion":"2021"'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
@@ -1,0 +1,38 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.BuildViPackage.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-008'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1'
+    }
+
+    It 'invokes build-vi-package via dispatcher [REQIE-008]' -Tag 'REQIE-008' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $base = $params.ArgsJson | ConvertFrom-Json
+        $vipbPath = Join-Path $repoRoot 'scripts' 'build-vi-package' 'NI Icon editor.vipb'
+        $releaseNotes = Join-Path $repoRoot 'scripts' 'build-vi-package' 'release-notes.md'
+        $base | Add-Member LabVIEWMinorRevision '3'
+        $base | Add-Member VIPBPath $vipbPath
+        $base | Add-Member Major 1
+        $base | Add-Member Minor 0
+        $base | Add-Member Patch 0
+        $base | Add-Member Build 2
+        $base | Add-Member Commit 'abcdef0'
+        $base | Add-Member DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
+        $base | Add-Member ReleaseNotesFile $releaseNotes
+        $json = $base | ConvertTo-Json -Compress
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName build-vi-package -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'build_vip.ps1'
+        $out | Should -Match [regex]::Escape('NI Icon editor.vipb')
+        $out | Should -Match '"Commit":"abcdef0"'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
@@ -1,0 +1,26 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.CloseLabview.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-010'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1'
+    }
+
+    It 'invokes close-labview via dispatcher [REQIE-010]' -Tag 'REQIE-010' {
+        $params = Get-LabVIEWIconEditorArgsJson
+        $json = $params.ArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'Close_LabVIEW.ps1'
+        $out | Should -Match '"MinimumSupportedLVVersion":"2021"'
+        $out | Should -Match '"SupportedBitness":"64"'
+    }
+}


### PR DESCRIPTION
## Summary
- add dry-run dispatcher tests for AddTokenToLabview, ApplyVipc, BuildViPackage, and CloseLabview
- verify dispatcher outputs match existing script tests

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a60c1586548329a1ef0e2b336e382e