### PR TITLE
fix: update runner runtime workflow to scan all requirements (REQ-024)

### DIFF
--- a/.github/workflows/update-runner-runtime.yml
+++ b/.github/workflows/update-runner-runtime.yml
@@ -47,7 +47,7 @@ jobs:
           const type = process.env.RUNNER_TYPE;
           const skipInput = process.env.SKIP_DRY_RUN;
           const files = fs.readdirSync(process.cwd()).filter(f => f.startsWith('requirements') && f.endsWith('.json'));
-          let found = false;
+          const updated = [];
           for (const file of files) {
             const json = JSON.parse(fs.readFileSync(file, 'utf8'));
             if (json.runners && json.runners[key]) {
@@ -55,22 +55,21 @@ jobs:
               if (type) json.runners[key].runner_type = type;
               if (skipInput) json.runners[key].skip_dry_run = skipInput === 'true';
               fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
-              fs.appendFileSync(process.env.GITHUB_ENV, `REQ_FILE=${file}\n`);
-              found = true;
+              updated.push(file);
               console.log(`Updated ${file}`);
-              break;
             }
           }
-          if (!found) {
+          if (updated.length === 0) {
             throw new Error(`Runner ${key} not found`);
           }
+          fs.appendFileSync(process.env.GITHUB_ENV, `REQ_FILES<<EOF\n${updated.join('\n')}\nEOF\n`);
           NODE
 
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$REQ_FILE"
+          printf '%s\n' "$REQ_FILES" | xargs git add
           git commit -m "chore: update runner runtime for ${{ inputs.runner_key }}" || echo "No changes to commit"
           git push
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 60 | 0 | 0 | 23.74 | 100.00 |
-| linux | 60 | 0 | 0 | 23.74 | 100.00 |
+| overall | 60 | 0 | 0 | 27.60 | 100.00 |
+| linux | 60 | 0 | 0 | 27.60 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 60 | 0 | 0 | 23.74 | 100.00 |
-| linux | 60 | 0 | 0 | 23.74 | 100.00 |
+| overall | 60 | 0 | 0 | 27.60 | 100.00 |
+| linux | 60 | 0 | 0 | 27.60 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,49 +4,49 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.017 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,60 +64,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.011 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.020 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.285 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.043 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.026 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.270 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.579 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.298 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.526 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.205 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.266 |  |  |
-| Unmapped | fails-without-runner-metadata | Passed | 0.825 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.352 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.450 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.472 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.554 |  |  |
+| Unmapped | fails-without-runner-metadata | Passed | 1.079 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.361 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.032 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.600 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.055 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.161 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.045 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.294 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.050 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.298 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.209 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.377 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.028 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.016 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.023 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.244 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.176 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.810 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.517 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.907 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.849 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.241 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.603 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.070 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.549 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.826 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.750 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.808 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010802,
+          "duration": 0.012664,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002729,
+          "duration": 0.004364,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.006149,
+          "duration": 0.011433,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001994,
+          "duration": 0.003767,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001389,
+          "duration": 0.003387,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003376,
+          "duration": 0.009429,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002179,
+          "duration": 0.017457,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002123,
+          "duration": 0.002987,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001122,
+          "duration": 0.000917,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000799,
+          "duration": 0.0006,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00418,
+          "duration": 0.010512,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015669,
+          "duration": 0.022103,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003472,
+          "duration": 0.001569,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001627,
+          "duration": 0.001603,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000891,
+          "duration": 0.002683,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.019617,
+          "duration": 0.019864,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008364,
+          "duration": 0.043263,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008127,
+          "duration": 0.02555,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00049,
+          "duration": 0.00146,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.285456,
+          "duration": 1.537657,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008556,
+          "duration": 0.008913,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.270083,
+          "duration": 1.578834,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001408,
+          "duration": 0.001979,
           "requirements": [],
           "os": "linux"
         },
@@ -339,7 +339,7 @@
           "name": "escapeMarkdown leaves plain text untouched",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000199,
+          "duration": 0.000272,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.297728,
+          "duration": 1.351772,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.525556,
+          "duration": 1.45023,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.204814,
+          "duration": 1.471522,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.266281,
+          "duration": 1.554093,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "fails without runner metadata",
           "className": "test",
           "status": "Passed",
-          "duration": 0.8252,
+          "duration": 1.078981,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000455,
+          "duration": 0.000706,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000323,
+          "duration": 0.000273,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00265,
+          "duration": 0.004465,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00055,
+          "duration": 0.000646,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.026061,
+          "duration": 0.03192,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.361341,
+          "duration": 1.599716,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002602,
+          "duration": 0.002163,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000886,
+          "duration": 0.000905,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000869,
+          "duration": 0.002112,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.054579,
+          "duration": 1.20857,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.160572,
+          "duration": 1.37671,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.045129,
+          "duration": 0.027777,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011535,
+          "duration": 0.016471,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.015018,
+          "duration": 0.02343,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.294323,
+          "duration": 1.243889,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.050325,
+          "duration": 1.175589,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.297657,
+          "duration": 1.810332,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000956,
+          "duration": 0.000661,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.517327,
+          "duration": 1.906514,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000396,
+          "duration": 0.001027,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000721,
+          "duration": 0.00117,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 0.849162,
+          "duration": 1.069637,
           "requirements": [],
           "os": "linux"
         },
