### PR TITLE
test: add dispatcher coverage for icon-editor actions

### DIFF
--- a/artifacts/linux/requirements-summary.md
+++ b/artifacts/linux/requirements-summary.md
@@ -12,7 +12,7 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 44 | 44 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 48 | 48 | 0 | 0 | 100.00 |
 
 ### Requirement Testcases
 | Requirement ID | Test ID | Status |
@@ -31,6 +31,10 @@
 | Unmapped | associates-classname-with-requirement | Passed |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed |
+| Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed |
+| Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed |
+| Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed |
+| Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed |
 | Unmapped | buildsummary-splits-totals-by-os | Passed |
 | Unmapped | collecttestcases-captures-requirement-property | Passed |
 | Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed |

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 20.36 | 100.00 |
-| linux | 55 | 0 | 0 | 20.36 | 100.00 |
+| overall | 59 | 0 | 0 | 21.58 | 100.00 |
+| linux | 59 | 0 | 0 | 21.58 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 55 | 0 | 0 | 20.36 | 100.00 |
-| linux | 55 | 0 | 0 | 20.36 | 100.00 |
+| overall | 59 | 0 | 0 | 21.58 | 100.00 |
+| linux | 59 | 0 | 0 | 21.58 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |
@@ -18,6 +18,6 @@
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. |  | 1 | 1 | 0 | 0 | 100.00 |
 | REQ-033 | Tests ending with SelfHosted.Workflow.Tests.ps1 execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled self-hosted-windows-lv. |  | 1 | 1 | 0 | 0 | 100.00 |
-| Unmapped |  |  | 44 | 44 | 0 | 0 | 100.00 |
+| Unmapped |  |  | 48 | 48 | 0 | 0 | 100.00 |
 
 _For detailed per-test information, see [traceability.md](traceability.md)._

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,25 +4,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,25 +34,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -70,49 +70,53 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
+| Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
+| Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
+| Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009747,
+          "duration": 0.022782,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007588,
+          "duration": 0.006805,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004783,
+          "duration": 0.012317,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002267,
+          "duration": 0.001227,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001161,
+          "duration": 0.001187,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002509,
+          "duration": 0.01091,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001412,
+          "duration": 0.001763,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001485,
+          "duration": 0.00203,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001755,
+          "duration": 0.000859,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001023,
+          "duration": 0.001374,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002682,
+          "duration": 0.002535,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015502,
+          "duration": 0.028064,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003125,
+          "duration": 0.001407,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,43 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001728,
+          "duration": 0.001573,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments-",
+          "name": "BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.dry-runs add-token-to-labview with expected arguments [REQIE-001]",
+          "className": "/workspace/open-source/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1",
+          "status": "Passed",
+          "duration": 0.482,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments-",
+          "name": "BuildProfile1.IconEditor.ApplyVipc.Dispatcher.dry-runs apply-vipc with expected arguments [REQIE-002]",
+          "className": "/workspace/open-source/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1",
+          "status": "Passed",
+          "duration": 0.042,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments-",
+          "name": "BuildProfile1.IconEditor.BuildViPackage.Dispatcher.dry-runs build-vi-package with expected arguments [REQIE-008]",
+          "className": "/workspace/open-source/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1",
+          "status": "Passed",
+          "duration": 0.106,
+          "requirements": [],
+          "os": "linux"
+        },
+        {
+          "id": "buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments-",
+          "name": "BuildProfile1.IconEditor.CloseLabview.Dispatcher.dry-runs close-labview with expected arguments [REQIE-010]",
+          "className": "/workspace/open-source/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1",
+          "status": "Passed",
+          "duration": 0.036,
           "requirements": [],
           "os": "linux"
         },
@@ -222,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001298,
+          "duration": 0.001865,
           "requirements": [],
           "os": "linux"
         },
@@ -231,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013926,
+          "duration": 0.01681,
           "requirements": [],
           "os": "linux"
         },
@@ -240,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008051,
+          "duration": 0.014548,
           "requirements": [],
           "os": "linux"
         },
