### PR TITLE
feat: add dry-run logging for icon editor actions

### DIFF
--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -20,7 +20,7 @@ function Invoke-OpenSourceActionScript {
     }
     if ($DryRun) {
         Write-Information "DryRun: & $scriptPath $($Arguments | ConvertTo-Json -Compress)"
-        return 0
+        $Arguments['DryRun'] = $true
     }
     $originalPath = $env:PATH
     try {

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 21.58 | 100.00 |
-| linux | 59 | 0 | 0 | 21.58 | 100.00 |
+| overall | 59 | 0 | 0 | 17.74 | 100.00 |
+| linux | 59 | 0 | 0 | 17.74 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 21.58 | 100.00 |
-| linux | 59 | 0 | 0 | 21.58 | 100.00 |
+| overall | 59 | 0 | 0 | 17.74 | 100.00 |
+| linux | 59 | 0 | 0 | 17.74 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,25 +28,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.007 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.038 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.006 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.017 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.015 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.004 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.129 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.010 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.049 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.967 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.069 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.003 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.016 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.004 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.104 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.728 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.866 |  |  |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.948 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.776 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.000 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.236 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.648 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.853 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.190 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.278 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022782,
+          "duration": 0.011148,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006805,
+          "duration": 0.002301,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012317,
+          "duration": 0.004065,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001227,
+          "duration": 0.001431,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001187,
+          "duration": 0.003444,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01091,
+          "duration": 0.003667,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001763,
+          "duration": 0.003855,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00203,
+          "duration": 0.006713,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000859,
+          "duration": 0.000759,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001374,
+          "duration": 0.000514,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002535,
+          "duration": 0.002178,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.028064,
+          "duration": 0.037536,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001407,
+          "duration": 0.001204,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001573,
+          "duration": 0.006179,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001865,
+          "duration": 0.00112,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01681,
+          "duration": 0.010775,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014548,
+          "duration": 0.016594,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022855,
+          "duration": 0.014554,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000413,
+          "duration": 0.003896,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.200369,
+          "duration": 1.129247,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009128,
+          "duration": 0.010176,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.251414,
+          "duration": 1.048986,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001383,
+          "duration": 0.002327,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000206,
+          "duration": 0.000225,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.258809,
+          "duration": 0.967256,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.342315,
+          "duration": 1.069295,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.237183,
+          "duration": 1.003016,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.213962,
+          "duration": 1.015718,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000452,
+          "duration": 0.000322,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000404,
+          "duration": 0.000194,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004599,
+          "duration": 0.005446,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001304,
+          "duration": 0.0041,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.038685,
+          "duration": 0.01721,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.376147,
+          "duration": 1.104118,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002115,
+          "duration": 0.001185,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00085,
+          "duration": 0.000367,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001112,
+          "duration": 0.000987,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.941473,
+          "duration": 0.728038,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.00302,
+          "duration": 0.866497,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013044,
+          "duration": 0.012885,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014155,
+          "duration": 0.008738,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004424,
+          "duration": 0.003863,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.16546,
+          "duration": 0.948267,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.966158,
+          "duration": 0.775588,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.243643,
+          "duration": 1.000204,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000636,
+          "duration": 0.000299,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.496572,
+          "duration": 1.236044,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000893,
+          "duration": 0.000321,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001172,
+          "duration": 0.001734,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.829463,
+          "duration": 0.648196,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.988567,
+          "duration": 0.852618,
           "requirements": [],
           "os": "linux"
         },
@@ -591,7 +591,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.412212,
+          "duration": 1.189685,
           "requirements": [],
           "os": "linux"
         },
@@ -600,7 +600,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006686,
+          "duration": 0.003251,
           "requirements": [],
           "os": "linux"
         },
@@ -609,7 +609,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006355,
+          "duration": 0.002196,
           "requirements": [],
           "os": "linux"
         },
@@ -618,7 +618,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.729754,
+          "duration": 1.278476,
           "requirements": [],
           "os": "linux"
         }
@@ -630,7 +630,7 @@
       "passed": 59,
       "failed": 0,
       "skipped": 0,
-      "duration": 21.581447999999998,
+      "duration": 17.735008000000004,
       "rate": 100
     },
     "byOs": {
@@ -638,7 +638,7 @@
         "passed": 59,
         "failed": 0,
         "skipped": 0,
-        "duration": 21.581447999999998,
+        "duration": 17.735008000000004,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.023 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.007 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.002 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.012 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.004 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,25 +28,25 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.011 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.004 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.004 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.007 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.003 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.028 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.038 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.006 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.002 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.017 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.015 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.023 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.200 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.251 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.017 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.015 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.004 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.129 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.010 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.049 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.259 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.342 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.237 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.214 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.967 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.069 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.003 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.016 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.005 |  |  |
-| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.039 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.376 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
-| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
+| Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.004 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.017 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.104 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
+| Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.000 |  |  |
 | Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.941 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.003 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.728 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.866 |  |  |
 | Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.013 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.014 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.009 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.165 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.966 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.244 |  |  |
-| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.497 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.829 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.989 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.412 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.007 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.006 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.730 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.948 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.776 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.000 |  |  |
+| Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.236 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.002 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.648 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.853 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.190 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.003 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.002 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.278 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"a4ddc5334d90f16cc8f3f0d60a7a84cd6e0bacba","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"402fdadfdc904b5a7ff7df98d1215f3467054a60","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -46,3 +46,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
+++ b/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
@@ -23,7 +23,8 @@
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness,
-    [string]$RelativePath
+    [string]$RelativePath,
+    [switch]$DryRun
 )
 
 # Build the g-cli argument array
