### PR TITLE
Use Node 24 and npm ci in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 22
+          node-version: 24
       - run: npm config delete proxy
       - run: npm config delete https-proxy
-      - run: npm install
+      - run: npm ci
       - run: npm run link:check
       - run: npm run derive:registry
       - run: git diff --exit-code -- dispatchers.json
@@ -115,9 +115,9 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 22
+          node-version: 24
+      - run: npm ci
       - run: npm run check:node
-      - run: npm install
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: test-results-pester-*

--- a/.github/workflows/publish-traceability.yml
+++ b/.github/workflows/publish-traceability.yml
@@ -25,8 +25,8 @@ jobs:
           path: artifacts/linux
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 22
-      - run: npm install
+          node-version: 24
+      - run: npm ci
       - run: npx tsx scripts/generate-traceability-badge.ts
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:

--- a/.github/workflows/update-runner-runtime.yml
+++ b/.github/workflows/update-runner-runtime.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - run: npm ci
 
       - name: Update requirements
         shell: bash

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 17.28 | 100.00 |
-| linux | 59 | 0 | 0 | 17.28 | 100.00 |
+| overall | 59 | 0 | 0 | 15.06 | 100.00 |
+| linux | 59 | 0 | 0 | 15.06 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 59 | 0 | 0 | 17.28 | 100.00 |
-| linux | 59 | 0 | 0 | 17.28 | 100.00 |
+| overall | 59 | 0 | 0 | 15.06 | 100.00 |
+| linux | 59 | 0 | 0 | 15.06 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.015 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.010 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,7 +28,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.008 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.018 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.024 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.014 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.999 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.075 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.894 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.952 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.916 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.145 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.854 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.938 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.759 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.749 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.766 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.019 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.856 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.816 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.875 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.008 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.721 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.804 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.003 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.908 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.769 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.067 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.845 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.763 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.818 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.101 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.994 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.657 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.914 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.131 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.242 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.671 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.866 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.048 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.946 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015367,
+          "duration": 0.006212,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005649,
+          "duration": 0.005192,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010137,
+          "duration": 0.000669,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000926,
+          "duration": 0.000506,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000682,
+          "duration": 0.007769,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001617,
+          "duration": 0.001575,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001629,
+          "duration": 0.001939,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001713,
+          "duration": 0.001094,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000838,
+          "duration": 0.000691,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000567,
+          "duration": 0.000569,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001633,
+          "duration": 0.001253,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017978,
+          "duration": 0.011747,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00114,
+          "duration": 0.001276,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002863,
+          "duration": 0.001038,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000577,
+          "duration": 0.000311,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.02373,
+          "duration": 0.008665,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.013354,
+          "duration": 0.008942,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014287,
+          "duration": 0.0032,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000306,
+          "duration": 0.00031,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.998774,
+          "duration": 0.894465,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003332,
+          "duration": 0.00239,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.075037,
+          "duration": 0.951951,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001169,
+          "duration": 0.0022,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000191,
+          "duration": 0.000172,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 0.915909,
+          "duration": 0.759453,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.14534,
+          "duration": 0.748901,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 0.853508,
+          "duration": 0.765915,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 0.938316,
+          "duration": 0.81344,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000306,
+          "duration": 0.000229,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000128,
+          "duration": 0.000106,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002535,
+          "duration": 0.001221,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000345,
+          "duration": 0.000187,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022454,
+          "duration": 0.020691,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.018638,
+          "duration": 0.855927,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001864,
+          "duration": 0.001157,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000604,
+          "duration": 0.000608,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000452,
+          "duration": 0.000832,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 0.816208,
+          "duration": 0.720984,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 0.874948,
+          "duration": 0.804072,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.014903,
+          "duration": 0.016972,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008402,
+          "duration": 0.002667,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00367,
+          "duration": 0.003562,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 0.907921,
+          "duration": 0.845258,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 0.768752,
+          "duration": 0.762931,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.066877,
+          "duration": 0.818483,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000375,
+          "duration": 0.000342,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.101184,
+          "duration": 0.99408,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000344,
+          "duration": 0.000204,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000572,
+          "duration": 0.000471,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.657427,
+          "duration": 0.670756,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 0.914005,
+          "duration": 0.865636,
           "requirements": [],
           "os": "linux"
         },
