### PR TITLE
refactor: extract runner runtime script

### DIFF
--- a/.github/workflows/update-runner-runtime.yml
+++ b/.github/workflows/update-runner-runtime.yml
@@ -33,43 +33,19 @@ jobs:
       - run: npm ci
 
       - name: Update requirements
-        shell: bash
+        id: update
         env:
           RUNNER_KEY: ${{ inputs.runner_key }}
           RUNNER_LABEL: ${{ inputs.runner_label }}
           RUNNER_TYPE: ${{ inputs.runner_type }}
           SKIP_DRY_RUN: ${{ inputs.skip_dry_run }}
-        run: |
-          node - <<'NODE'
-          const fs = require('fs');
-          const key = process.env.RUNNER_KEY;
-          const label = process.env.RUNNER_LABEL;
-          const type = process.env.RUNNER_TYPE;
-          const skipInput = process.env.SKIP_DRY_RUN;
-          const files = fs.readdirSync(process.cwd()).filter(f => f.startsWith('requirements') && f.endsWith('.json'));
-          const updated = [];
-          for (const file of files) {
-            const json = JSON.parse(fs.readFileSync(file, 'utf8'));
-            if (json.runners && json.runners[key]) {
-              if (label) json.runners[key].runner_label = label;
-              if (type) json.runners[key].runner_type = type;
-              if (skipInput) json.runners[key].skip_dry_run = skipInput === 'true';
-              fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
-              updated.push(file);
-              console.log(`Updated ${file}`);
-            }
-          }
-          if (updated.length === 0) {
-            throw new Error(`Runner ${key} not found`);
-          }
-          fs.appendFileSync(process.env.GITHUB_ENV, `REQ_FILES<<EOF\n${updated.join('\n')}\nEOF\n`);
-          NODE
+        run: node scripts/update-runner-runtime.js
 
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          printf '%s\n' "$REQ_FILES" | xargs git add
+          printf '%s\n' "${{ steps.update.outputs.req_files }}" | xargs git add
           git commit -m "chore: update runner runtime for ${{ inputs.runner_key }}" || echo "No changes to commit"
           git push
 

--- a/artifacts/linux/summary-standard.md
+++ b/artifacts/linux/summary-standard.md
@@ -1,7 +1,7 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 60 | 0 | 0 | 27.60 | 100.00 |
-| linux | 60 | 0 | 0 | 27.60 | 100.00 |
+| overall | 60 | 0 | 0 | 24.77 | 100.00 |
+| linux | 60 | 0 | 0 | 24.77 | 100.00 |
 
 _For detailed per-test information, see [traceability-standard.md](traceability-standard.md)._

--- a/artifacts/linux/summary.md
+++ b/artifacts/linux/summary.md
@@ -1,8 +1,8 @@
 ### Test Summary
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
-| overall | 60 | 0 | 0 | 27.60 | 100.00 |
-| linux | 60 | 0 | 0 | 27.60 | 100.00 |
+| overall | 60 | 0 | 0 | 24.77 | 100.00 |
+| linux | 60 | 0 | 0 | 24.77 | 100.00 |
 
 ### Requirement Summary
 | Requirement ID | Description | Owner | Total Tests | Passed | Failed | Skipped | Pass Rate (%) |

--- a/artifacts/linux/traceability-standard.md
+++ b/artifacts/linux/traceability-standard.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.011 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.017 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,60 +64,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.011 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.013 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.020 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.043 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.026 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.579 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.280 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.369 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.352 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.450 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.472 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.554 |  |  |
-| Unmapped | fails-without-runner-metadata | Passed | 1.079 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.427 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.607 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.243 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.286 |  |  |
+| Unmapped | fails-without-runner-metadata | Passed | 0.861 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.032 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.600 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.037 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.620 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.007 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.209 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.377 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.028 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.023 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.244 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.176 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.810 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.056 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.163 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.008 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.281 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.036 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.508 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.907 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.681 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.070 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.549 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.826 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.840 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.125 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.550 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.808 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.985 |  |  |
 
 </details>

--- a/artifacts/linux/traceability.json
+++ b/artifacts/linux/traceability.json
@@ -9,7 +9,7 @@
           "name": "[REQ-023] parses nested JUnit structures",
           "className": "test",
           "status": "Passed",
-          "duration": 0.012664,
+          "duration": 0.012007,
           "requirements": [
             "REQ-023"
           ],
@@ -26,7 +26,7 @@
           "name": "[REQ-024] captures root testsuites attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004364,
+          "duration": 0.01146,
           "requirements": [
             "REQ-024"
           ],
@@ -43,7 +43,7 @@
           "name": "[REQ-025] captures testsuite attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.011433,
+          "duration": 0.008366,
           "requirements": [
             "REQ-025"
           ],
@@ -60,7 +60,7 @@
           "name": "[REQ-026] captures suite properties",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003767,
+          "duration": 0.001167,
           "requirements": [
             "REQ-026"
           ],
@@ -77,7 +77,7 @@
           "name": "[REQ-027] captures testcase attributes and skipped message",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003387,