@@ -35,6 +36,11 @@ $gcliArgs = @(
 )
 
 Write-Output "Executing: g-cli $($gcliArgs -join ' ')"
+
+if ($DryRun) {
+    Write-Output 'DryRun: Create localhost.library path from ini file'
+    return 0
+}
 
 & g-cli @gcliArgs
 if ($LASTEXITCODE -eq 0) {

--- a/scripts/apply-vipc/ApplyVIPC.ps1
+++ b/scripts/apply-vipc/ApplyVIPC.ps1
@@ -13,7 +13,8 @@ Param (
     [string]$VIP_LVVersion,
     [string]$SupportedBitness,
     [string]$RelativePath,
-    [string]$VIPCPath
+    [string]$VIPCPath,
+    [switch]$DryRun
 )
 
 # Auto-detect the VIPC file if one isn't provided
@@ -135,6 +136,11 @@ Write-Verbose "Full script content (for debugging): `n$script"
 # -------------------------
 # 5) Execute the Script & Handle Errors (Try/Catch with Invoke-Expression)
 # -------------------------
+if ($DryRun) {
+    Write-Output "DryRun: Successfully applied dependencies to LabVIEW: $VIP_LVVersion_B"
+    return 0
+}
+
 try {
     Write-Verbose "Starting Invoke-Expression to run g-cli commands..."
     Invoke-Expression $script

--- a/scripts/build-vi-package/build_vip.ps1
+++ b/scripts/build-vi-package/build_vip.ps1
@@ -57,7 +57,8 @@ param (
     [string]$ReleaseNotesFile,
 
     [Parameter(Mandatory=$true)]
-    [string]$DisplayInformationJSON
+    [string]$DisplayInformationJSON,
+    [switch]$DryRun
 )
 
 # 1) Locate VIPB file in the action directory
@@ -144,6 +145,11 @@ Write-Output "Executing the following commands:"
 Write-Output $script
 
 # 6) Execute the commands
+if ($DryRun) {
+    Write-Output "DryRun: Successfully built VI package: $ResolvedVIPBPath"
+    return 0
+}
+
 try {
     Invoke-Expression $script
     Write-Host "Successfully built VI package: $ResolvedVIPBPath"

--- a/scripts/close-labview/Close_LabVIEW.ps1
+++ b/scripts/close-labview/Close_LabVIEW.ps1
@@ -17,7 +17,8 @@
 #>
 param(
     [string]$MinimumSupportedLVVersion,
-    [string]$SupportedBitness
+    [string]$SupportedBitness,
+    [switch]$DryRun
 )
 
 # Construct the command
@@ -27,6 +28,11 @@ g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW
 
 Write-Output "Executing the following command:"
 Write-Output $script
+
+if ($DryRun) {
+    Write-Output "DryRun: Close LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+    return 0
+}
 
 # Execute the command and check for errors
 try {

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.342315" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.258809" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.243643" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.237183" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.213962" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.009128" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004599" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000452" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000404" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.001304" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.038685" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.006355" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.006686" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.028064" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.013044" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.004424" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.014155" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.022855" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.014548" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.016810" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002115" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000850" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000636" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000413" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001172" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000893" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.001865" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.729754" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.496572" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.412212" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.251414" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.003020" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.829463" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.966158" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.941473" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.022782" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.006805" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.012317" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001227" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001187" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.010910" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.001112" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001763" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002030" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000859" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.001374" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.002535" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001383" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000206" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.376147" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.165460" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.200369" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.988567" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001407" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001573" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.069295" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.967256" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.000204" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.003016" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.015718" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.010176" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.005446" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000322" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000194" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.004100" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.017210" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002196" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.003251" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.037536" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.012885" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003863" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.008738" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.014554" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.016594" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.010775" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001185" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000367" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000299" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.003896" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001734" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000321" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.001120" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.278476" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.236044" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.189685" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.048986" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.866497" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.648196" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.775588" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.728038" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.011148" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002301" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.004065" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001431" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.003444" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003667" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000987" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.003855" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.006713" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000759" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000514" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.002178" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002327" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000225" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.104118" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.948267" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.129247" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.852618" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001204" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.006179" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 11656.124195 -->
+	<!-- duration_ms 9326.130404 -->
 </testsuites>

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Dispatcher' {
         $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $params.ArgsJson -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $out | Should -Match 'AddTokenToLabVIEW.ps1'
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
         $obj = $jsonText | ConvertFrom-Json

--- a/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.AddTokenToLabview.Script.Tests.ps1
@@ -12,13 +12,9 @@ Describe 'BuildProfile1.IconEditor.AddTokenToLabview.Script' {
     It 'invokes AddTokenToLabVIEW with expected arguments [REQIE-001]' -Tag 'REQIE-001' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'add-token-to-labview' 'AddTokenToLabVIEW.ps1'
-        $captured = $null
-        Mock g-cli { $script:captured = $args }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot *> $null
-        Assert-MockCalled g-cli -Exactly 1 -Scope It
-        $captured | Should -Contain '--lv-ver'
-        $captured | Should -Contain '2021'
-        $captured | Should -Contain '--arch'
-        $captured | Should -Contain '64'
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -DryRun 6>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
+        $out | Should -Match 'DryRun: Create localhost.library path from ini file'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Dispatcher.Tests.ps1
@@ -23,6 +23,7 @@ Describe 'BuildProfile1.IconEditor.ApplyVipc.Dispatcher' {
         $out = & $dispatcher -ActionName apply-vipc -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $out | Should -Match 'ApplyVIPC.ps1'
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
         $obj = $jsonText | ConvertFrom-Json

--- a/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.ApplyVipc.Script.Tests.ps1
@@ -13,11 +13,10 @@ Describe 'BuildProfile1.IconEditor.ApplyVipc.Script' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'ApplyVIPC.ps1'
         $vipcPath = Join-Path $repoRoot 'scripts' 'apply-vipc' 'runner_dependencies.vipc'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -VIP_LVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -VIPCPath $vipcPath *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64'
-        $captured | Should -Match [regex]::Escape($vipcPath)
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -VIP_LVVersion '2021' -SupportedBitness '64' -RelativePath $repoRoot -VIPCPath $vipcPath -DryRun 6>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
+        $out | Should -Match [regex]::Escape($vipcPath)
+        $out | Should -Match 'DryRun: Successfully applied dependencies'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Dispatcher.Tests.ps1
@@ -29,6 +29,7 @@ Describe 'BuildProfile1.IconEditor.BuildViPackage.Dispatcher' {
         $out = & $dispatcher -ActionName build-vi-package -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $out | Should -Match 'build_vip.ps1'
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
         $obj = $jsonText | ConvertFrom-Json

--- a/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.BuildViPackage.Script.Tests.ps1
@@ -14,11 +14,9 @@ Describe 'BuildProfile1.IconEditor.BuildViPackage.Script' {
         $scriptPath = Join-Path $repoRoot 'scripts' 'build-vi-package' 'build_vip.ps1'
         $releaseNotes = Join-Path $repoRoot 'scripts' 'build-vi-package' 'release-notes.md'
         $json = '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        Mock New-Item { }
-        & $scriptPath -SupportedBitness '64' -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit 'abcdef0' -ReleaseNotesFile $releaseNotes -DisplayInformationJSON $json *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 vipb'
+        $out = & $scriptPath -SupportedBitness '64' -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit 'abcdef0' -ReleaseNotesFile $releaseNotes -DisplayInformationJSON $json -DryRun 6>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64 vipb'
+        $out | Should -Match 'DryRun: Successfully built VI package'
     }
 }

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Dispatcher.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'BuildProfile1.IconEditor.CloseLabview.Dispatcher' {
         $out = & $dispatcher -ActionName close-labview -ArgsJson $params.ArgsJson -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $out | Should -Match 'Close_LabVIEW.ps1'
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64'
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
         $obj = $jsonText | ConvertFrom-Json

--- a/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
+++ b/tests/pester/BuildProfile1.IconEditor.CloseLabview.Script.Tests.ps1
@@ -12,10 +12,9 @@ Describe 'BuildProfile1.IconEditor.CloseLabview.Script' {
     It 'constructs g-cli QuitLabVIEW command without executing [REQIE-010]' -Tag 'REQIE-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $scriptPath = Join-Path $repoRoot 'scripts' 'close-labview' 'Close_LabVIEW.ps1'
-        $captured = $null
-        Mock Invoke-Expression { param($cmd) $script:captured = $cmd }
-        & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' *> $null
-        Assert-MockCalled Invoke-Expression -Exactly 1 -Scope It
-        $captured | Should -Match 'g-cli --lv-ver 2021 --arch 64 QuitLabVIEW'
+        $out = & $scriptPath -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -DryRun 6>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'g-cli --lv-ver 2021 --arch 64 QuitLabVIEW'
+        $out | Should -Match 'DryRun: Close LabVIEW 2021 (64-bit)'
     }
 }


### PR DESCRIPTION
## Summary
- support dry-run logging in dispatcher so scripts receive `-DryRun`
- add dry-run mode to icon-editor scripts and log expected g-cli commands
- expose dry-run output in tests for assertion

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh 402fdadfdc904b5a7ff7df98d1215f3467054a60`


------
https://chatgpt.com/codex/tasks/task_e_68a616a7b4988329afb4ff56e85f7eb2