@@ -591,7 +591,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.131071,
+          "duration": 1.048228,
           "requirements": [],
           "os": "linux"
         },
@@ -600,7 +600,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011979,
+          "duration": 0.005534,
           "requirements": [],
           "os": "linux"
         },
@@ -609,7 +609,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003976,
+          "duration": 0.002942,
           "requirements": [],
           "os": "linux"
         },
@@ -618,7 +618,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.242115,
+          "duration": 0.945781,
           "requirements": [],
           "os": "linux"
         }
@@ -630,7 +630,7 @@
       "passed": 59,
       "failed": 0,
       "skipped": 0,
-      "duration": 17.284624,
+      "duration": 15.057706000000003,
       "rate": 100
     },
     "byOs": {
@@ -638,7 +638,7 @@
         "passed": 59,
         "failed": 0,
         "skipped": 0,
-        "duration": 17.284624,
+        "duration": 15.057706000000003,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,19 +4,19 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.015 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.006 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.006 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.005 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.010 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.001 |  |  |
 
 #### REQ-026 (100% passed)
 
@@ -28,7 +28,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.008 |  |  |
 
 #### REQ-028 (100% passed)
 
@@ -46,7 +46,7 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.001 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,59 +64,59 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.001 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.018 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.012 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.001 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.003 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.024 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.013 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.014 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.000 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.003 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 0.999 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.075 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 0.894 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.002 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 0.952 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.916 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.145 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 0.854 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.938 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 0.759 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 0.749 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 0.766 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 0.813 |  |  |
 | Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.000 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.022 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.019 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.021 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 0.856 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.001 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.000 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 0.816 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.875 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.015 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.008 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 0.721 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 0.804 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.017 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.003 |  |  |
 | Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.004 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.908 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.769 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.067 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 0.845 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 0.763 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 0.818 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.000 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.101 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 0.994 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
-| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.657 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.914 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.131 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
-| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.242 |  |  |
+| Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.000 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.671 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 0.866 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.048 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.006 |  |  |
+| Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.003 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 0.946 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"85a73ea39c0b2fe1e91c7dc2504fd8fcd7a71b52","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"18df35a724af7429bac01805085922dddf3b9b85","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -62,3 +62,35 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:94:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
+```

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.145340" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="0.915909" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.066877" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="0.853508" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="0.938316" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.003332" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002535" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000306" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000128" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000345" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.022454" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003976" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.011979" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.017978" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.014903" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.003670" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.008402" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.014287" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.013354" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.023730" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001864" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000604" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000375" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000306" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000572" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000344" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000577" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.242115" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.101184" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.131071" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.075037" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="0.874948" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.657427" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="0.768752" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="0.816208" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.015367" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005649" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.010137" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.000926" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.000682" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001617" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000452" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001629" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001713" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000838" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000567" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.001633" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001169" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000191" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.018638" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="0.907921" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="0.998774" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="0.914005" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001140" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.002863" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="0.748901" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="0.759453" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="0.818483" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="0.765915" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="0.813440" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002390" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.001221" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000229" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000106" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000187" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.020691" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.002942" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005534" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.011747" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.016972" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.003562" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.002667" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.003200" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008942" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.008665" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.001157" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000608" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000342" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000310" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000471" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000204" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000311" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="0.945781" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="0.994080" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.048228" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="0.951951" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="0.804072" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.670756" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="0.762931" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="0.720984" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.006212" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.005192" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.000669" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.000506" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.007769" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.001575" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000832" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001939" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001094" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000691" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000569" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001253" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002200" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000172" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="0.855927" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="0.845258" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="0.894465" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="0.865636" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001276" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001038" classname="test"/>
 	<!-- tests 55 -->
 	<!-- suites 0 -->
 	<!-- pass 55 -->
@@ -62,5 +62,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 9201.658174 -->
+	<!-- duration_ms 7995.170819 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- update CI workflow to setup Node 24 and install dependencies with `npm ci`
- ensure publish-traceability and runner runtime workflows use Node 24 with `npm ci`

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh 18df35a724af7429bac01805085922dddf3b9b85`


------
https://chatgpt.com/codex/tasks/task_e_68a7357a284083299844f3571a0c2fba