@@ -249,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.018238,
+          "duration": 0.022855,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001865,
+          "duration": 0.000413,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.248288,
+          "duration": 1.200369,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.007936,
+          "duration": 0.009128,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.174451,
+          "duration": 1.251414,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001569,
+          "duration": 0.001383,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +339,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000203,
+          "duration": 0.000206,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.123831,
+          "duration": 1.258809,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.446471,
+          "duration": 1.342315,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.097653,
+          "duration": 1.237183,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.230001,
+          "duration": 1.213962,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +384,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000573,
+          "duration": 0.000452,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +393,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000414,
+          "duration": 0.000404,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +402,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006045,
+          "duration": 0.004599,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +411,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000676,
+          "duration": 0.001304,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +420,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022972,
+          "duration": 0.038685,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +429,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.310561,
+          "duration": 1.376147,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +438,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004251,
+          "duration": 0.002115,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +447,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002915,
+          "duration": 0.00085,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +456,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000897,
+          "duration": 0.001112,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +465,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.001176,
+          "duration": 0.941473,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +474,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.968813,
+          "duration": 1.00302,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +483,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.020384,
+          "duration": 0.013044,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +492,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010414,
+          "duration": 0.014155,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +501,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003853,
+          "duration": 0.004424,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +510,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.117278,
+          "duration": 1.16546,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +519,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.985076,
+          "duration": 0.966158,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +528,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.193745,
+          "duration": 1.243643,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +537,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000844,
+          "duration": 0.000636,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +546,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.466826,
+          "duration": 1.496572,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +555,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000227,
+          "duration": 0.000893,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +564,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001145,
+          "duration": 0.001172,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +573,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.798065,
+          "duration": 0.829463,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +582,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.98769,
+          "duration": 0.988567,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +591,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.403466,
+          "duration": 1.412212,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +600,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005096,
+          "duration": 0.006686,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +609,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004257,
+          "duration": 0.006355,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +618,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.615607,
+          "duration": 1.729754,
           "requirements": [],
           "os": "linux"
         }