+          "duration": 0.001737,
           "requirements": [
             "REQ-027"
           ],
@@ -94,7 +94,7 @@
           "name": "[REQ-028] extracts requirement identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.009429,
+          "duration": 0.003095,
           "requirements": [
             "REQ-028"
           ],
@@ -111,7 +111,7 @@
           "name": "[REQ-029] aggregates status by requirement and suite",
           "className": "test",
           "status": "Passed",
-          "duration": 0.017457,
+          "duration": 0.001544,
           "requirements": [
             "REQ-029"
           ],
@@ -128,7 +128,7 @@
           "name": "[REQ-030] builds traceability matrix with skipped reasons",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002987,
+          "duration": 0.00188,
           "requirements": [
             "REQ-030"
           ],
@@ -145,7 +145,7 @@
           "name": "[REQ-031] validates missing fields",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000917,
+          "duration": 0.001805,
           "requirements": [
             "REQ-031"
           ],
@@ -162,7 +162,7 @@
           "name": "[REQ-032] preserves unknown attributes",
           "className": "test",
           "status": "Passed",
-          "duration": 0.0006,
+          "duration": 0.00096,
           "requirements": [
             "REQ-032"
           ],
@@ -179,7 +179,7 @@
           "name": "[REQ-033] throws error for malformed XML",
           "className": "test",
           "status": "Passed",
-          "duration": 0.010512,
+          "duration": 0.001986,
           "requirements": [
             "REQ-033"
           ],
@@ -195,7 +195,7 @@
           "name": "associates classname with requirement",
           "className": "test",
           "status": "Passed",
-          "duration": 0.022103,
+          "duration": 0.013356,
           "requirements": [],
           "os": "linux"
         },
@@ -204,7 +204,7 @@
           "name": "buildIssueBranchName formats branch name",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001569,
+          "duration": 0.001912,
           "requirements": [],
           "os": "linux"
         },
@@ -213,7 +213,7 @@
           "name": "buildIssueBranchName rejects non-numeric input",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001603,
+          "duration": 0.001386,
           "requirements": [],
           "os": "linux"
         },
@@ -258,7 +258,7 @@
           "name": "buildSummary splits totals by OS",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002683,
+          "duration": 0.000887,
           "requirements": [],
           "os": "linux"
         },
@@ -267,7 +267,7 @@
           "name": "collectTestCases captures requirement property",
           "className": "test",
           "status": "Passed",
-          "duration": 0.019864,
+          "duration": 0.011256,
           "requirements": [],
           "os": "linux"
         },
@@ -276,7 +276,7 @@
           "name": "collectTestCases uses evidence property and falls back to directory scan",
           "className": "test",
           "status": "Passed",
-          "duration": 0.043263,
+          "duration": 0.008639,
           "requirements": [],
           "os": "linux"
         },
@@ -285,7 +285,7 @@
           "name": "collectTestCases uses machine-name property for owner",
           "className": "test",
           "status": "Passed",
-          "duration": 0.02555,
+          "duration": 0.007982,
           "requirements": [],
           "os": "linux"
         },
@@ -294,7 +294,7 @@
           "name": "computeStatusCounts tallies test statuses",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00146,
+          "duration": 0.000535,
           "requirements": [],
           "os": "linux"
         },
@@ -303,7 +303,7 @@
           "name": "detects downloaded artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.537657,
+          "duration": 1.279692,
           "requirements": [],
           "os": "linux"
         },
@@ -312,7 +312,7 @@
           "name": "Dispatchers and parameters include descriptions",
           "className": "test",
           "status": "Passed",
-          "duration": 0.008913,
+          "duration": 0.002614,
           "requirements": [],
           "os": "linux"
         },
@@ -321,7 +321,7 @@
           "name": "errors when strict unmapped mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.578834,
+          "duration": 1.368995,
           "requirements": [],
           "os": "linux"
         },
@@ -330,7 +330,7 @@
           "name": "escapeMarkdown escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001979,
+          "duration": 0.002228,
           "requirements": [],
           "os": "linux"
         },
@@ -348,7 +348,7 @@
           "name": "fails when commit lacks requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.351772,
+          "duration": 1.42704,
           "requirements": [],
           "os": "linux"
         },
@@ -357,7 +357,7 @@
           "name": "fails when requirement lacks test coverage",
           "className": "test",
           "status": "Passed",
-          "duration": 1.45023,
+          "duration": 1.606652,
           "requirements": [],
           "os": "linux"
         },
@@ -366,7 +366,7 @@
           "name": "fails when tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.471522,
+          "duration": 1.243432,
           "requirements": [],
           "os": "linux"
         },
@@ -375,7 +375,7 @@
           "name": "fails when tests reference unknown requirements",
           "className": "test",
           "status": "Passed",
-          "duration": 1.554093,
+          "duration": 1.286002,
           "requirements": [],
           "os": "linux"
         },
@@ -384,7 +384,7 @@
           "name": "fails without runner metadata",
           "className": "test",
           "status": "Passed",
