### PR TITLE
feat: add DryRun logging for icon editor scripts

### DIFF
--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -19,8 +19,8 @@ function Invoke-OpenSourceActionScript {
         $Arguments['RelativePath'] = [System.IO.Path]::TrimEndingDirectorySeparator($Arguments['RelativePath'])
     }
     if ($DryRun) {
+        $Arguments['DryRun'] = $true
         Write-Information "DryRun: & $scriptPath $($Arguments | ConvertTo-Json -Compress)"
-        return 0
     }
     $originalPath = $env:PATH
     try {

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 21.58 | 100.00 |
-| linux | 59 | 0 | 0 | 21.58 | 100.00 |
+| overall | 59 | 0 | 0 | 21.04 | 100.00 |
+| linux | 59 | 0 | 0 | 21.04 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 21.58 | 100.00 |
-| linux | 59 | 0 | 0 | 21.58 | 100.00 |
+| overall | 59 | 0 | 0 | 21.04 | 100.00 |
+| linux | 59 | 0 | 0 | 21.04 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,13 +34,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.026 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.187 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.131 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.315 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.073 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.141 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.170 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.377 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.030 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.113 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.008 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.169 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.980 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.200 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.400 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.815 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.053 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.353 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.014 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.680 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022782,
+          "duration": 0.01149,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006805,
+          "duration": 0.005473,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012317,
+          "duration": 0.001695,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001227,
+          "duration": 0.001125,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001187,
+          "duration": 0.001118,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01091,
+          "duration": 0.002531,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001763,
+          "duration": 0.001478,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00203,
+          "duration": 0.001539,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000859,
+          "duration": 0.000984,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001374,
+          "duration": 0.000954,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002535,
+          "duration": 0.002282,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.028064,
+          "duration": 0.016699,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001407,
+          "duration": 0.001345,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001573,
+          "duration": 0.001127,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001865,
+          "duration": 0.000593,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01681,
+          "duration": 0.016836,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014548,
+          "duration": 0.025946,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022855,
+          "duration": 0.011325,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000413,
+          "duration": 0.000329,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.200369,
+          "duration": 1.187196,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009128,
+          "duration": 0.00467,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.251414,
+          "duration": 1.130725,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001383,
+          "duration": 0.002421,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000206,
+          "duration": 0.000239,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.258809,
+          "duration": 1.315266,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.342315,
+          "duration": 1.073293,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.237183,
+          "duration": 1.140595,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.213962,
+          "duration": 1.169545,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000452,
+          "duration": 0.000416,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000404,
+          "duration": 0.000428,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004599,
+          "duration": 0.003461,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001304,
+          "duration": 0.000482,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.038685,
+          "duration": 0.020655,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.376147,
+          "duration": 1.376937,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002115,
+          "duration": 0.00213,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00085,
+          "duration": 0.000653,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001112,
+          "duration": 0.001583,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.941473,
+          "duration": 1.03038,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.00302,
+          "duration": 1.11253,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013044,
+          "duration": 0.013504,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014155,
+          "duration": 0.007105,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004424,
+          "duration": 0.008306,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.16546,
+          "duration": 1.168911,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.966158,
+          "duration": 0.979689,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.243643,
+          "duration": 1.199696,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000636,
+          "duration": 0.000396,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.496572,
+          "duration": 1.400018,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000893,
+          "duration": 0.000281,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001172,
+          "duration": 0.001563,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.829463,
+          "duration": 0.815091,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.988567,
+          "duration": 1.053257,
           "requirements": [],
           "os": "linux"
         },
@@ -591,7 +591,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.412212,
+          "duration": 1.35268,
           "requirements": [],
           "os": "linux"
         },
@@ -600,7 +600,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006686,
+          "duration": 0.014075,
           "requirements": [],
           "os": "linux"
         },
@@ -609,7 +609,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006355,
+          "duration": 0.00491,
           "requirements": [],
           "os": "linux"
         },
@@ -618,7 +618,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.729754,
+          "duration": 1.680373,
           "requirements": [],
           "os": "linux"
         }
@@ -630,7 +630,7 @@
       "passed": 59,
       "failed": 0,
       "skipped": 0,
-      "duration": 21.581447999999998,
+      "duration": 21.04432899999999,
       "rate": 100
     },
     "byOs": {
@@ -638,7 +638,7 @@
         "passed": 59,
         "failed": 0,
         "skipped": 0,
-        "duration": 21.581447999999998,
+        "duration": 21.04432899999999,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.002 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -34,13 +34,13 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.001 |  |  |
 
 #### REQ-030 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.017 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.026 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.011 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.187 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.005 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.131 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.315 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.073 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.141 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.170 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.377 |  |  |
 | Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.030 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.113 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.014 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.007 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.008 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.169 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.980 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.200 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.400 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.815 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.053 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.353 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.014 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.005 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.680 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"a4ddc5334d90f16cc8f3f0d60a7a84cd6e0bacba","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"4b0b9a12daaa22dee400e3c6cff128245bf347bb","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -46,3 +46,35 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
+++ b/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
@@ -23,7 +23,8 @@
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness,
-    [string]$RelativePath
+    [string]$RelativePath,
+    [switch]$DryRun
 )
 
 # Build the g-cli argument array