@@ -591,18 +627,18 @@
   ],
   "totals": {
     "overall": {
-      "passed": 55,
+      "passed": 59,
       "failed": 0,
       "skipped": 0,
-      "duration": 20.36381400000001,
+      "duration": 21.581447999999998,
       "rate": 100
     },
     "byOs": {
       "linux": {
-        "passed": 55,
+        "passed": 59,
         "failed": 0,
         "skipped": 0,
-        "duration": 20.36381400000001,
+        "duration": 21.581447999999998,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,25 +4,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.010 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.008 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.005 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
@@ -34,25 +34,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -70,49 +70,53 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.014 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.018 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.002 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.248 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.008 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.174 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
+| Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
+| Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
+| Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.124 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.446 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.098 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.230 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.006 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.023 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.311 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.004 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.001 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.969 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.020 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.117 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.985 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.194 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.467 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.798 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.988 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.403 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.616 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"b271bd747a41a33b2823b019f2dc112473499c5c","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"a4ddc5334d90f16cc8f3f0d60a7a84cd6e0bacba","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -30,3 +30,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.446471" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.123831" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.193745" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.097653" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.230001" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.007936" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.006045" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000573" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000414" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000676" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022972" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004257" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005096" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.015502" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.020384" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.003853" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.010414" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.018238" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008051" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.013926" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.004251" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.002915" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000844" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.001865" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001145" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000227" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001298" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.615607" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.466826" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.403466" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.174451" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.968813" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.798065" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.985076" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.001176" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.009747" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.007588" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.004783" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.002267" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001161" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002509" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000897" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001412" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001485" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001755" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001023" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002682" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001569" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000203" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.310561" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.117278" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.248288" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.987690" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003125" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001728" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.342315" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.258809" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.243643" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.237183" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.213962" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.009128" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004599" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000452" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000404" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.001304" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.038685" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006355" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.006686" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.028064" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013044" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.004424" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.014155" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.022855" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014548" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.016810" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002115" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000850" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000636" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000413" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001172" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000893" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001865" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.729754" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.496572" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.412212" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.251414" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.003020" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.829463" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.966158" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.941473" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.022782" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.006805" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.012317" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001227" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001187" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.010910" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001112" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001763" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002030" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000859" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.001374" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002535" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001383" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000206" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.376147" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.165460" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.200369" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.988567" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001407" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001573" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 11254.672041 -->
+	<!-- duration_ms 11656.124195 -->
 </testsuites>

--- a/test-results/pester-junit.xml
+++ b/test-results/pester-junit.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<testsuites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="junit_schema_4.xsd" name="Pester" tests="4" errors="0" failures="0" disabled="0" time="1.403">
+  <testsuite name="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1" tests="1" errors="0" failures="0" hostname="71c40d4e897c" id="0" skipped="0" disabled="0" package="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1" time="1.060">
+    <properties>
+      <property name="cwd" value="/workspace/open-source" />
+      <property name="user" value="root" />
+      <property name="framework-version" value="5.7.1" />
+      <property name="os-version" value="6.12.13" />
+      <property name="platform" value="Linux" />
+      <property name="junit-version" value="4" />
+      <property name="clr-version" value="9.0.4" />
+      <property name="machine-name" value="71c40d4e897c" />
+      <property name="user-domain" value="" />
+    </properties>
+    <testcase name="BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.dry-runs add-token-to-labview with expected arguments [REQIE-001]" status="Passed" classname="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1" assertions="0" time="0.482" />
+  </testsuite>
+  <testsuite name="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1" tests="1" errors="0" failures="0" hostname="71c40d4e897c" id="1" skipped="0" disabled="0" package="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1" time="0.084">
+    <properties>
+      <property name="cwd" value="/workspace/open-source" />
+      <property name="user" value="root" />
+      <property name="framework-version" value="5.7.1" />
+      <property name="os-version" value="6.12.13" />
+      <property name="platform" value="Linux" />
+      <property name="junit-version" value="4" />
+      <property name="clr-version" value="9.0.4" />
+      <property name="machine-name" value="71c40d4e897c" />
+      <property name="user-domain" value="" />
+    </properties>
+    <testcase name="BuildProfile1.IconEditor.ApplyVipc.Dispatcher.dry-runs apply-vipc with expected arguments [REQIE-002]" status="Passed" classname="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1" assertions="0" time="0.042" />
+  </testsuite>
+  <testsuite name="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1" tests="1" errors="0" failures="0" hostname="71c40d4e897c" id="2" skipped="0" disabled="0" package="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1" time="0.147">
+    <properties>
+      <property name="cwd" value="/workspace/open-source" />
+      <property name="user" value="root" />
+      <property name="framework-version" value="5.7.1" />
+      <property name="os-version" value="6.12.13" />
+      <property name="platform" value="Linux" />
+      <property name="junit-version" value="4" />
+      <property name="clr-version" value="9.0.4" />
+      <property name="machine-name" value="71c40d4e897c" />
+      <property name="user-domain" value="" />
+    </properties>
+    <testcase name="BuildProfile1.IconEditor.BuildViPackage.Dispatcher.dry-runs build-vi-package with expected arguments [REQIE-008]" status="Passed" classname="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1" assertions="0" time="0.106" />
+  </testsuite>
+  <testsuite name="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1" tests="1" errors="0" failures="0" hostname="71c40d4e897c" id="3" skipped="0" disabled="0" package="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1" time="0.112">
+    <properties>
+      <property name="cwd" value="/workspace/open-source" />
+      <property name="user" value="root" />
+      <property name="framework-version" value="5.7.1" />
+      <property name="os-version" value="6.12.13" />
+      <property name="platform" value="Linux" />
+      <property name="junit-version" value="4" />
+      <property name="clr-version" value="9.0.4" />
+      <property name="machine-name" value="71c40d4e897c" />
+      <property name="user-domain" value="" />
+    </properties>
+    <testcase name="BuildProfile1.IconEditor.CloseLabview.Dispatcher.dry-runs close-labview with expected arguments [REQIE-010]" status="Passed" classname="/workspace/open-source/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1" assertions="0" time="0.036" />
+  </testsuite>
+</testsuites>

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
@@ -1,0 +1,29 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-001'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1'
+    }
+
+    It 'dry-runs add-token-to-labview with expected arguments [REQIE-001]' -Tag 'REQIE-001' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $params.ArgsJson -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'AddTokenToLabVIEW.ps1'
+        $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
+        $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
+        $obj = $jsonText | ConvertFrom-Json
+        $obj.MinimumSupportedLVVersion | Should -Be '2021'
+        $obj.SupportedBitness | Should -Be '64'
+        $obj.RelativePath | Should -Be '.'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
@@ -1,0 +1,34 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.ApplyVipc.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-002'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1'
+    }
+
+    It 'dry-runs apply-vipc with expected arguments [REQIE-002]' -Tag 'REQIE-002' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $args = $params.ArgsJson | ConvertFrom-Json
+        $args | Add-Member -NotePropertyName VIP_LVVersion -NotePropertyValue '2021'
+        $args | Add-Member -NotePropertyName VIPCPath -NotePropertyValue 'dummy.vipc'
+        $json = $args | ConvertTo-Json -Compress
+        $out = & $dispatcher -ActionName apply-vipc -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'ApplyVIPC.ps1'
+        $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
+        $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
+        $obj = $jsonText | ConvertFrom-Json
+        $obj.MinimumSupportedLVVersion | Should -Be '2021'
+        $obj.SupportedBitness | Should -Be '64'
+        $obj.VIP_LVVersion | Should -Be '2021'
+        $obj.VIPCPath | Should -Be 'dummy.vipc'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.BuildViPackage.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-008'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1'
+    }
+
+    It 'dry-runs build-vi-package with expected arguments [REQIE-008]' -Tag 'REQIE-008' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $args = $params.ArgsJson | ConvertFrom-Json
+        $args | Add-Member -NotePropertyName LabVIEWMinorRevision -NotePropertyValue '2021'
+        $args | Add-Member -NotePropertyName VIPBPath -NotePropertyValue 'dummy.vipb'
+        $args | Add-Member -NotePropertyName Major -NotePropertyValue 1
+        $args | Add-Member -NotePropertyName Minor -NotePropertyValue 0
+        $args | Add-Member -NotePropertyName Patch -NotePropertyValue 0
+        $args | Add-Member -NotePropertyName Build -NotePropertyValue 2
+        $args | Add-Member -NotePropertyName Commit -NotePropertyValue 'abcdef0'
+        $args | Add-Member -NotePropertyName DisplayInformationJSON -NotePropertyValue '{}'
+        $json = $args | ConvertTo-Json -Compress
+        $out = & $dispatcher -ActionName build-vi-package -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'build_vip.ps1'
+        $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
+        $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
+        $obj = $jsonText | ConvertFrom-Json
+        $obj.MinimumSupportedLVVersion | Should -Be '2021'
+        $obj.SupportedBitness | Should -Be '64'
+        $obj.VIPBPath | Should -Be 'dummy.vipb'
+        $obj.Commit | Should -Be 'abcdef0'
+    }
+}

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
@@ -1,0 +1,28 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'BuildProfile1.IconEditor.CloseLabview.Dispatcher' {
+    $meta = @{
+        requirement = 'REQIE-010'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1'
+    }
+
+    It 'dry-runs close-labview with expected arguments [REQIE-010]' -Tag 'REQIE-010' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $params = Get-LabVIEWIconEditorArgsJson
+        $projectRoot = $params.WorkingDirectory
+        $out = & $dispatcher -ActionName close-labview -ArgsJson $params.ArgsJson -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'Close_LabVIEW.ps1'
+        $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
+        $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
+        $obj = $jsonText | ConvertFrom-Json
+        $obj.MinimumSupportedLVVersion | Should -Be '2021'
+        $obj.SupportedBitness | Should -Be '64'
+    }
+}


### PR DESCRIPTION
## Summary
- add dispatcher tests for icon-editor add-token, apply-vipc, build-vi-package, and close-labview actions
- capture dry-run parameters using Invoke-OSAction

## Testing
- `npm run test:ci`
- `pwsh -NoLogo -NoProfile -Command "$cfg=New-PesterConfiguration; $cfg.Run.Path=@('tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1','tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1','tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1','tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1'); $cfg.TestResult.Enabled=$true; $cfg.TestResult.OutputFormat='JUnitXml'; $cfg.TestResult.OutputPath='test-results/pester-junit.xml'; $cfg.Run.Exit=$true; Invoke-Pester -Configuration $cfg"`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD~1)`
- `npm run check:traceability`


------
https://chatgpt.com/codex/tasks/task_e_68a60c1586548329a1ef0e2b336e382e