-          "duration": 1.078981,
+          "duration": 0.861494,
           "requirements": [],
           "os": "linux"
         },
@@ -393,7 +393,7 @@
           "name": "formatError handles plain objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000706,
+          "duration": 0.000492,
           "requirements": [],
           "os": "linux"
         },
@@ -402,7 +402,7 @@
           "name": "formatError handles primitives",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000273,
+          "duration": 0.000548,
           "requirements": [],
           "os": "linux"
         },
@@ -411,7 +411,7 @@
           "name": "formatError handles real Error objects",
           "className": "test",
           "status": "Passed",
-          "duration": 0.004465,
+          "duration": 0.003753,
           "requirements": [],
           "os": "linux"
         },
@@ -420,7 +420,7 @@
           "name": "formatError handles unstringifiable values",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000646,
+          "duration": 0.001101,
           "requirements": [],
           "os": "linux"
         },
@@ -429,7 +429,7 @@
           "name": "generate-ci-summary features",
           "className": "test",
           "status": "Passed",
-          "duration": 0.03192,
+          "duration": 0.037181,
           "requirements": [],
           "os": "linux"
         },
@@ -438,7 +438,7 @@
           "name": "groups owners and includes requirements and evidence",
           "className": "test",
           "status": "Passed",
-          "duration": 1.599716,
+          "duration": 1.620358,
           "requirements": [],
           "os": "linux"
         },
@@ -447,7 +447,7 @@
           "name": "groupToMarkdown omits numeric identifiers",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002163,
+          "duration": 0.00654,
           "requirements": [],
           "os": "linux"
         },
@@ -456,7 +456,7 @@
           "name": "groupToMarkdown supports optional limit for truncation",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000905,
+          "duration": 0.000931,
           "requirements": [],
           "os": "linux"
         },
@@ -465,7 +465,7 @@
           "name": "handles root-level testcases",
           "className": "test",
           "status": "Passed",
-          "duration": 0.002112,
+          "duration": 0.000828,
           "requirements": [],
           "os": "linux"
         },
@@ -474,7 +474,7 @@
           "name": "handles zipped JUnit artifacts",
           "className": "test",
           "status": "Passed",
-          "duration": 1.20857,
+          "duration": 1.055923,
           "requirements": [],
           "os": "linux"
         },
@@ -483,7 +483,7 @@
           "name": "ignores stale JUnit files outside artifacts path",
           "className": "test",
           "status": "Passed",
-          "duration": 1.37671,
+          "duration": 1.163121,
           "requirements": [],
           "os": "linux"
         },
@@ -492,7 +492,7 @@
           "name": "loadRequirements logs warning on invalid JSON",
           "className": "test",
           "status": "Passed",
-          "duration": 0.027777,
+          "duration": 0.008242,
           "requirements": [],
           "os": "linux"
         },
@@ -501,7 +501,7 @@
           "name": "loadRequirements merges multiple files",
           "className": "test",
           "status": "Passed",
-          "duration": 0.016471,
+          "duration": 0.009819,
           "requirements": [],
           "os": "linux"
         },
@@ -510,7 +510,7 @@
           "name": "loadRequirements warns and skips invalid entries",
           "className": "test",
           "status": "Passed",
-          "duration": 0.02343,
+          "duration": 0.004795,
           "requirements": [],
           "os": "linux"
         },
@@ -519,7 +519,7 @@
           "name": "logs a warning when no JUnit files are found",
           "className": "test",
           "status": "Passed",
-          "duration": 1.243889,
+          "duration": 1.28104,
           "requirements": [],
           "os": "linux"
         },
@@ -528,7 +528,7 @@
           "name": "partitions requirement groups by runner_type",
           "className": "test",
           "status": "Passed",
-          "duration": 1.175589,
+          "duration": 1.035724,
           "requirements": [],
           "os": "linux"
         },
@@ -537,7 +537,7 @@
           "name": "passes with coverage and requirement reference",
           "className": "test",
           "status": "Passed",
-          "duration": 1.810332,
+          "duration": 1.508429,
           "requirements": [],
           "os": "linux"
         },
@@ -546,7 +546,7 @@
           "name": "requirementsSummaryToMarkdown escapes pipes in description",
           "className": "test",
           "status": "Passed",
-          "duration": 0.000661,
+          "duration": 0.000755,
           "requirements": [],
           "os": "linux"
         },
@@ -555,7 +555,7 @@
           "name": "skips invalid JUnit files and still generates summary",
           "className": "test",
           "status": "Passed",
-          "duration": 1.906514,
+          "duration": 1.680781,
           "requirements": [],
           "os": "linux"
         },
@@ -564,7 +564,7 @@
           "name": "summaryToMarkdown handles no tests",
           "className": "test",
           "status": "Passed",
-          "duration": 0.001027,
+          "duration": 0.00063,
           "requirements": [],
           "os": "linux"
         },
@@ -573,7 +573,7 @@
           "name": "summaryToMarkdown sorts OS alphabetically and escapes special characters",
           "className": "test",
           "status": "Passed",