@@ -33,8 +34,15 @@ $gcliArgs = @(
     '-v', "$RelativePath\Tooling\deployment\Create_LV_INI_Token.vi",
     '--', 'LabVIEW', 'Localhost.LibraryPaths', $RelativePath
 )
+$command = "g-cli $($gcliArgs -join ' ')"
 
-Write-Output "Executing: g-cli $($gcliArgs -join ' ')"
+if ($DryRun) {
+    Write-Output "DryRun: $command"
+    Write-Host 'DryRun: Create localhost.library path from ini file'
+    return 0
+}
+
+Write-Output "Executing: $command"
 
 & g-cli @gcliArgs
 if ($LASTEXITCODE -eq 0) {

--- a/scripts/apply-vipc/ApplyVIPC.ps1
+++ b/scripts/apply-vipc/ApplyVIPC.ps1
@@ -13,7 +13,8 @@ Param (
     [string]$VIP_LVVersion,
     [string]$SupportedBitness,
     [string]$RelativePath,
-    [string]$VIPCPath
+    [string]$VIPCPath,
+    [switch]$DryRun
 )
 
 # Auto-detect the VIPC file if one isn't provided
@@ -126,8 +127,16 @@ g-cli vipc -- -t 3000 -v "$VIP_LVVersion" "$ResolvedVIPCPath"
 }
 
 # -------------------------
-# 4) Output the script for debugging
+# 4) Output or execute the script
 # -------------------------