@@ -591,7 +591,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.240923,
+          "duration": 1.549051,
           "requirements": [],
           "os": "linux"
         },
@@ -600,7 +600,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.603055,
+          "duration": 1.825801,
           "requirements": [],
           "os": "linux"
         },
@@ -609,7 +609,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.005131,
+          "duration": 0.01181,
           "requirements": [],
           "os": "linux"
         },
@@ -618,7 +618,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004137,
+          "duration": 0.003733,
           "requirements": [],
           "os": "linux"
         },
@@ -627,7 +627,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.750139,
+          "duration": 1.808366,
           "requirements": [],
           "os": "linux"
         }
@@ -639,7 +639,7 @@
       "passed": 60,
       "failed": 0,
       "skipped": 0,
-      "duration": 23.743201999999997,
+      "duration": 27.599308999999995,
       "rate": 100
     },
     "byOs": {
@@ -647,7 +647,7 @@
         "passed": 60,
         "failed": 0,
         "skipped": 0,
-        "duration": 23.743201999999997,
+        "duration": 27.599308999999995,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,49 +4,49 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.011 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.003 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.006 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.002 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.001 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.017 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
 
 #### REQ-031 (100% passed)
 
@@ -64,60 +64,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.004 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.011 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.016 |  |  |
-| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.003 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
+| Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
 | Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
 | Unmapped | collecttestcases-captures-requirement-property | Passed | 0.020 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.008 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
-| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.000 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.285 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.043 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.026 |  |  |
+| Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
 | Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.270 |  |  |
-| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.001 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.579 |  |  |
+| Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.298 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.526 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.205 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.266 |  |  |
-| Unmapped | fails-without-runner-metadata | Passed | 0.825 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.352 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.450 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.472 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.554 |  |  |
+| Unmapped | fails-without-runner-metadata | Passed | 1.079 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
-| Unmapped | formaterror-handles-real-error-objects | Passed | 0.003 |  |  |
+| Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.026 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.361 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.003 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.032 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.600 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.055 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.161 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.045 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.012 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.015 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.294 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.050 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.298 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.209 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.377 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.028 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.016 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.023 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.244 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.176 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.810 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.517 |  |  |
-| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.000 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.907 |  |  |
+| Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.849 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.241 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.603 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.070 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.549 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.826 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.750 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.808 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"74b28b12cf04f046cf9f89dfedf9a33e093d7e34","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"5bd931c1a6e83f71c4d950cf2d01a6caeb4f1292","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.525556" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.297728" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.297657" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.204814" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.266281" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.008556" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.002650" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000455" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000323" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000550" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.026061" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004137" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.005131" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.015669" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.045129" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.015018" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.011535" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.008127" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008364" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.019617" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002602" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000886" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000956" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.000490" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000721" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.000396" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.000891" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.750139" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.517327" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.603055" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.270083" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.160572" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.849162" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.050325" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.054579" classname="test"/>
-	<testcase name="fails without runner metadata" time="0.825200" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.010802" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.002729" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.006149" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.001994" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001389" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003376" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.000869" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.002179" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002123" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.001122" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000799" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.004180" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001408" classname="test"/>
-	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000199" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.361341" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.294323" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.285456" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.240923" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.003472" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001627" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.450230" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.351772" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.810332" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.471522" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.554093" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.008913" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.004465" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000706" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000273" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.000646" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.031920" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003733" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.011810" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.022103" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.027777" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.023430" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.016471" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.025550" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.043263" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.019864" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002163" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000905" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000661" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.001460" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001170" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.001027" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.002683" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.808366" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.906514" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.825801" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.578834" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.376710" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.069637" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.175589" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.208570" classname="test"/>
+	<testcase name="fails without runner metadata" time="1.078981" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012664" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004364" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.011433" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.003767" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.003387" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.009429" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.002112" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.017457" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002987" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.000917" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000600" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.010512" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.001979" classname="test"/>
+	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000272" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.599716" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.243889" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.537657" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.549051" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001569" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001603" classname="test"/>
 	<!-- tests 56 -->
 	<!-- suites 0 -->
 	<!-- pass 56 -->
@@ -63,5 +63,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 13092.636524 -->
+	<!-- duration_ms 15070.676145 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- iterate through all requirement files when updating runner runtime
- collect modified requirement files in REQ_FILES for batch commit

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_LABEL=ubuntu-latest TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD^)`


------
https://chatgpt.com/codex/tasks/task_e_68a73996dc3483298863a9eeb62d1e64