-          "duration": 0.00117,
+          "duration": 0.000765,
           "requirements": [],
           "os": "linux"
         },
@@ -582,7 +582,7 @@
           "name": "throws when no JUnit files found and strict mode enabled",
           "className": "test",
           "status": "Passed",
-          "duration": 1.069637,
+          "duration": 0.839618,
           "requirements": [],
           "os": "linux"
         },
@@ -591,7 +591,7 @@
           "name": "uses latest artifact directory when multiple are present",
           "className": "test",
           "status": "Passed",
-          "duration": 1.549051,
+          "duration": 1.124753,
           "requirements": [],
           "os": "linux"
         },
@@ -600,7 +600,7 @@
           "name": "warns when all tests are unmapped",
           "className": "test",
           "status": "Passed",
-          "duration": 1.825801,
+          "duration": 1.549502,
           "requirements": [],
           "os": "linux"
         },
@@ -609,7 +609,7 @@
           "name": "writeErrorSummary appends error details to summary file",
           "className": "test",
           "status": "Passed",
-          "duration": 0.01181,
+          "duration": 0.005018,
           "requirements": [],
           "os": "linux"
         },
@@ -618,7 +618,7 @@
           "name": "writeErrorSummary skips summary file for non-Error throws",
           "className": "test",
           "status": "Passed",
-          "duration": 0.003733,
+          "duration": 0.004102,
           "requirements": [],
           "os": "linux"
         },
@@ -627,7 +627,7 @@
           "name": "writes outputs to OS-specific directory",
           "className": "test",
           "status": "Passed",
-          "duration": 1.808366,
+          "duration": 1.985494,
           "requirements": [],
           "os": "linux"
         }
@@ -639,7 +639,7 @@
       "passed": 60,
       "failed": 0,
       "skipped": 0,
-      "duration": 27.599308999999995,
+      "duration": 24.766624000000004,
       "rate": 100
     },
     "byOs": {
@@ -647,7 +647,7 @@
         "passed": 60,
         "failed": 0,
         "skipped": 0,
-        "duration": 27.599308999999995,
+        "duration": 24.766624000000004,
         "rate": 100
       }
     }

--- a/artifacts/linux/traceability.md
+++ b/artifacts/linux/traceability.md
@@ -4,55 +4,55 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-023 | parses-nested-junit-structures | Passed | 0.013 |  |  |
+| REQ-023 | parses-nested-junit-structures | Passed | 0.012 |  |  |
 
 #### REQ-024 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-024 | captures-root-testsuites-attributes | Passed | 0.004 |  |  |
+| REQ-024 | captures-root-testsuites-attributes | Passed | 0.011 |  |  |
 
 #### REQ-025 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-025 | captures-testsuite-attributes | Passed | 0.011 |  |  |
+| REQ-025 | captures-testsuite-attributes | Passed | 0.008 |  |  |
 
 #### REQ-026 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-026 | captures-suite-properties | Passed | 0.004 |  |  |
+| REQ-026 | captures-suite-properties | Passed | 0.001 |  |  |
 
 #### REQ-027 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.003 |  |  |
+| REQ-027 | captures-testcase-attributes-and-skipped-message | Passed | 0.002 |  |  |
 
 #### REQ-028 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-028 | extracts-requirement-identifiers | Passed | 0.009 |  |  |
+| REQ-028 | extracts-requirement-identifiers | Passed | 0.003 |  |  |
 
 #### REQ-029 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.017 |  |  |
+| REQ-029 | aggregates-status-by-requirement-and-suite | Passed | 0.002 |  |  |
 
 #### REQ-030 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.003 |  |  |
+| REQ-030 | builds-traceability-matrix-with-skipped-reasons | Passed | 0.002 |  |  |
 
 #### REQ-031 (100% passed)
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-031 | validates-missing-fields | Passed | 0.001 |  |  |
+| REQ-031 | validates-missing-fields | Passed | 0.002 |  |  |
 
 #### REQ-032 (100% passed)
 
@@ -64,60 +64,60 @@
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| REQ-033 | throws-error-for-malformed-xml | Passed | 0.011 |  |  |
+| REQ-033 | throws-error-for-malformed-xml | Passed | 0.002 |  |  |
 
 <details><summary>Unmapped (100% passed)</summary>
 
 | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |
 | --- | --- | --- | --- | --- | --- |
-| Unmapped | associates-classname-with-requirement | Passed | 0.022 |  |  |
+| Unmapped | associates-classname-with-requirement | Passed | 0.013 |  |  |
 | Unmapped | buildissuebranchname-formats-branch-name | Passed | 0.002 |  |  |
-| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.002 |  |  |
+| Unmapped | buildissuebranchname-rejects-non-numeric-input | Passed | 0.001 |  |  |
 | Unmapped | buildprofile1.iconeditor.addtokentolabview.dispatcher.dry-runs-add-token-to-labview-with-expected-arguments- | Passed | 0.482 |  |  |
 | Unmapped | buildprofile1.iconeditor.applyvipc.dispatcher.dry-runs-apply-vipc-with-expected-arguments- | Passed | 0.042 |  |  |
 | Unmapped | buildprofile1.iconeditor.buildvipackage.dispatcher.dry-runs-build-vi-package-with-expected-arguments- | Passed | 0.106 |  |  |
 | Unmapped | buildprofile1.iconeditor.closelabview.dispatcher.dry-runs-close-labview-with-expected-arguments- | Passed | 0.036 |  |  |
-| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.003 |  |  |
-| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.020 |  |  |
-| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.043 |  |  |
-| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.026 |  |  |
+| Unmapped | buildsummary-splits-totals-by-os | Passed | 0.001 |  |  |
+| Unmapped | collecttestcases-captures-requirement-property | Passed | 0.011 |  |  |
+| Unmapped | collecttestcases-uses-evidence-property-and-falls-back-to-directory-scan | Passed | 0.009 |  |  |
+| Unmapped | collecttestcases-uses-machine-name-property-for-owner | Passed | 0.008 |  |  |
 | Unmapped | computestatuscounts-tallies-test-statuses | Passed | 0.001 |  |  |
-| Unmapped | detects-downloaded-artifacts-path | Passed | 1.538 |  |  |
-| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.009 |  |  |
-| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.579 |  |  |
+| Unmapped | detects-downloaded-artifacts-path | Passed | 1.280 |  |  |
+| Unmapped | dispatchers-and-parameters-include-descriptions | Passed | 0.003 |  |  |
+| Unmapped | errors-when-strict-unmapped-mode-enabled | Passed | 1.369 |  |  |
 | Unmapped | escapemarkdown-escapes-special-characters | Passed | 0.002 |  |  |
 | Unmapped | escapemarkdown-leaves-plain-text-untouched | Passed | 0.000 |  |  |
-| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.352 |  |  |
-| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.450 |  |  |
-| Unmapped | fails-when-tests-are-unmapped | Passed | 1.472 |  |  |
-| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.554 |  |  |
-| Unmapped | fails-without-runner-metadata | Passed | 1.079 |  |  |
-| Unmapped | formaterror-handles-plain-objects | Passed | 0.001 |  |  |
-| Unmapped | formaterror-handles-primitives | Passed | 0.000 |  |  |
+| Unmapped | fails-when-commit-lacks-requirement-reference | Passed | 1.427 |  |  |
+| Unmapped | fails-when-requirement-lacks-test-coverage | Passed | 1.607 |  |  |
+| Unmapped | fails-when-tests-are-unmapped | Passed | 1.243 |  |  |
+| Unmapped | fails-when-tests-reference-unknown-requirements | Passed | 1.286 |  |  |
+| Unmapped | fails-without-runner-metadata | Passed | 0.861 |  |  |
+| Unmapped | formaterror-handles-plain-objects | Passed | 0.000 |  |  |
+| Unmapped | formaterror-handles-primitives | Passed | 0.001 |  |  |
 | Unmapped | formaterror-handles-real-error-objects | Passed | 0.004 |  |  |
 | Unmapped | formaterror-handles-unstringifiable-values | Passed | 0.001 |  |  |
-| Unmapped | generate-ci-summary-features | Passed | 0.032 |  |  |
-| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.600 |  |  |
-| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.002 |  |  |
+| Unmapped | generate-ci-summary-features | Passed | 0.037 |  |  |
+| Unmapped | groups-owners-and-includes-requirements-and-evidence | Passed | 1.620 |  |  |
+| Unmapped | grouptomarkdown-omits-numeric-identifiers | Passed | 0.007 |  |  |
 | Unmapped | grouptomarkdown-supports-optional-limit-for-truncation | Passed | 0.001 |  |  |
-| Unmapped | handles-root-level-testcases | Passed | 0.002 |  |  |
-| Unmapped | handles-zipped-junit-artifacts | Passed | 1.209 |  |  |
-| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.377 |  |  |
-| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.028 |  |  |
-| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.016 |  |  |
-| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.023 |  |  |
-| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.244 |  |  |
-| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.176 |  |  |
-| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.810 |  |  |
+| Unmapped | handles-root-level-testcases | Passed | 0.001 |  |  |
+| Unmapped | handles-zipped-junit-artifacts | Passed | 1.056 |  |  |
+| Unmapped | ignores-stale-junit-files-outside-artifacts-path | Passed | 1.163 |  |  |
+| Unmapped | loadrequirements-logs-warning-on-invalid-json | Passed | 0.008 |  |  |
+| Unmapped | loadrequirements-merges-multiple-files | Passed | 0.010 |  |  |
+| Unmapped | loadrequirements-warns-and-skips-invalid-entries | Passed | 0.005 |  |  |
+| Unmapped | logs-a-warning-when-no-junit-files-are-found | Passed | 1.281 |  |  |
+| Unmapped | partitions-requirement-groups-by-runner\_type | Passed | 1.036 |  |  |
+| Unmapped | passes-with-coverage-and-requirement-reference | Passed | 1.508 |  |  |
 | Unmapped | requirementssummarytomarkdown-escapes-pipes-in-description | Passed | 0.001 |  |  |
-| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.907 |  |  |
+| Unmapped | skips-invalid-junit-files-and-still-generates-summary | Passed | 1.681 |  |  |
 | Unmapped | summarytomarkdown-handles-no-tests | Passed | 0.001 |  |  |
 | Unmapped | summarytomarkdown-sorts-os-alphabetically-and-escapes-special-characters | Passed | 0.001 |  |  |
-| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 1.070 |  |  |
-| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.549 |  |  |
-| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.826 |  |  |
-| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.012 |  |  |
+| Unmapped | throws-when-no-junit-files-found-and-strict-mode-enabled | Passed | 0.840 |  |  |
+| Unmapped | uses-latest-artifact-directory-when-multiple-are-present | Passed | 1.125 |  |  |
+| Unmapped | warns-when-all-tests-are-unmapped | Passed | 1.550 |  |  |
+| Unmapped | writeerrorsummary-appends-error-details-to-summary-file | Passed | 0.005 |  |  |
 | Unmapped | writeerrorsummary-skips-summary-file-for-non-error-throws | Passed | 0.004 |  |  |
-| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.808 |  |  |
+| Unmapped | writes-outputs-to-os-specific-directory | Passed | 1.985 |  |  |
 
 </details>

--- a/ci_evidence.txt
+++ b/ci_evidence.txt
@@ -1,1 +1,1 @@
-{"pipeline":"Unknown","git_sha":"5bd931c1a6e83f71c4d950cf2d01a6caeb4f1292","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}
+{"pipeline":"Unknown","git_sha":"aef6fbdeb462ead1d824f06c451ea42466d3b3a7","req_status":{"REQ-023":"PASS","REQ-024":"PASS","REQ-025":"PASS","REQ-026":"PASS","REQ-027":"PASS","REQ-028":"PASS","REQ-029":"PASS","REQ-030":"PASS","REQ-031":"PASS","REQ-032":"PASS","REQ-033":"PASS"}}

--- a/error-summary.md
+++ b/error-summary.md
@@ -94,3 +94,19 @@ Error: All tests are unmapped; verify requirements mapping.
 Error: No JUnit files found
     at main (/workspace/open-source/scripts/generate-ci-summary.ts:79:15)
 ```
+
+
+### Error generating CI summary
+
+```
+Error: All tests are unmapped; verify requirements mapping.
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:105:13)
+```
+
+
+### Error generating CI summary
+
+```
+Error: No JUnit files found
+    at main (/workspace/open-source/scripts/generate-ci-summary.ts:90:15)
+```

--- a/scripts/update-runner-runtime.js
+++ b/scripts/update-runner-runtime.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+
+const key = process.env.RUNNER_KEY;
+const label = process.env.RUNNER_LABEL;
+const type = process.env.RUNNER_TYPE;
+const skipInput = process.env.SKIP_DRY_RUN;
+
+const files = fs.readdirSync(process.cwd()).filter(f => f.startsWith('requirements') && f.endsWith('.json'));
+const updated = [];
+for (const file of files) {
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (json.runners && json.runners[key]) {
+    if (label) json.runners[key].runner_label = label;
+    if (type) json.runners[key].runner_type = type;
+    if (skipInput) json.runners[key].skip_dry_run = skipInput === 'true';
+    fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
+    updated.push(file);
+    console.log(`Updated ${file}`);
+  }
+}
+
+if (updated.length === 0) {
+  throw new Error(`Runner ${key} not found`);
+}
+
+const outputFile = process.env.GITHUB_OUTPUT || process.env.GITHUB_ENV;
+if (outputFile) {
+  fs.appendFileSync(outputFile, `req_files<<EOF\n${updated.join('\n')}\nEOF\n`);
+}

--- a/test-results/node-junit.xml
+++ b/test-results/node-junit.xml
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-	<testcase name="fails when requirement lacks test coverage" time="1.450230" classname="test"/>
-	<testcase name="fails when commit lacks requirement reference" time="1.351772" classname="test"/>
-	<testcase name="passes with coverage and requirement reference" time="1.810332" classname="test"/>
-	<testcase name="fails when tests are unmapped" time="1.471522" classname="test"/>
-	<testcase name="fails when tests reference unknown requirements" time="1.554093" classname="test"/>
-	<testcase name="Dispatchers and parameters include descriptions" time="0.008913" classname="test"/>
-	<testcase name="formatError handles real Error objects" time="0.004465" classname="test"/>
-	<testcase name="formatError handles plain objects" time="0.000706" classname="test"/>
-	<testcase name="formatError handles primitives" time="0.000273" classname="test"/>
-	<testcase name="formatError handles unstringifiable values" time="0.000646" classname="test"/>
-	<testcase name="generate-ci-summary features" time="0.031920" classname="test"/>
-	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.003733" classname="test"/>
-	<testcase name="writeErrorSummary appends error details to summary file" time="0.011810" classname="test"/>
-	<testcase name="associates classname with requirement" time="0.022103" classname="test"/>
-	<testcase name="loadRequirements logs warning on invalid JSON" time="0.027777" classname="test"/>
-	<testcase name="loadRequirements warns and skips invalid entries" time="0.023430" classname="test"/>
-	<testcase name="loadRequirements merges multiple files" time="0.016471" classname="test"/>
-	<testcase name="collectTestCases uses machine-name property for owner" time="0.025550" classname="test"/>
-	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.043263" classname="test"/>
-	<testcase name="collectTestCases captures requirement property" time="0.019864" classname="test"/>
-	<testcase name="groupToMarkdown omits numeric identifiers" time="0.002163" classname="test"/>
-	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000905" classname="test"/>
-	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000661" classname="test"/>
-	<testcase name="computeStatusCounts tallies test statuses" time="0.001460" classname="test"/>
-	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.001170" classname="test"/>
-	<testcase name="summaryToMarkdown handles no tests" time="0.001027" classname="test"/>
-	<testcase name="buildSummary splits totals by OS" time="0.002683" classname="test"/>
-	<testcase name="writes outputs to OS-specific directory" time="1.808366" classname="test"/>
-	<testcase name="skips invalid JUnit files and still generates summary" time="1.906514" classname="test"/>
-	<testcase name="warns when all tests are unmapped" time="1.825801" classname="test"/>
-	<testcase name="errors when strict unmapped mode enabled" time="1.578834" classname="test"/>
-	<testcase name="ignores stale JUnit files outside artifacts path" time="1.376710" classname="test"/>
-	<testcase name="throws when no JUnit files found and strict mode enabled" time="1.069637" classname="test"/>
-	<testcase name="partitions requirement groups by runner_type" time="1.175589" classname="test"/>
-	<testcase name="handles zipped JUnit artifacts" time="1.208570" classname="test"/>
-	<testcase name="fails without runner metadata" time="1.078981" classname="test"/>
-	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012664" classname="test"/>
-	<testcase name="[REQ-024] captures root testsuites attributes" time="0.004364" classname="test"/>
-	<testcase name="[REQ-025] captures testsuite attributes" time="0.011433" classname="test"/>
-	<testcase name="[REQ-026] captures suite properties" time="0.003767" classname="test"/>
-	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.003387" classname="test"/>
-	<testcase name="[REQ-028] extracts requirement identifiers" time="0.009429" classname="test"/>
-	<testcase name="handles root-level testcases" time="0.002112" classname="test"/>
-	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.017457" classname="test"/>
-	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.002987" classname="test"/>
-	<testcase name="[REQ-031] validates missing fields" time="0.000917" classname="test"/>
-	<testcase name="[REQ-032] preserves unknown attributes" time="0.000600" classname="test"/>
-	<testcase name="[REQ-033] throws error for malformed XML" time="0.010512" classname="test"/>
-	<testcase name="escapeMarkdown escapes special characters" time="0.001979" classname="test"/>
+	<testcase name="fails when requirement lacks test coverage" time="1.606652" classname="test"/>
+	<testcase name="fails when commit lacks requirement reference" time="1.427040" classname="test"/>
+	<testcase name="passes with coverage and requirement reference" time="1.508429" classname="test"/>
+	<testcase name="fails when tests are unmapped" time="1.243432" classname="test"/>
+	<testcase name="fails when tests reference unknown requirements" time="1.286002" classname="test"/>
+	<testcase name="Dispatchers and parameters include descriptions" time="0.002614" classname="test"/>
+	<testcase name="formatError handles real Error objects" time="0.003753" classname="test"/>
+	<testcase name="formatError handles plain objects" time="0.000492" classname="test"/>
+	<testcase name="formatError handles primitives" time="0.000548" classname="test"/>
+	<testcase name="formatError handles unstringifiable values" time="0.001101" classname="test"/>
+	<testcase name="generate-ci-summary features" time="0.037181" classname="test"/>
+	<testcase name="writeErrorSummary skips summary file for non-Error throws" time="0.004102" classname="test"/>
+	<testcase name="writeErrorSummary appends error details to summary file" time="0.005018" classname="test"/>
+	<testcase name="associates classname with requirement" time="0.013356" classname="test"/>
+	<testcase name="loadRequirements logs warning on invalid JSON" time="0.008242" classname="test"/>
+	<testcase name="loadRequirements warns and skips invalid entries" time="0.004795" classname="test"/>
+	<testcase name="loadRequirements merges multiple files" time="0.009819" classname="test"/>
+	<testcase name="collectTestCases uses machine-name property for owner" time="0.007982" classname="test"/>
+	<testcase name="collectTestCases uses evidence property and falls back to directory scan" time="0.008639" classname="test"/>
+	<testcase name="collectTestCases captures requirement property" time="0.011256" classname="test"/>
+	<testcase name="groupToMarkdown omits numeric identifiers" time="0.006540" classname="test"/>
+	<testcase name="groupToMarkdown supports optional limit for truncation" time="0.000931" classname="test"/>
+	<testcase name="requirementsSummaryToMarkdown escapes pipes in description" time="0.000755" classname="test"/>
+	<testcase name="computeStatusCounts tallies test statuses" time="0.000535" classname="test"/>
+	<testcase name="summaryToMarkdown sorts OS alphabetically and escapes special characters" time="0.000765" classname="test"/>
+	<testcase name="summaryToMarkdown handles no tests" time="0.000630" classname="test"/>
+	<testcase name="buildSummary splits totals by OS" time="0.000887" classname="test"/>
+	<testcase name="writes outputs to OS-specific directory" time="1.985494" classname="test"/>
+	<testcase name="skips invalid JUnit files and still generates summary" time="1.680781" classname="test"/>
+	<testcase name="warns when all tests are unmapped" time="1.549502" classname="test"/>
+	<testcase name="errors when strict unmapped mode enabled" time="1.368995" classname="test"/>
+	<testcase name="ignores stale JUnit files outside artifacts path" time="1.163121" classname="test"/>
+	<testcase name="throws when no JUnit files found and strict mode enabled" time="0.839618" classname="test"/>
+	<testcase name="partitions requirement groups by runner_type" time="1.035724" classname="test"/>
+	<testcase name="handles zipped JUnit artifacts" time="1.055923" classname="test"/>
+	<testcase name="fails without runner metadata" time="0.861494" classname="test"/>
+	<testcase name="[REQ-023] parses nested JUnit structures" time="0.012007" classname="test"/>
+	<testcase name="[REQ-024] captures root testsuites attributes" time="0.011460" classname="test"/>
+	<testcase name="[REQ-025] captures testsuite attributes" time="0.008366" classname="test"/>
+	<testcase name="[REQ-026] captures suite properties" time="0.001167" classname="test"/>
+	<testcase name="[REQ-027] captures testcase attributes and skipped message" time="0.001737" classname="test"/>
+	<testcase name="[REQ-028] extracts requirement identifiers" time="0.003095" classname="test"/>
+	<testcase name="handles root-level testcases" time="0.000828" classname="test"/>
+	<testcase name="[REQ-029] aggregates status by requirement and suite" time="0.001544" classname="test"/>
+	<testcase name="[REQ-030] builds traceability matrix with skipped reasons" time="0.001880" classname="test"/>
+	<testcase name="[REQ-031] validates missing fields" time="0.001805" classname="test"/>
+	<testcase name="[REQ-032] preserves unknown attributes" time="0.000960" classname="test"/>
+	<testcase name="[REQ-033] throws error for malformed XML" time="0.001986" classname="test"/>
+	<testcase name="escapeMarkdown escapes special characters" time="0.002228" classname="test"/>
 	<testcase name="escapeMarkdown leaves plain text untouched" time="0.000272" classname="test"/>
-	<testcase name="groups owners and includes requirements and evidence" time="1.599716" classname="test"/>
-	<testcase name="logs a warning when no JUnit files are found" time="1.243889" classname="test"/>
-	<testcase name="detects downloaded artifacts path" time="1.537657" classname="test"/>
-	<testcase name="uses latest artifact directory when multiple are present" time="1.549051" classname="test"/>
-	<testcase name="buildIssueBranchName formats branch name" time="0.001569" classname="test"/>
-	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001603" classname="test"/>
+	<testcase name="groups owners and includes requirements and evidence" time="1.620358" classname="test"/>
+	<testcase name="logs a warning when no JUnit files are found" time="1.281040" classname="test"/>
+	<testcase name="detects downloaded artifacts path" time="1.279692" classname="test"/>
+	<testcase name="uses latest artifact directory when multiple are present" time="1.124753" classname="test"/>
+	<testcase name="buildIssueBranchName formats branch name" time="0.001912" classname="test"/>
+	<testcase name="buildIssueBranchName rejects non-numeric input" time="0.001386" classname="test"/>
 	<!-- tests 56 -->
 	<!-- suites 0 -->
 	<!-- pass 56 -->
@@ -63,5 +63,5 @@
 	<!-- cancelled 0 -->
 	<!-- skipped 0 -->
 	<!-- todo 0 -->
-	<!-- duration_ms 15070.676145 -->
+	<!-- duration_ms 13649.17391 -->
 </testsuites>


### PR DESCRIPTION
## Summary
- refactor `update-runner-runtime` workflow to use dedicated `scripts/update-runner-runtime.js`
- commit updated requirements using workflow output

## Testing
- `npm run check:node`
- `npm install`
- `npm run test:ci`
- `npm run derive:registry`
- `RUNNER_LABEL=ubuntu-latest TEST_RESULTS_GLOBS='test-results/*junit*.xml' npm run generate:summary`
- `npm run lint:md`
- `npx --yes linkinator README.md docs scripts --config linkinator.config.json`
- `actionlint`
- `npm run check:traceability`
- `scripts/check-commit-requirements.sh $(git rev-parse HEAD^)`


------
https://chatgpt.com/codex/tasks/task_e_68a73bd96be08329ad0c5cc7d33b2c69