+if ($DryRun) {
+    Write-Output "DryRun: would run the following commands:"
+    Write-Output $script
+    Write-Host "DryRun: Successfully applied dependencies to LabVIEW: $VIP_LVVersion_B" `
+        " (and potentially $VIP_LVVersion_A if switched)."
+    return 0
+}
+
 Write-Output "Executing the following commands:"
 Write-Output $script
 Write-Verbose "Full script content (for debugging): `n$script"

--- a/scripts/build-vi-package/build_vip.ps1
+++ b/scripts/build-vi-package/build_vip.ps1
@@ -57,7 +57,9 @@ param (
     [string]$ReleaseNotesFile,
 
     [Parameter(Mandatory=$true)]
-    [string]$DisplayInformationJSON
+    [string]$DisplayInformationJSON,
+
+    [switch]$DryRun
 )
 
 # 1) Locate VIPB file in the action directory
@@ -128,17 +130,31 @@ else {
 if (-not $jsonObj.commit) {
     $jsonObj | Add-Member -MemberType NoteProperty -Name 'commit' -Value $Commit
 } else {
-    $jsonObj.commit = $Commit
+$jsonObj.commit = $Commit
 }
 
 # Re-convert to a JSON string with a comfortable nesting depth
 $UpdatedDisplayInformationJSON = $jsonObj | ConvertTo-Json -Depth 5
 
+# Precompute output names
+$shortCommit = if ($Commit.Length -ge 7) { $Commit.Substring(0,7) } else { $Commit }
+$versionTag  = "v$Major.$Minor.$Patch.$Build+g$shortCommit"
+$originalVip = Join-Path $PSScriptRoot 'lv_icon.vip'
+$newVip      = "lv_icon_$versionTag.vip"
+
 # 5) Construct the command script
 
 $script = @"
-g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness vipb -- --buildspec "$ResolvedVIPBPath" -v "$Major.$Minor.$Patch.$Build" --release-notes "$ReleaseNotesFile" --timeout 300
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness vipb -- --buildspec \"$ResolvedVIPBPath\" -v \"$Major.$Minor.$Patch.$Build\" --release-notes \"$ReleaseNotesFile\" --timeout 300
 "@
+
+if ($DryRun) {
+    Write-Output "DryRun: would run the following commands:"
+    Write-Output $script
+    Write-Host "DryRun: Successfully built VI package: $ResolvedVIPBPath"
+    Write-Host "DryRun: Rename VI package to '$newVip'"
+    return 0
+}
 
 Write-Output "Executing the following commands:"
 Write-Output $script
@@ -147,11 +163,7 @@ Write-Output $script
 try {
     Invoke-Expression $script
     Write-Host "Successfully built VI package: $ResolvedVIPBPath"
-    $shortCommit = if ($Commit.Length -ge 7) { $Commit.Substring(0,7) } else { $Commit }
-    $versionTag  = "v$Major.$Minor.$Patch.$Build+g$shortCommit"
-    $originalVip = Join-Path $PSScriptRoot 'lv_icon.vip'
     if (Test-Path $originalVip) {
-        $newVip = "lv_icon_$versionTag.vip"
         Rename-Item -Path $originalVip -NewName $newVip
         Write-Host "Renamed VI package to '$newVip'"
     } else {

--- a/scripts/close-labview/Close_LabVIEW.ps1
+++ b/scripts/close-labview/Close_LabVIEW.ps1
@@ -17,13 +17,20 @@
 #>
 param(
     [string]$MinimumSupportedLVVersion,
-    [string]$SupportedBitness
+    [string]$SupportedBitness,
+    [switch]$DryRun
 )
 
 # Construct the command
 $script = @"
 g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW
 "@
+
+if ($DryRun) {
+    Write-Output "DryRun: $script"
+    Write-Host "DryRun: Close LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+    return 0
+}
 
 Write-Output "Executing the following command:"
 Write-Output $script

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.342315" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.258809" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.243643" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.237183" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.213962" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.009128" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004599" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000452" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000404" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001304" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.038685" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006355" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006686" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.028064" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013044" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.004424" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.014155" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.022855" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014548" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.016810" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002115" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000850" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000636" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000413" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001172" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000893" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001865" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.729754" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.496572" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.412212" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.251414" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.003020" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.829463" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.966158" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.941473" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.022782" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.006805" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.012317" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001227" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001187" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.010910" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001112" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001763" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002030" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000859" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001374" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002535" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001383" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000206" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.376147" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.165460" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.200369" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.988567" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001407" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001573" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.073293" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.315266" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.199696" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.140595" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.169545" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.004670" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003461" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000416" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000428" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000482" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.020655" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004910" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.014075" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.016699" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013504" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.008306" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.007105" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.011325" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.025946" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.016836" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002130" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000653" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000396" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000329" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001563" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000281" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000593" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.680373" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.400018" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.352680" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.130725" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.112530" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.815091" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.979689" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.030380" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.011490" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005473" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.001695" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001125" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001118" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.002531" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.001583" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001478" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001539" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000984" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000954" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002282" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002421" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000239" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.376937" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.168911" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.187196" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.053257" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001345" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001127" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 11656.124195 -->
+	<!-- duration_ms 11058.974756 -->
 </testsuites>

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
@@ -12,13 +12,8 @@ Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Script' {
     It 'invokes AddTokenToLabVIEW with expected arguments [REQIE-001]' -Tag 'REQIE-001' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'add-token-to-labview' 'AddTokenToLabVIEW.ps1'
-        $captured = $null
-        Mock g-cli { $script:captured = $args }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot *> $null
-        Assert-MockCalled g-cli -Exactly 1 -Scope It
-        $captured | Should -Contain '--lv-ver'
-        $captured | Should -Contain '2021'
-        $captured | Should -Contain '--arch'
-        $captured | Should -Contain '64'
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -DryRun *>&1 | Out-String
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
+        $out | Should -Match 'DryRun: Create localhost.library path from ini file'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
@@ -13,11 +13,9 @@ Describe 'BuildProfile1.IconEditor.ApplyVipc.Script' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'ApplyVIPC.ps1'
         $vipcPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'runner_dependencies.vipc'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -VIP_LVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -VIPCPath $vipcPath *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64'
-        $captured | Should -Match [regex]::Escape($vipcPath)
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -VIP_LVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -VIPCPath $vipcPath -DryRun *>&1 | Out-String
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
+        $out | Should -Match [regex]::Escape($vipcPath)
+        $out | Should -Match 'DryRun: Successfully applied dependencies'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
@@ -14,11 +14,8 @@ Describe 'BuildProfile1.IconEditor.BuildViPackage.Script' {
         $scriptPath = Join-Path $repoRoot 'scripts' 'build-vi-package' 'build_vip.ps1'
         $releaseNotes = Join-Path $repoRoot 'scripts' 'build-vi-package' 'release-notes.md'
         $json = '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        Mock New-Item { }
-        & $scriptPath -SupportedBitness '64' -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit 'abcdef0' -ReleaseNotesFile $releaseNotes -DisplayInformationJSON $json *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 vipb'
+        $out = & $scriptPath -SupportedBitness '64' -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit 'abcdef0' -ReleaseNotesFile $releaseNotes -DisplayInformationJSON $json -DryRun *>&1 | Out-String
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64 vipb'
+        $out | Should -Match 'DryRun: Successfully built VI package'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
@@ -12,10 +12,8 @@ Describe 'BuildProfile1.IconEditor.CloseLabview.Script' {
     It 'constructs g-cli QuitLabVIEW command without executing [REQIE-010]' -Tag 'REQIE-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'close-labview' 'Close_LabVIEW.ps1'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 QuitLabVIEW'
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -DryRun *>&1 | Out-String
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64 QuitLabVIEW'
+        $out | Should -Match 'DryRun: Close LabVIEW 2021 (64-bit)'
     }
 }


### PR DESCRIPTION
## Summary
- forward DryRun parameter to action scripts
- add DryRun handling and logging for icon editor g-cli scripts
- assert dry-run outputs in icon editor tests

## Testing
- `node --version`
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `g-cli --version` *(fails: command not found)*
- `pwsh --version` *(fails: command not found)*
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh 402fdadfdc904b5a7ff7df98d1215f3467054a60`

------
https://chatgpt.com/codex/tasks/task_e_68a616a7b4988329afb4ff56e85f7eb2